### PR TITLE
0010 - add session persistence models and storage coverage

### DIFF
--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -94,6 +94,63 @@ class ContainerLimits(BaseModel):
         return self
 
 
+class JobTypeGPUConfig(BaseModel):
+    """GPU configuration for a job type."""
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = Field(default=False)
+    vendor: Optional[str] = Field(default=None, description="GPU vendor: 'nvidia' or 'amd'")
+    count: Optional[int] = Field(default=None, ge=1, le=16)
+    device_ids: List[str] = Field(default_factory=list, max_length=16)
+
+    @field_validator("vendor")
+    @classmethod
+    def validate_vendor(cls, v: Optional[str]) -> Optional[str]:
+        """Validate GPU vendor."""
+        if v is None:
+            return None
+        normalized = v.lower().strip()
+        if normalized not in {"nvidia", "amd"}:
+            raise ValueError("gpu.vendor must be one of: amd, nvidia")
+        return normalized
+
+    @field_validator("device_ids")
+    @classmethod
+    def validate_device_ids(cls, values: List[str]) -> List[str]:
+        """Validate GPU device ID list."""
+        normalized: List[str] = []
+        for value in values:
+            device_id = value.strip()
+            if not device_id:
+                raise ValueError("gpu.device_ids cannot contain empty values")
+            if "," in device_id:
+                raise ValueError("gpu.device_ids entries cannot contain commas")
+            normalized.append(device_id)
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_gpu_config(self) -> "JobTypeGPUConfig":
+        """Validate cross-field GPU settings."""
+        if not self.enabled:
+            if self.vendor is not None or self.count is not None or self.device_ids:
+                raise ValueError(
+                    "gpu.enabled must be true when setting gpu.vendor, gpu.count, or gpu.device_ids"
+                )
+            return self
+
+        if self.vendor is None:
+            raise ValueError("gpu.vendor is required when gpu.enabled is true")
+
+        if self.count is not None and self.device_ids:
+            raise ValueError("gpu.count and gpu.device_ids are mutually exclusive")
+
+        if self.vendor == "amd" and self.count is not None:
+            raise ValueError("gpu.count is only supported for gpu.vendor='nvidia'")
+
+        return self
+
+
 class JobTypeConfig(BaseModel):
     """Job type configuration for embedding in main config."""
 
@@ -114,6 +171,11 @@ class JobTypeConfig(BaseModel):
     """Timeout for startup phase (container init + dep install) in seconds."""
 
     network_enabled: bool = Field(default=False, description="Allow network access (security risk)")
+    session_enabled: bool = Field(
+        default=False,
+        description="Allow this job type to be used for long-running sessions",
+    )
+    gpu: JobTypeGPUConfig = Field(default_factory=JobTypeGPUConfig)
 
     @field_validator("name")
     @classmethod
@@ -472,7 +534,6 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         config_dict["api_rate_limit_window_seconds"] = parse_env_int(
             "TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS"
         )
-
     # Validate and create config
     try:
         config = TakoVMConfig(**config_dict)

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -209,15 +209,17 @@ class CodeExecutor:
         self.registry = registry or JobTypeRegistry()
         self.config = config or get_config()
 
-        # Check runtime availability
-        self._runtime = self._resolve_runtime()
+        # Resolve and validate baseline non-GPU runtime availability at startup
+        self._runtime = self._resolve_runtime(use_gpu=False, workload="job")
 
-    def _resolve_runtime(self) -> str:
+    def _resolve_runtime(self, use_gpu: bool = False, workload: str = "job") -> str:
         """
         Resolve the container runtime to use.
 
         In strict mode (default), gVisor must be available or we fail.
         In permissive mode, we fall back to runc with a warning.
+
+        GPU execution/session workloads always require runc.
 
         Returns:
             The runtime to use ('runsc' or 'runc')
@@ -227,6 +229,20 @@ class CodeExecutor:
         """
         requested_runtime = self.config.container_runtime
         security_mode = self.config.security_mode
+
+        if use_gpu:
+            if security_mode == "strict":
+                raise RuntimeUnavailableError(
+                    "GPU workloads require gVisor to be disabled, but security_mode='strict' "
+                    "requires gVisor. Use security_mode='permissive' for GPU sessions/jobs."
+                )
+
+            if requested_runtime == "runsc":
+                logger.info(
+                    "GPU enabled for %s workload; forcing runtime to runc (gVisor disabled)",
+                    workload,
+                )
+            return "runc"
 
         # If runc is explicitly requested, allow it (user knows what they're doing)
         if requested_runtime == "runc":
@@ -261,6 +277,45 @@ class CodeExecutor:
         logger.warning("WARNING: DO NOT USE FOR UNTRUSTED CODE")
         logger.warning("=" * 60)
         return "runc"
+
+    def resolve_runtime_for_job_type(self, job_type: JobType, workload: str = "job") -> str:
+        """Resolve runtime for a specific job type, accounting for GPU requirements."""
+        return self._resolve_runtime(use_gpu=job_type.gpu_enabled, workload=workload)
+
+    def build_gpu_flags(self, job_type: JobType) -> List[str]:
+        """Build Docker CLI GPU flags for a job type."""
+        if not job_type.gpu_enabled:
+            return []
+
+        vendor = (job_type.gpu_vendor or "").lower()
+        if vendor == "nvidia":
+            if job_type.gpu_device_ids:
+                return [f"--gpus=device={','.join(job_type.gpu_device_ids)}"]
+            if job_type.gpu_count is not None:
+                return [f"--gpus={job_type.gpu_count}"]
+            return ["--gpus=all"]
+
+        if vendor == "amd":
+            return ["--device=/dev/kfd", "--device=/dev/dri"]
+
+        raise RuntimeUnavailableError(f"Unsupported GPU vendor: {job_type.gpu_vendor}")
+
+    def build_gpu_env_vars(self, job_type: JobType) -> Dict[str, str]:
+        """Build environment variables used for GPU device selection."""
+        if not job_type.gpu_enabled or not job_type.gpu_device_ids:
+            return {}
+
+        device_list = ",".join(job_type.gpu_device_ids)
+        vendor = (job_type.gpu_vendor or "").lower()
+
+        if vendor == "nvidia":
+            return {"CUDA_VISIBLE_DEVICES": device_list}
+        if vendor == "amd":
+            return {
+                "ROCR_VISIBLE_DEVICES": device_list,
+                "HIP_VISIBLE_DEVICES": device_list,
+            }
+        return {}
 
     def _get_job_type(self, job_type_name: Optional[str]) -> JobType:
         """
@@ -819,6 +874,20 @@ class CodeExecutor:
                 "For true network isolation, use pre-built images via 'tako-vm build'."
             )
 
+        try:
+            runtime = self.resolve_runtime_for_job_type(job_type=job_type, workload="job")
+            gpu_flags = self.build_gpu_flags(job_type)
+            gpu_env_vars = self.build_gpu_env_vars(job_type)
+        except RuntimeUnavailableError as e:
+            safe_error = sanitize_error(str(e))
+            return {
+                "success": False,
+                "error": safe_error,
+                "stdout": "",
+                "stderr": safe_error,
+                "exit_code": -1,
+            }
+
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako", job_id)
 
@@ -849,8 +918,11 @@ class CodeExecutor:
         # Only specify runtime explicitly for gVisor (runsc)
         # runc is the default Docker runtime, so we don't need to specify it explicitly
         # (and some Docker configurations may not accept --runtime=runc)
-        if self._runtime == "runsc":
-            cmd.append(f"--runtime={self._runtime}")
+        if runtime == "runsc":
+            cmd.append("--runtime=runsc")
+
+        # GPU access flags (if enabled by job type)
+        cmd.extend(gpu_flags)
 
         # Mount uv cache volume for faster repeated installs
         if has_runtime_deps:
@@ -908,6 +980,10 @@ class CodeExecutor:
             if not validate_env_value(value):
                 logger.warning(f"Skipping environment variable with unsafe value: {key}")
                 continue
+            cmd.append(f"--env={key}={value}")
+
+        # Add GPU selection env vars (safe, generated by server)
+        for key, value in gpu_env_vars.items():
             cmd.append(f"--env={key}={value}")
 
         # Pass requirements for runtime installation via uv

--- a/tako_vm/job_types.json
+++ b/tako_vm/job_types.json
@@ -11,7 +11,14 @@
       "cpu_limit": 1.0,
       "timeout": 30,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     },
     {
       "name": "data-processing",
@@ -27,7 +34,14 @@
       "cpu_limit": 2.0,
       "timeout": 60,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     },
     {
       "name": "ml-inference",
@@ -43,7 +57,14 @@
       "cpu_limit": 2.0,
       "timeout": 120,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     },
     {
       "name": "test-with-secrets",
@@ -59,7 +80,14 @@
       "cpu_limit": 0.5,
       "timeout": 10,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     }
   ]
 }

--- a/tako_vm/job_types.py
+++ b/tako_vm/job_types.py
@@ -62,6 +62,21 @@ class JobType:
     network_enabled: bool = False
     """Allow network access (default: no network for security)."""
 
+    session_enabled: bool = False
+    """Allow this job type to be used for long-running sessions."""
+
+    gpu_enabled: bool = False
+    """Enable GPU access for this job type."""
+
+    gpu_vendor: Optional[str] = None
+    """GPU vendor ('nvidia' or 'amd')."""
+
+    gpu_count: Optional[int] = None
+    """Number of GPUs (NVIDIA only)."""
+
+    gpu_device_ids: list[str] = field(default_factory=list)
+    """Specific GPU device IDs/UUIDs to expose."""
+
     @property
     def image_name(self) -> str:
         """Docker image name for this job type."""
@@ -81,12 +96,38 @@ class JobType:
             "timeout": self.timeout,
             "startup_timeout": self.startup_timeout,
             "network_enabled": self.network_enabled,
+            "session_enabled": self.session_enabled,
+            "gpu": {
+                "enabled": self.gpu_enabled,
+                "vendor": self.gpu_vendor,
+                "count": self.gpu_count,
+                "device_ids": self.gpu_device_ids,
+            },
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> JobType:
         """Create from dictionary."""
-        return cls(**data)
+        gpu = data.get("gpu") or {}
+
+        return cls(
+            name=data["name"],
+            requirements=list(data.get("requirements", [])),
+            python_version=data.get("python_version", "3.11"),
+            base_image=data.get("base_image"),
+            shared_code=list(data.get("shared_code", [])),
+            environment=dict(data.get("environment", {})),
+            memory_limit=data.get("memory_limit", "512m"),
+            cpu_limit=float(data.get("cpu_limit", 1.0)),
+            timeout=int(data.get("timeout", 30)),
+            startup_timeout=int(data.get("startup_timeout", 120)),
+            network_enabled=bool(data.get("network_enabled", False)),
+            session_enabled=bool(data.get("session_enabled", False)),
+            gpu_enabled=bool(data.get("gpu_enabled", gpu.get("enabled", False))),
+            gpu_vendor=data.get("gpu_vendor", gpu.get("vendor")),
+            gpu_count=data.get("gpu_count", gpu.get("count")),
+            gpu_device_ids=list(data.get("gpu_device_ids", gpu.get("device_ids", []))),
+        )
 
     @classmethod
     def from_config(cls, config: JobTypeConfig) -> JobType:
@@ -111,6 +152,11 @@ class JobType:
             timeout=config.timeout,
             startup_timeout=config.startup_timeout,
             network_enabled=config.network_enabled,
+            session_enabled=config.session_enabled,
+            gpu_enabled=config.gpu.enabled,
+            gpu_vendor=config.gpu.vendor,
+            gpu_count=config.gpu.count,
+            gpu_device_ids=list(config.gpu.device_ids),
         )
 
     def to_config(self) -> JobTypeConfig:
@@ -120,7 +166,7 @@ class JobType:
         Returns:
             Pydantic JobTypeConfig instance
         """
-        from tako_vm.config import JobTypeConfig
+        from tako_vm.config import JobTypeConfig, JobTypeGPUConfig
 
         return JobTypeConfig(
             name=self.name,
@@ -134,6 +180,13 @@ class JobType:
             timeout=self.timeout,
             startup_timeout=self.startup_timeout,
             network_enabled=self.network_enabled,
+            session_enabled=self.session_enabled,
+            gpu=JobTypeGPUConfig(
+                enabled=self.gpu_enabled,
+                vendor=self.gpu_vendor,
+                count=self.gpu_count,
+                device_ids=list(self.gpu_device_ids),
+            ),
         )
 
 
@@ -172,15 +225,28 @@ class JobTypeRegistry:
         with open(self.config_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
-    def register(self, job_type: JobType) -> None:
+    def register(self, job_type: JobType, persist: bool = True) -> None:
         """
         Register a new job type.
 
         Args:
             job_type: Job type configuration
+            persist: Whether to save registry changes to disk
         """
         self._job_types[job_type.name] = job_type
-        self._save()
+        if persist:
+            self._save()
+
+    def register_many(self, job_types: list[JobType], persist: bool = True) -> None:
+        """Register multiple job types at once."""
+        if not job_types:
+            return
+
+        for job_type in job_types:
+            self._job_types[job_type.name] = job_type
+
+        if persist:
+            self._save()
 
     def get(self, name: str) -> Optional[JobType]:
         """
@@ -249,3 +315,29 @@ def init_default_job_types(registry: JobTypeRegistry) -> None:
     for jt in DEFAULT_JOB_TYPES:
         if registry.get(jt.name) is None:
             registry.register(jt)
+
+
+def merge_config_job_types(
+    registry: JobTypeRegistry, config_job_types: list["JobTypeConfig"]
+) -> int:
+    """
+    Merge config-defined job types into a runtime registry.
+
+    Job types from config override any existing registry entry with the same name.
+    Changes are applied in memory only (no persistence to job_types.json).
+
+    Args:
+        registry: Runtime job type registry
+        config_job_types: Job types loaded from TakoVM config
+
+    Returns:
+        Number of config job types merged
+    """
+    if not config_job_types:
+        return 0
+
+    runtime_job_types = [
+        JobType.from_config(job_type_config) for job_type_config in config_job_types
+    ]
+    registry.register_many(runtime_job_types, persist=False)
+    return len(runtime_job_types)

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -490,3 +490,61 @@ class DeadLetterEntry(BaseModel):
 
     correlation_id: Optional[str] = Field(default=None, max_length=64)
     """Correlation ID for tracing."""
+
+
+SessionStatus = Literal[
+    "creating",
+    "running",
+    "terminated",
+    "failed",
+    "expired",
+]
+
+SessionEventDirection = Literal["in", "out", "system"]
+
+
+class SessionRecord(BaseModel):
+    """Persistent metadata for a long-running session container."""
+
+    model_config = {"extra": "forbid"}
+
+    session_id: str = Field(default_factory=lambda: str(uuid.uuid4()), min_length=1, max_length=64)
+    status: SessionStatus = "creating"
+    job_type: str = Field(default="default", min_length=1, max_length=64)
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    last_activity_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: Optional[datetime] = None
+
+    idle_timeout_seconds: int = Field(default=1800, ge=30, le=86400)
+    ttl_seconds: int = Field(default=86400, ge=60, le=604800)
+
+    container_name: str = Field(..., min_length=1, max_length=128)
+    container_id: Optional[str] = Field(default=None, max_length=128)
+    image_name: str = Field(..., min_length=1, max_length=255)
+    runtime: str = Field(..., min_length=1, max_length=16)
+
+    gpu_enabled: bool = False
+    gpu_vendor: Optional[str] = Field(default=None, max_length=16)
+
+    workspace_dir: str = Field(..., min_length=1, max_length=1024)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    error_message: Optional[str] = Field(default=None, max_length=4096)
+    terminated_reason: Optional[str] = Field(default=None, max_length=256)
+
+
+class SessionEvent(BaseModel):
+    """Input/output event persisted for session polling."""
+
+    model_config = {"extra": "forbid"}
+
+    id: Optional[int] = Field(default=None, ge=0)
+    session_id: str = Field(..., min_length=1, max_length=64)
+    direction: SessionEventDirection
+    event_type: str = Field(default="message", min_length=1, max_length=64)
+    payload: Any = None
+    file_name: Optional[str] = Field(default=None, max_length=255)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field, field_validator
 from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.execution.health import get_circuit_breaker, startup_cleanup
 from tako_vm.execution.worker import CodeExecutor, check_gvisor_available
-from tako_vm.job_types import JobTypeRegistry
+from tako_vm.job_types import JobTypeRegistry, merge_config_job_types
 from tako_vm.models import ExecutionRecord, sha256_content, sha256_json
 from tako_vm.security import sanitize_error
 from tako_vm.server.correlation import (
@@ -169,6 +169,9 @@ async def lifespan(app: FastAPI):
     # Configure log level from config
     _configure_log_level(state.config.log_level)
     state.registry = JobTypeRegistry()
+    merged_job_types = merge_config_job_types(state.registry, state.config.job_types)
+    if merged_job_types:
+        logger.info("Loaded %s job type(s) from config", merged_job_types)
     state.executor = CodeExecutor(registry=state.registry, config=state.config)
     state.storage = ExecutionStorage(state.config.database_url)
     await state.storage.init()
@@ -409,6 +412,9 @@ class JobTypeResponse(BaseModel):
     memory_limit: str
     cpu_limit: float
     timeout: int
+    session_enabled: bool
+    gpu_enabled: bool
+    gpu_vendor: Optional[str] = None
     image_exists: bool
 
 
@@ -1305,6 +1311,9 @@ async def list_job_types():
                 memory_limit=jt.memory_limit,
                 cpu_limit=jt.cpu_limit,
                 timeout=jt.timeout,
+                session_enabled=jt.session_enabled,
+                gpu_enabled=jt.gpu_enabled,
+                gpu_vendor=jt.gpu_vendor,
                 image_exists=builder.image_exists(jt),
             )
         )
@@ -1336,6 +1345,9 @@ async def get_job_type(name: str):
         memory_limit=jt.memory_limit,
         cpu_limit=jt.cpu_limit,
         timeout=jt.timeout,
+        session_enabled=jt.session_enabled,
+        gpu_enabled=jt.gpu_enabled,
+        gpu_vendor=jt.gpu_vendor,
         image_exists=builder.image_exists(jt),
     )
 

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -22,6 +22,8 @@ from .models import (
     InputArtifact,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
 )
 
 logger = logging.getLogger(__name__)
@@ -130,7 +132,61 @@ MIGRATIONS: list[tuple[str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_dlq_error_type ON dead_letter_queue(error_type);
         CREATE INDEX IF NOT EXISTS idx_dlq_job_id ON dead_letter_queue(job_id);
         """,
-    )
+    ),
+    (
+        "0002_sessions",
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            job_type TEXT NOT NULL,
+
+            created_at TIMESTAMPTZ NOT NULL,
+            started_at TIMESTAMPTZ,
+            ended_at TIMESTAMPTZ,
+            last_activity_at TIMESTAMPTZ NOT NULL,
+            expires_at TIMESTAMPTZ,
+
+            idle_timeout_seconds INTEGER NOT NULL,
+            ttl_seconds INTEGER NOT NULL,
+
+            container_name TEXT NOT NULL,
+            container_id TEXT,
+            image_name TEXT NOT NULL,
+            runtime TEXT NOT NULL,
+
+            gpu_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+            gpu_vendor TEXT,
+
+            workspace_dir TEXT NOT NULL,
+            metadata_json JSONB,
+
+            error_message TEXT,
+            terminated_reason TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+        CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity_at);
+
+        CREATE TABLE IF NOT EXISTS session_events (
+            id BIGSERIAL PRIMARY KEY,
+            session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+            direction TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            payload_json JSONB,
+            file_name TEXT,
+            created_at TIMESTAMPTZ NOT NULL
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_session_events_unique_file
+            ON session_events(session_id, file_name);
+        CREATE INDEX IF NOT EXISTS idx_session_events_session_id_id
+            ON session_events(session_id, id);
+        CREATE INDEX IF NOT EXISTS idx_session_events_created_at
+            ON session_events(created_at DESC);
+        """,
+    ),
 ]
 
 
@@ -483,6 +539,189 @@ class ExecutionStorage:
             relationship=row.get("relationship"),
         )
 
+    async def save_session(self, session: SessionRecord) -> None:
+        """Insert or update a session record."""
+        metadata_json = Jsonb(session.metadata) if session.metadata is not None else None
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO sessions (
+                    session_id, status, job_type,
+                    created_at, started_at, ended_at, last_activity_at, expires_at,
+                    idle_timeout_seconds, ttl_seconds,
+                    container_name, container_id, image_name, runtime,
+                    gpu_enabled, gpu_vendor,
+                    workspace_dir, metadata_json,
+                    error_message, terminated_reason
+                ) VALUES (
+                    %s, %s, %s,
+                    %s, %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s,
+                    %s, %s
+                )
+                ON CONFLICT (session_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    job_type = EXCLUDED.job_type,
+                    created_at = EXCLUDED.created_at,
+                    started_at = EXCLUDED.started_at,
+                    ended_at = EXCLUDED.ended_at,
+                    last_activity_at = EXCLUDED.last_activity_at,
+                    expires_at = EXCLUDED.expires_at,
+                    idle_timeout_seconds = EXCLUDED.idle_timeout_seconds,
+                    ttl_seconds = EXCLUDED.ttl_seconds,
+                    container_name = EXCLUDED.container_name,
+                    container_id = EXCLUDED.container_id,
+                    image_name = EXCLUDED.image_name,
+                    runtime = EXCLUDED.runtime,
+                    gpu_enabled = EXCLUDED.gpu_enabled,
+                    gpu_vendor = EXCLUDED.gpu_vendor,
+                    workspace_dir = EXCLUDED.workspace_dir,
+                    metadata_json = EXCLUDED.metadata_json,
+                    error_message = EXCLUDED.error_message,
+                    terminated_reason = EXCLUDED.terminated_reason
+                """,
+                (
+                    session.session_id,
+                    session.status,
+                    session.job_type,
+                    session.created_at,
+                    session.started_at,
+                    session.ended_at,
+                    session.last_activity_at,
+                    session.expires_at,
+                    session.idle_timeout_seconds,
+                    session.ttl_seconds,
+                    session.container_name,
+                    session.container_id,
+                    session.image_name,
+                    session.runtime,
+                    session.gpu_enabled,
+                    session.gpu_vendor,
+                    session.workspace_dir,
+                    metadata_json,
+                    session.error_message,
+                    session.terminated_reason,
+                ),
+            )
+
+    async def get_session(self, session_id: str) -> Optional[SessionRecord]:
+        """Retrieve a session by ID."""
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                "SELECT * FROM sessions WHERE session_id = %s", (session_id,)
+            )
+            row = await cursor.fetchone()
+
+        if not row:
+            return None
+        return self._row_to_session(cast(RowMapping, row))
+
+    async def list_sessions(
+        self,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[SessionRecord]:
+        """List sessions with optional status filter."""
+        query = "SELECT * FROM sessions WHERE 1=1"
+        params: List[Any] = []
+
+        if status:
+            query += " AND status = %s"
+            params.append(status)
+
+        query += " ORDER BY created_at DESC LIMIT %s OFFSET %s"
+        params.extend([limit, offset])
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(query, params)
+            rows = await cursor.fetchall()
+
+        return [self._row_to_session(cast(RowMapping, row)) for row in rows]
+
+    async def touch_session(self, session_id: str, touched_at: Optional[datetime] = None) -> None:
+        """Update last activity timestamp for a session."""
+        now = touched_at or datetime.now(timezone.utc)
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            await conn.execute(
+                "UPDATE sessions SET last_activity_at = %s WHERE session_id = %s",
+                (now, session_id),
+            )
+
+    async def save_session_event(self, event: SessionEvent) -> SessionEvent:
+        """Insert a session event and return persisted row (dedupes by file_name)."""
+        payload_json = Jsonb(event.payload) if event.payload is not None else None
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                INSERT INTO session_events (
+                    session_id, direction, event_type, payload_json, file_name, created_at
+                ) VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (session_id, file_name) DO NOTHING
+                RETURNING *
+                """,
+                (
+                    event.session_id,
+                    event.direction,
+                    event.event_type,
+                    payload_json,
+                    event.file_name,
+                    event.created_at,
+                ),
+            )
+            row = await cursor.fetchone()
+
+            if row:
+                return self._row_to_session_event(cast(RowMapping, row))
+
+            if event.file_name:
+                existing_cursor = await conn.execute(
+                    """
+                    SELECT * FROM session_events
+                    WHERE session_id = %s AND file_name = %s
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """,
+                    (event.session_id, event.file_name),
+                )
+                existing = await existing_cursor.fetchone()
+                if existing:
+                    return self._row_to_session_event(cast(RowMapping, existing))
+
+        return event
+
+    async def list_session_events(
+        self,
+        session_id: str,
+        after_id: int = 0,
+        limit: int = 100,
+    ) -> List[SessionEvent]:
+        """List session events after a cursor ID."""
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT * FROM session_events
+                WHERE session_id = %s AND id > %s
+                ORDER BY id ASC
+                LIMIT %s
+                """,
+                (session_id, after_id, limit),
+            )
+            rows = await cursor.fetchall()
+
+        return [self._row_to_session_event(cast(RowMapping, row)) for row in rows]
+
     async def save_version(self, version: JobVersion) -> None:
         """Save job version record."""
         pool = self._get_pool()
@@ -602,6 +841,45 @@ class ExecutionStorage:
             dockerfile_hash=row["dockerfile_hash"],
             requirements_hash=row["requirements_hash"],
             image_ref=row["image_ref"],
+        )
+
+    def _row_to_session(self, row: RowMapping) -> SessionRecord:
+        """Convert database row to SessionRecord."""
+        metadata = _decode_json_field(row.get("metadata_json")) or {}
+        return SessionRecord(
+            session_id=row["session_id"],
+            status=row["status"],
+            job_type=row["job_type"],
+            created_at=row["created_at"],
+            started_at=row.get("started_at"),
+            ended_at=row.get("ended_at"),
+            last_activity_at=row["last_activity_at"],
+            expires_at=row.get("expires_at"),
+            idle_timeout_seconds=row["idle_timeout_seconds"],
+            ttl_seconds=row["ttl_seconds"],
+            container_name=row["container_name"],
+            container_id=row.get("container_id"),
+            image_name=row["image_name"],
+            runtime=row["runtime"],
+            gpu_enabled=bool(row.get("gpu_enabled", False)),
+            gpu_vendor=row.get("gpu_vendor"),
+            workspace_dir=row["workspace_dir"],
+            metadata=metadata,
+            error_message=row.get("error_message"),
+            terminated_reason=row.get("terminated_reason"),
+        )
+
+    def _row_to_session_event(self, row: RowMapping) -> SessionEvent:
+        """Convert database row to SessionEvent."""
+        payload = _decode_json_field(row.get("payload_json"))
+        return SessionEvent(
+            id=row["id"],
+            session_id=row["session_id"],
+            direction=row["direction"],
+            event_type=row["event_type"],
+            payload=payload,
+            file_name=row.get("file_name"),
+            created_at=row["created_at"],
         )
 
     async def add_to_dlq(self, entry: DeadLetterEntry) -> int:

--- a/tako_vm/version.py
+++ b/tako_vm/version.py
@@ -57,6 +57,11 @@ class VersionManager:
                 "base_image": job_type.base_image,
                 "environment": dict(sorted(job_type.environment.items())),
                 "shared_code": sorted(job_type.shared_code),
+                "session_enabled": job_type.session_enabled,
+                "gpu_enabled": job_type.gpu_enabled,
+                "gpu_vendor": job_type.gpu_vendor,
+                "gpu_count": job_type.gpu_count,
+                "gpu_device_ids": sorted(job_type.gpu_device_ids),
             },
             sort_keys=True,
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,6 +155,9 @@ class TestJobTypes:
         assert data["name"] == "default"
         assert "requirements" in data
         assert "python_version" in data
+        assert "session_enabled" in data
+        assert "gpu_enabled" in data
+        assert "gpu_vendor" in data
 
     def test_job_type_not_found(self, client):
         """Non-existent job type returns 404."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from tako_vm.config import (
     ConfigurationError,
     ContainerLimits,
     JobTypeConfig,
+    JobTypeGPUConfig,
     TakoVMConfig,
     find_config_file,
     get_config,
@@ -164,6 +165,62 @@ class TestJobTypeConfig:
         with pytest.raises(ValueError) as exc_info:
             JobTypeConfig(name="test", memory_limit="64g")
         assert "at most 32g" in str(exc_info.value)
+
+
+class TestJobTypeGPUConfig:
+    """Tests for JobTypeGPUConfig validation."""
+
+    def test_job_type_gpu_config_defaults(self):
+        """GPU config defaults to disabled with no selection."""
+        config = JobTypeGPUConfig()
+        assert config.enabled is False
+        assert config.vendor is None
+        assert config.count is None
+        assert config.device_ids == []
+
+    def test_job_type_gpu_config_nvidia_count(self):
+        """NVIDIA GPU config accepts count selection."""
+        config = JobTypeGPUConfig(enabled=True, vendor="NVIDIA", count=2)
+        assert config.enabled is True
+        assert config.vendor == "nvidia"
+        assert config.count == 2
+
+    def test_job_type_gpu_config_rejects_missing_vendor(self):
+        """Enabled GPU config requires vendor."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(enabled=True)
+        assert "gpu.vendor is required" in str(exc_info.value)
+
+    def test_job_type_gpu_config_rejects_count_with_device_ids(self):
+        """GPU config forbids combining count and device_ids."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(
+                enabled=True,
+                vendor="nvidia",
+                count=1,
+                device_ids=["GPU-123"],
+            )
+        assert "mutually exclusive" in str(exc_info.value)
+
+    def test_job_type_gpu_config_rejects_amd_count(self):
+        """AMD GPU config does not support count selection."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(enabled=True, vendor="amd", count=1)
+        assert "only supported" in str(exc_info.value)
+
+    def test_job_type_gpu_config_rejects_fields_when_disabled(self):
+        """GPU details are rejected unless enabled=true."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(enabled=False, vendor="nvidia")
+        assert "gpu.enabled must be true" in str(exc_info.value)
+
+    def test_job_type_gpu_config_device_ids_validation(self):
+        """Device IDs are stripped and validated."""
+        config = JobTypeGPUConfig(enabled=True, vendor="nvidia", device_ids=[" GPU-1 ", "GPU-2"])
+        assert config.device_ids == ["GPU-1", "GPU-2"]
+
+        with pytest.raises(ValueError):
+            JobTypeGPUConfig(enabled=True, vendor="nvidia", device_ids=["bad,id"])
 
 
 class TestTakoVMConfig:

--- a/tests/test_job_types.py
+++ b/tests/test_job_types.py
@@ -1,0 +1,119 @@
+"""Tests for job type schema and merge behavior."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from tako_vm.config import JobTypeConfig, JobTypeGPUConfig
+from tako_vm.job_types import JobType, JobTypeRegistry, merge_config_job_types
+
+
+def test_job_type_from_dict_reads_nested_gpu_config():
+    """from_dict supports nested gpu object in JSON config."""
+    job_type = JobType.from_dict(
+        {
+            "name": "gpu-job",
+            "session_enabled": True,
+            "gpu": {
+                "enabled": True,
+                "vendor": "nvidia",
+                "count": 2,
+                "device_ids": [],
+            },
+        }
+    )
+
+    assert job_type.name == "gpu-job"
+    assert job_type.session_enabled is True
+    assert job_type.gpu_enabled is True
+    assert job_type.gpu_vendor == "nvidia"
+    assert job_type.gpu_count == 2
+
+
+def test_job_type_from_dict_supports_legacy_gpu_top_level_fields():
+    """Top-level gpu_* fields remain supported for compatibility."""
+    job_type = JobType.from_dict(
+        {
+            "name": "legacy-gpu",
+            "gpu_enabled": True,
+            "gpu_vendor": "amd",
+            "gpu_device_ids": ["0", "1"],
+        }
+    )
+
+    assert job_type.gpu_enabled is True
+    assert job_type.gpu_vendor == "amd"
+    assert job_type.gpu_device_ids == ["0", "1"]
+
+
+def test_job_type_config_roundtrip_preserves_gpu_and_session_fields():
+    """Dataclass <-> pydantic conversion preserves new fields."""
+    original = JobType(
+        name="roundtrip",
+        session_enabled=True,
+        gpu_enabled=True,
+        gpu_vendor="nvidia",
+        gpu_count=1,
+        gpu_device_ids=[],
+    )
+
+    config_model = original.to_config()
+    restored = JobType.from_config(config_model)
+
+    assert restored.name == "roundtrip"
+    assert restored.session_enabled is True
+    assert restored.gpu_enabled is True
+    assert restored.gpu_vendor == "nvidia"
+    assert restored.gpu_count == 1
+
+
+def test_merge_config_job_types_overrides_in_memory_without_persistence():
+    """Config merge updates runtime registry without rewriting job_types.json."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "job_types.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "job_types": [
+                        {
+                            "name": "default",
+                            "timeout": 30,
+                            "session_enabled": False,
+                            "gpu": {
+                                "enabled": False,
+                                "vendor": None,
+                                "count": None,
+                                "device_ids": [],
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        registry = JobTypeRegistry(config_path=config_path)
+        original_on_disk = config_path.read_text(encoding="utf-8")
+
+        merged_count = merge_config_job_types(
+            registry,
+            [
+                JobTypeConfig(
+                    name="default",
+                    timeout=99,
+                    session_enabled=True,
+                    gpu=JobTypeGPUConfig(enabled=True, vendor="nvidia", count=1),
+                )
+            ],
+        )
+
+        assert merged_count == 1
+        merged = registry.get("default")
+        assert merged is not None
+        assert merged.timeout == 99
+        assert merged.session_enabled is True
+        assert merged.gpu_enabled is True
+        assert merged.gpu_vendor == "nvidia"
+
+        # Persist=False means disk config should be untouched.
+        assert config_path.read_text(encoding="utf-8") == original_on_disk

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,8 @@ from tako_vm.models import (
     JobStatus,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
     sha256_content,
     sha256_json,
 )
@@ -416,3 +418,47 @@ class TestDeadLetterEntry:
         for error_type in valid_types:
             entry = DeadLetterEntry(job_id="job", job_data={}, error_type=error_type)
             assert entry.error_type == error_type
+
+
+class TestSessionModels:
+    """Tests for session-related models."""
+
+    def test_session_record_defaults(self):
+        """SessionRecord initializes with expected defaults."""
+        record = SessionRecord(
+            container_name="tako-session-1",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir="/tmp/session-1",
+        )
+
+        assert record.status == "creating"
+        assert record.job_type == "default"
+        assert record.gpu_enabled is False
+        assert record.metadata == {}
+
+    def test_session_record_validates_status_literal(self):
+        """SessionRecord enforces allowed status values."""
+        with pytest.raises(ValidationError):
+            SessionRecord(
+                status="unknown",  # type: ignore[arg-type]
+                container_name="tako-session-1",
+                image_name="code-executor:latest",
+                runtime="runc",
+                workspace_dir="/tmp/session-1",
+            )
+
+    def test_session_event_defaults(self):
+        """SessionEvent defaults event type to message."""
+        event = SessionEvent(session_id="session-1", direction="out", payload={"ok": True})
+        assert event.event_type == "message"
+        assert event.file_name is None
+
+    def test_session_event_validates_direction_literal(self):
+        """SessionEvent enforces direction literals."""
+        with pytest.raises(ValidationError):
+            SessionEvent(
+                session_id="session-1",
+                direction="sideways",  # type: ignore[arg-type]
+                payload={"bad": True},
+            )

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -44,6 +44,7 @@ async def test_schema_migrations_written(temp_data_dir):
             versions = [row[0] for row in cur.fetchall()]
 
     assert "0001_initial" in versions
+    assert "0002_sessions" in versions
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -14,6 +14,7 @@ from tako_vm.execution import (
     RuntimeUnavailableError,
     reset_gvisor_check,
 )
+from tako_vm.job_types import JobType
 
 
 @pytest.fixture(autouse=True)
@@ -234,3 +235,102 @@ class TestPlatformDetection:
         from tako_vm.execution.worker import is_native_linux
 
         assert is_native_linux() is False
+
+
+class TestGpuRuntimePolicy:
+    """Tests for GPU-specific runtime resolution and Docker flags."""
+
+    @pytest.fixture(autouse=True)
+    def mock_gvisor_available(self, monkeypatch):
+        """Mock gVisor as available for baseline executor initialization."""
+        monkeypatch.setattr(worker_module, "_gvisor_available", True)
+
+    def test_gpu_workload_rejected_in_strict_mode(self):
+        """GPU workloads are blocked when strict mode requires gVisor."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
+        gpu_job = JobType(name="gpu-job", gpu_enabled=True, gpu_vendor="nvidia")
+
+        with pytest.raises(RuntimeUnavailableError) as exc_info:
+            executor.resolve_runtime_for_job_type(gpu_job)
+
+        assert "GPU workloads require gVisor to be disabled" in str(exc_info.value)
+
+    def test_gpu_workload_forces_runc_in_permissive_mode(self):
+        """GPU workloads always use runc in permissive mode."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+        gpu_job = JobType(name="gpu-job", gpu_enabled=True, gpu_vendor="nvidia")
+
+        assert executor.resolve_runtime_for_job_type(gpu_job) == "runc"
+
+    def test_build_gpu_flags_for_nvidia_variants(self):
+        """NVIDIA flag generation supports all/count/device selection."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+
+        assert executor.build_gpu_flags(
+            JobType(name="all", gpu_enabled=True, gpu_vendor="nvidia")
+        ) == ["--gpus=all"]
+        assert executor.build_gpu_flags(
+            JobType(name="count", gpu_enabled=True, gpu_vendor="nvidia", gpu_count=2)
+        ) == ["--gpus=2"]
+        assert executor.build_gpu_flags(
+            JobType(
+                name="devices",
+                gpu_enabled=True,
+                gpu_vendor="nvidia",
+                gpu_device_ids=["GPU-1", "GPU-2"],
+            )
+        ) == ["--gpus=device=GPU-1,GPU-2"]
+
+    def test_build_gpu_flags_for_amd(self):
+        """AMD jobs mount required device nodes."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+        flags = executor.build_gpu_flags(JobType(name="amd", gpu_enabled=True, gpu_vendor="amd"))
+        assert flags == ["--device=/dev/kfd", "--device=/dev/dri"]
+
+    def test_build_gpu_env_vars_for_device_selection(self):
+        """Device selection env vars are vendor-specific."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+
+        nvidia_env = executor.build_gpu_env_vars(
+            JobType(
+                name="nvidia",
+                gpu_enabled=True,
+                gpu_vendor="nvidia",
+                gpu_device_ids=["0", "2"],
+            )
+        )
+        assert nvidia_env == {"CUDA_VISIBLE_DEVICES": "0,2"}
+
+        amd_env = executor.build_gpu_env_vars(
+            JobType(
+                name="amd",
+                gpu_enabled=True,
+                gpu_vendor="amd",
+                gpu_device_ids=["card0"],
+            )
+        )
+        assert amd_env == {
+            "ROCR_VISIBLE_DEVICES": "card0",
+            "HIP_VISIBLE_DEVICES": "card0",
+        }
+
+    def test_build_gpu_flags_rejects_unknown_vendor(self):
+        """Unsupported GPU vendor raises a runtime error."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+
+        with pytest.raises(RuntimeUnavailableError) as exc_info:
+            executor.build_gpu_flags(JobType(name="bad", gpu_enabled=True, gpu_vendor="intel"))
+
+        assert "Unsupported GPU vendor" in str(exc_info.value)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -19,6 +19,9 @@ from tako_vm.models import (
     InputArtifact,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
+    SessionStatus,
 )
 from tako_vm.storage import ExecutionStorage
 
@@ -412,6 +415,108 @@ class TestJobVersions:
 
         versions = storage.list_versions("test-job")
         assert len(versions) == 3
+
+
+class TestSessionStorage:
+    """Tests for session persistence operations."""
+
+    @staticmethod
+    def _make_session(session_id: str, status: SessionStatus = "running") -> SessionRecord:
+        now = datetime.now(timezone.utc)
+        return SessionRecord(
+            session_id=session_id,
+            status=status,
+            job_type="default",
+            created_at=now,
+            last_activity_at=now,
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            container_name=f"tako-session-{session_id}",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=f"/tmp/{session_id}",
+            metadata={"source": "test"},
+        )
+
+    def test_save_and_get_session(self, storage):
+        """Can save and retrieve a session record."""
+        session = self._make_session("session-1")
+        storage.save_session(session)
+
+        loaded = storage.get_session("session-1")
+        assert loaded is not None
+        assert loaded.session_id == "session-1"
+        assert loaded.status == "running"
+        assert loaded.metadata["source"] == "test"
+
+    def test_list_sessions_with_status_filter(self, storage):
+        """Can list sessions filtered by status."""
+        storage.save_session(self._make_session("running-1", status="running"))
+        storage.save_session(self._make_session("terminated-1", status="terminated"))
+
+        running = storage.list_sessions(status="running")
+        assert len(running) == 1
+        assert running[0].session_id == "running-1"
+
+    def test_touch_session_updates_last_activity(self, storage):
+        """touch_session updates last_activity_at timestamp."""
+        session = self._make_session("session-touch")
+        storage.save_session(session)
+
+        touched_at = datetime.now(timezone.utc) + timedelta(seconds=5)
+        storage.touch_session("session-touch", touched_at=touched_at)
+
+        loaded = storage.get_session("session-touch")
+        assert loaded is not None
+        assert loaded.last_activity_at == touched_at
+
+    def test_save_session_event_dedupes_by_file_name(self, storage):
+        """Duplicate file_name inserts return existing event row."""
+        storage.save_session(self._make_session("session-events"))
+
+        first = storage.save_session_event(
+            SessionEvent(
+                session_id="session-events",
+                direction="out",
+                event_type="message",
+                payload={"value": 1},
+                file_name="event-1.json",
+            )
+        )
+        second = storage.save_session_event(
+            SessionEvent(
+                session_id="session-events",
+                direction="out",
+                event_type="message",
+                payload={"value": 2},
+                file_name="event-1.json",
+            )
+        )
+
+        assert first.id is not None
+        assert second.id == first.id
+
+        events = storage.list_session_events("session-events")
+        assert len(events) == 1
+        assert events[0].file_name == "event-1.json"
+
+    def test_list_session_events_after_cursor(self, storage):
+        """Can list events using an after_id cursor."""
+        storage.save_session(self._make_session("session-cursor"))
+
+        event1 = storage.save_session_event(
+            SessionEvent(session_id="session-cursor", direction="in", payload={"n": 1})
+        )
+        event2 = storage.save_session_event(
+            SessionEvent(session_id="session-cursor", direction="out", payload={"n": 2})
+        )
+
+        assert event1.id is not None
+        assert event2.id is not None
+
+        later_events = storage.list_session_events("session-cursor", after_id=event1.id)
+        assert len(later_events) == 1
+        assert later_events[0].id == event2.id
 
 
 class TestDeadLetterQueue:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,47 @@
+"""Tests for job type digest computation."""
+
+from dataclasses import replace
+
+from tako_vm.job_types import JobType
+from tako_vm.version import VersionManager
+
+
+def _version_manager() -> VersionManager:
+    # compute_digest() is pure and does not access storage.
+    return VersionManager(storage=None)  # type: ignore[arg-type]
+
+
+def test_compute_digest_changes_when_session_or_gpu_settings_change():
+    """Digest includes session and GPU fields."""
+    manager = _version_manager()
+    base = JobType(name="model-job")
+
+    base_digest = manager.compute_digest(base)
+    session_digest = manager.compute_digest(replace(base, session_enabled=True))
+    gpu_digest = manager.compute_digest(
+        replace(base, gpu_enabled=True, gpu_vendor="nvidia", gpu_count=1)
+    )
+
+    assert base_digest != session_digest
+    assert base_digest != gpu_digest
+    assert session_digest != gpu_digest
+
+
+def test_compute_digest_is_stable_for_reordered_gpu_device_ids():
+    """Device IDs are normalized for deterministic hashes."""
+    manager = _version_manager()
+
+    a = JobType(
+        name="gpu-job",
+        gpu_enabled=True,
+        gpu_vendor="nvidia",
+        gpu_device_ids=["GPU-2", "GPU-1"],
+    )
+    b = JobType(
+        name="gpu-job",
+        gpu_enabled=True,
+        gpu_vendor="nvidia",
+        gpu_device_ids=["GPU-1", "GPU-2"],
+    )
+
+    assert manager.compute_digest(a) == manager.compute_digest(b)


### PR DESCRIPTION
This PR introduces durable session persistence primitives before implementing session orchestration and API lifecycle behaviour.

## What Changed
- Added session domain models in `tako_vm/models.py`
  - `SessionRecord`
  - `SessionEvent`
  - `SessionStatus` and direction literals
- Added migration `0002_sessions` in `tako_vm/storage.py`
  - `sessions` table
  - `session_events` table with dedupe index `(session_id, file_name)`
- Added storage operations in `tako_vm/storage.py`
  - save/get/list/touch session
  - save/list session events
  - cursor pagination support
- Added row mappers for new session entities

## Tests Added/Updated
- `tests/test_models.py`
  - model defaults and literal validation
- `tests/test_storage.py`
  - CRUD/list filters
  - touch timestamp updates
  - event dedupe behavior
  - cursor-based event listing
- `tests/test_postgres_integration.py`
  - migration includes `0002_sessions`

## How To Review
1. Review new models in `tako_vm/models.py`.
2. Review migration DDL and indexes in `tako_vm/storage.py`.
3. Review storage methods for idempotence and cursor semantics.
4. Validate durability via `tests/test_storage.py` (behavior-focused, low mocking).

## Suggested Verification
- `ruff check tako_vm tests`
- `pytest tests/test_models.py tests/test_storage.py tests/test_postgres_integration.py -v`

## Out of Scope
- No session container lifecycle yet.
- No session HTTP endpoints yet.