### PR TITLE
0012 - add session API surface, docs, and CLI visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,35 @@ job_types:
     network_enabled: true
 ```
 
+### Ollama GPU Sessions (Minimal)
+
+Use a persistent Docker volume for model files, then configure an Ollama GPU session job type:
+
+```yaml
+security_mode: permissive
+sessions_enabled: true
+session_model_cache_volume: "tako-ollama-models"
+
+job_types:
+  - name: ollama-nvidia
+    base_image: "ollama/ollama:latest"
+    network_enabled: true
+    memory_limit: "8g"
+    cpu_limit: 4.0
+    timeout: 3600
+    session_enabled: true
+    environment:
+      OLLAMA_MODELS: "/models"
+      OLLAMA_HOST: "0.0.0.0:11434"
+    gpu:
+      enabled: true
+      vendor: nvidia
+```
+
+Notes:
+- GPU sessions/jobs require `security_mode: permissive`.
+- `/sessions/{id}/send` writes to Tako's inbox contract; it does not proxy Ollama HTTP endpoints.
+
 ### Network Control
 
 By default, containers have **no network access** (`--network=none`).
@@ -369,6 +398,11 @@ curl http://localhost:8000/jobs/abc123/result
 | `/jobs/{id}` | GET | Get job status |
 | `/jobs/{id}/result` | GET | Wait for job result |
 | `/jobs/{id}/cancel` | POST | Cancel pending/running job |
+| `/sessions` | POST | Create long-running session |
+| `/sessions/{id}` | GET | Get session status |
+| `/sessions/{id}/send` | POST | Send message to session inbox |
+| `/sessions/{id}/events` | GET | Poll session output events |
+| `/sessions/{id}/terminate` | POST | Terminate session |
 | `/job-types` | GET | List available job types |
 | `/health` | GET | Health check |
 
@@ -543,6 +577,10 @@ Or via environment variable for testing:
 ```bash
 TAKO_VM_SECURITY_MODE=permissive pytest tests/ -v
 ```
+
+**GPU policy:**
+- GPU workloads (NVIDIA/AMD) run with `runc` and do not use gVisor.
+- In `security_mode: strict`, GPU sessions/jobs are rejected.
 
 **Additional isolation options:**
 - **AppArmor/SELinux** (Linux only) - Can block `/proc` reads if needed

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -14,6 +14,11 @@ Complete reference for the Tako VM HTTP API.
 | `/jobs/{id}/cancel` | POST | Cancel running job |
 | `/jobs/{id}/rerun` | POST | Re-execute with same code/inputs |
 | `/jobs/{id}/fork` | POST | Re-execute with modified code |
+| `/sessions` | POST | Create long-running session |
+| `/sessions/{id}` | GET | Get session status |
+| `/sessions/{id}/send` | POST | Send message to session inbox |
+| `/sessions/{id}/events` | GET | Poll session events (cursor-based) |
+| `/sessions/{id}/terminate` | POST | End session and remove container |
 | `/health` | GET | Health check with queue stats |
 
 ## Base URL
@@ -171,6 +176,60 @@ If the same `idempotency_key` and payload are submitted again, the existing job 
 ```
 
 The status will reflect the current state of the existing job (e.g., `queued`, `running`, `succeeded`).
+
+---
+
+## Sessions API (Long-Running Containers)
+
+Sessions are disabled by default. Enable `sessions_enabled: true` in config and mark job types with `session_enabled: true`.
+
+If a job type enables GPU, sessions run with `runc` (gVisor disabled). In `security_mode: strict`, GPU sessions are rejected.
+
+### Create Session
+
+```http
+POST /sessions
+```
+
+```json
+{
+  "job_type": "ollama-nvidia",
+  "metadata": {"workflow": "assistant"},
+  "idle_timeout_seconds": 1800,
+  "ttl_seconds": 86400
+}
+```
+
+### Send Input to Session
+
+```http
+POST /sessions/{session_id}/send
+```
+
+```json
+{
+  "event_type": "input",
+  "payload": {
+    "message": "summarize the latest logs"
+  }
+}
+```
+
+This endpoint writes messages into the session inbox contract. It does not proxy the Ollama HTTP API.
+
+### Poll Session Events
+
+```http
+GET /sessions/{session_id}/events?after=0&limit=100
+```
+
+The response includes `next_cursor`; pass it as `after` in the next poll request.
+
+### Terminate Session
+
+```http
+POST /sessions/{session_id}/terminate
+```
 
 ---
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -268,6 +268,17 @@ Tako VM uses gVisor (runsc) by default for strong container isolation:
 - **strict** (default): Fails with `RuntimeUnavailableError` if gVisor is not installed. Use this in production for guaranteed strong isolation.
 - **permissive**: Falls back to standard runc runtime with a warning if gVisor is unavailable. Useful for development on systems without gVisor.
 
+**GPU compatibility note:**
+
+- GPU workloads run with `runc` (gVisor disabled).
+- If `security_mode: strict` is enabled, GPU sessions/jobs are rejected.
+
+For Ollama-style long-running sessions, configure a persistent Docker volume for model cache:
+
+```yaml
+session_model_cache_volume: "tako-ollama-models"
+```
+
 ```yaml
 # Development (allow fallback to runc)
 security_mode: permissive
@@ -306,3 +317,9 @@ limactl shell tako-gvisor
 | `enable_seccomp` | Enable seccomp syscall filtering | `true` |
 | `enable_cap_restrictions` | Enable capability restrictions (`--cap-drop=ALL`) | `true` |
 | `enable_userns` | Enable user namespace isolation | `false` |
+| `sessions_enabled` | Enable long-running session API endpoints | `false` |
+| `session_idle_timeout_seconds` | Idle timeout before auto-expire | `1800` |
+| `session_max_ttl_seconds` | Max lifetime for any session | `86400` |
+| `session_max_message_bytes` | Max `/sessions/{id}/send` payload size | `262144` |
+| `session_max_events_per_poll` | Max events returned per poll request | `100` |
+| `session_model_cache_volume` | Optional Docker volume mounted at `/models` in session containers | `null` |

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -88,8 +88,39 @@ print(response.json()["output"])
 | `cpu_limit` | CPU cores | `1.0` |
 | `timeout` | Default timeout (seconds) | `30` |
 | `network_enabled` | Allow outbound network | `false` |
+| `session_enabled` | Allow long-running session API usage | `false` |
+| `gpu.enabled` | Enable GPU access for this job type | `false` |
+| `gpu.vendor` | GPU vendor (`nvidia` or `amd`) | `null` |
+| `gpu.count` | Number of GPUs (NVIDIA only) | `null` |
+| `gpu.device_ids` | Specific GPU IDs/UUIDs | `[]` |
 | `environment` | Environment variables | `{}` |
 | `shared_code` | Python files to include | `[]` |
+
+### GPU + Sessions Example (Ollama)
+
+```yaml
+session_model_cache_volume: "tako-ollama-models"
+
+job_types:
+  - name: ollama-nvidia
+    base_image: "ollama/ollama:latest"
+    network_enabled: true
+    memory_limit: "8g"
+    cpu_limit: 4.0
+    timeout: 3600
+    session_enabled: true
+    environment:
+      OLLAMA_MODELS: "/models"
+      OLLAMA_HOST: "0.0.0.0:11434"
+    gpu:
+      enabled: true
+      vendor: nvidia
+      # count: 1
+```
+
+GPU workloads run with `runc` (gVisor disabled). If `security_mode: strict` is enabled, GPU sessions are rejected.
+
+`/sessions/{id}/send` writes to the session inbox contract. It does not proxy Ollama HTTP APIs.
 
 ## Network Access
 

--- a/tako_vm.yaml.example
+++ b/tako_vm.yaml.example
@@ -70,6 +70,16 @@ container_runtime: runsc
 # - 'permissive': Falls back to runc with warnings. ONLY for local development.
 security_mode: strict
 
+# Long-running sessions (disabled by default)
+sessions_enabled: false
+session_idle_timeout_seconds: 1800   # Auto-expire idle sessions after 30m
+session_max_ttl_seconds: 86400       # Hard cap on session lifetime (24h)
+session_max_message_bytes: 262144    # Max inbox message size (256KB)
+session_max_events_per_poll: 100     # Max events returned per /sessions/{id}/events poll
+# Optional Docker named volume mounted at /models for session containers
+# Use this for persistent Ollama model cache across sessions
+# session_model_cache_volume: "tako-ollama-models"
+
 # =============================================================================
 # Container Resource Limits
 # =============================================================================
@@ -117,6 +127,9 @@ job_types:
     memory_limit: "1g"
     cpu_limit: 2.0
     timeout: 60
+    session_enabled: false
+    gpu:
+      enabled: false
 
   # ML inference
   - name: ml-inference
@@ -126,6 +139,9 @@ job_types:
     memory_limit: "2g"
     cpu_limit: 2.0
     timeout: 120
+    session_enabled: false
+    gpu:
+      enabled: false
 
   # API client with network access
   - name: api-client
@@ -135,3 +151,39 @@ job_types:
     network_enabled: true
     memory_limit: "512m"
     timeout: 30
+    session_enabled: false
+    gpu:
+      enabled: false
+
+  # OpenClaw/Ollama-style long-running GPU session (NVIDIA example)
+  - name: openclaw-nvidia
+    base_image: "tako-openclaw:latest"
+    network_enabled: true
+    memory_limit: "8g"
+    cpu_limit: 4.0
+    timeout: 3600
+    session_enabled: true
+    gpu:
+      enabled: true
+      vendor: nvidia
+      # count: 1
+      # device_ids: ["GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+
+  # Minimal Ollama GPU session (NVIDIA)
+  # Requires:
+  # - sessions_enabled: true
+  # - security_mode: permissive (GPU workloads run with runc)
+  # - session_model_cache_volume configured for persistent model cache (recommended)
+  - name: ollama-nvidia
+    base_image: "ollama/ollama:latest"
+    network_enabled: true
+    memory_limit: "8g"
+    cpu_limit: 4.0
+    timeout: 3600
+    session_enabled: true
+    environment:
+      OLLAMA_MODELS: "/models"
+      OLLAMA_HOST: "0.0.0.0:11434"
+    gpu:
+      enabled: true
+      vendor: nvidia

--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -517,8 +517,19 @@ def show_config(args):
 
         print("[Docker]")
         print(f"  docker_image: {config.docker_image}")
+        print(f"  container_runtime: {config.container_runtime}")
+        print(f"  security_mode: {config.security_mode}")
         print(f"  enable_seccomp: {config.enable_seccomp}")
+        print(f"  enable_cap_restrictions: {config.enable_cap_restrictions}")
         print(f"  enable_userns: {config.enable_userns}")
+        print()
+
+        print("[Sessions]")
+        print(f"  sessions_enabled: {config.sessions_enabled}")
+        print(f"  session_idle_timeout_seconds: {config.session_idle_timeout_seconds}")
+        print(f"  session_max_ttl_seconds: {config.session_max_ttl_seconds}")
+        print(f"  session_max_message_bytes: {config.session_max_message_bytes}")
+        print(f"  session_max_events_per_poll: {config.session_max_events_per_poll}")
         print()
 
         if config.job_types:
@@ -528,6 +539,16 @@ def show_config(args):
                 print(
                     f"      memory: {jt.memory_limit}, cpu: {jt.cpu_limit}, timeout: {jt.timeout}s"
                 )
+                print(f"      session_enabled: {jt.session_enabled}")
+                if jt.gpu.enabled:
+                    gpu_parts = [f"vendor={jt.gpu.vendor}"]
+                    if jt.gpu.count is not None:
+                        gpu_parts.append(f"count={jt.gpu.count}")
+                    if jt.gpu.device_ids:
+                        gpu_parts.append(f"device_ids={','.join(jt.gpu.device_ids)}")
+                    print(f"      gpu: enabled ({', '.join(gpu_parts)})")
+                else:
+                    print("      gpu: disabled")
                 if jt.requirements:
                     print(f"      requirements: {', '.join(jt.requirements)}")
 

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -94,6 +94,63 @@ class ContainerLimits(BaseModel):
         return self
 
 
+class JobTypeGPUConfig(BaseModel):
+    """GPU configuration for a job type."""
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = Field(default=False)
+    vendor: Optional[str] = Field(default=None, description="GPU vendor: 'nvidia' or 'amd'")
+    count: Optional[int] = Field(default=None, ge=1, le=16)
+    device_ids: List[str] = Field(default_factory=list, max_length=16)
+
+    @field_validator("vendor")
+    @classmethod
+    def validate_vendor(cls, v: Optional[str]) -> Optional[str]:
+        """Validate GPU vendor."""
+        if v is None:
+            return None
+        normalized = v.lower().strip()
+        if normalized not in {"nvidia", "amd"}:
+            raise ValueError("gpu.vendor must be one of: amd, nvidia")
+        return normalized
+
+    @field_validator("device_ids")
+    @classmethod
+    def validate_device_ids(cls, values: List[str]) -> List[str]:
+        """Validate GPU device ID list."""
+        normalized: List[str] = []
+        for value in values:
+            device_id = value.strip()
+            if not device_id:
+                raise ValueError("gpu.device_ids cannot contain empty values")
+            if "," in device_id:
+                raise ValueError("gpu.device_ids entries cannot contain commas")
+            normalized.append(device_id)
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_gpu_config(self) -> "JobTypeGPUConfig":
+        """Validate cross-field GPU settings."""
+        if not self.enabled:
+            if self.vendor is not None or self.count is not None or self.device_ids:
+                raise ValueError(
+                    "gpu.enabled must be true when setting gpu.vendor, gpu.count, or gpu.device_ids"
+                )
+            return self
+
+        if self.vendor is None:
+            raise ValueError("gpu.vendor is required when gpu.enabled is true")
+
+        if self.count is not None and self.device_ids:
+            raise ValueError("gpu.count and gpu.device_ids are mutually exclusive")
+
+        if self.vendor == "amd" and self.count is not None:
+            raise ValueError("gpu.count is only supported for gpu.vendor='nvidia'")
+
+        return self
+
+
 class JobTypeConfig(BaseModel):
     """Job type configuration for embedding in main config."""
 
@@ -114,6 +171,11 @@ class JobTypeConfig(BaseModel):
     """Timeout for startup phase (container init + dep install) in seconds."""
 
     network_enabled: bool = Field(default=False, description="Allow network access (security risk)")
+    session_enabled: bool = Field(
+        default=False,
+        description="Allow this job type to be used for long-running sessions",
+    )
+    gpu: JobTypeGPUConfig = Field(default_factory=JobTypeGPUConfig)
 
     @field_validator("name")
     @classmethod
@@ -472,7 +534,6 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         config_dict["api_rate_limit_window_seconds"] = parse_env_int(
             "TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS"
         )
-
     # Validate and create config
     try:
         config = TakoVMConfig(**config_dict)

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -6,6 +6,7 @@ Loads configuration from YAML file with optional env var overrides.
 """
 
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
@@ -20,6 +21,10 @@ CONFIG_SEARCH_PATHS = [
     Path.home() / ".tako_vm" / "config.yaml",  # User home
     Path("/etc/tako_vm/config.yaml"),  # System-wide
 ]
+
+
+# Docker named volume pattern (1-128 chars, conservative allowlist)
+_DOCKER_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 
 
 def get_default_data_dir() -> Path:
@@ -343,6 +348,17 @@ class TakoVMConfig(BaseModel):
         description="Security mode: 'strict' fails if gVisor unavailable, 'permissive' allows fallback to runc",
     )
 
+    # Session runtime controls
+    sessions_enabled: bool = Field(default=False)
+    session_idle_timeout_seconds: int = Field(default=1800, ge=30, le=86400)
+    session_max_ttl_seconds: int = Field(default=86400, ge=60, le=604800)
+    session_max_message_bytes: int = Field(default=262144, ge=1024, le=10485760)
+    session_max_events_per_poll: int = Field(default=100, ge=1, le=1000)
+    session_model_cache_volume: Optional[str] = Field(
+        default=None,
+        description="Optional Docker named volume mounted at /models for session container model cache",
+    )
+
     @field_validator("container_runtime")
     @classmethod
     def validate_container_runtime(cls, v: str) -> str:
@@ -363,6 +379,25 @@ class TakoVMConfig(BaseModel):
             raise ValueError(f"security_mode must be one of: {', '.join(sorted(valid_modes))}")
         return v
 
+    @field_validator("session_model_cache_volume")
+    @classmethod
+    def validate_session_model_cache_volume(cls, value: Optional[str]) -> Optional[str]:
+        """Validate optional session model cache volume name."""
+        if value is None:
+            return None
+
+        normalized = value.strip()
+        if not normalized:
+            return None
+
+        if not _DOCKER_VOLUME_NAME_PATTERN.match(normalized):
+            raise ValueError(
+                "session_model_cache_volume must be a valid Docker named volume "
+                "([A-Za-z0-9][A-Za-z0-9_.-]{0,127})"
+            )
+
+        return normalized
+
     # Container limits (new!)
     container_limits: ContainerLimits = Field(default_factory=ContainerLimits)
 
@@ -382,6 +417,8 @@ class TakoVMConfig(BaseModel):
             raise ValueError("default_timeout must be <= max_timeout")
         if self.default_startup_timeout > self.max_startup_timeout:
             raise ValueError("default_startup_timeout must be <= max_startup_timeout")
+        if self.session_idle_timeout_seconds > self.session_max_ttl_seconds:
+            raise ValueError("session_idle_timeout_seconds must be <= session_max_ttl_seconds")
         return self
 
     def resolve_paths(self) -> "TakoVMConfig":
@@ -534,6 +571,29 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         config_dict["api_rate_limit_window_seconds"] = parse_env_int(
             "TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS"
         )
+    if "TAKO_VM_SESSIONS_ENABLED" in os.environ:
+        config_dict["sessions_enabled"] = os.environ["TAKO_VM_SESSIONS_ENABLED"].lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+    if "TAKO_VM_SESSION_IDLE_TIMEOUT_SECONDS" in os.environ:
+        config_dict["session_idle_timeout_seconds"] = parse_env_int(
+            "TAKO_VM_SESSION_IDLE_TIMEOUT_SECONDS"
+        )
+    if "TAKO_VM_SESSION_MAX_TTL_SECONDS" in os.environ:
+        config_dict["session_max_ttl_seconds"] = parse_env_int("TAKO_VM_SESSION_MAX_TTL_SECONDS")
+    if "TAKO_VM_SESSION_MAX_MESSAGE_BYTES" in os.environ:
+        config_dict["session_max_message_bytes"] = parse_env_int(
+            "TAKO_VM_SESSION_MAX_MESSAGE_BYTES"
+        )
+    if "TAKO_VM_SESSION_MAX_EVENTS_PER_POLL" in os.environ:
+        config_dict["session_max_events_per_poll"] = parse_env_int(
+            "TAKO_VM_SESSION_MAX_EVENTS_PER_POLL"
+        )
+    if "TAKO_VM_SESSION_MODEL_CACHE_VOLUME" in os.environ:
+        config_dict["session_model_cache_volume"] = os.environ["TAKO_VM_SESSION_MODEL_CACHE_VOLUME"]
+
     # Validate and create config
     try:
         config = TakoVMConfig(**config_dict)

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -209,15 +209,17 @@ class CodeExecutor:
         self.registry = registry or JobTypeRegistry()
         self.config = config or get_config()
 
-        # Check runtime availability
-        self._runtime = self._resolve_runtime()
+        # Resolve and validate baseline non-GPU runtime availability at startup
+        self._runtime = self._resolve_runtime(use_gpu=False, workload="job")
 
-    def _resolve_runtime(self) -> str:
+    def _resolve_runtime(self, use_gpu: bool = False, workload: str = "job") -> str:
         """
         Resolve the container runtime to use.
 
         In strict mode (default), gVisor must be available or we fail.
         In permissive mode, we fall back to runc with a warning.
+
+        GPU execution/session workloads always require runc.
 
         Returns:
             The runtime to use ('runsc' or 'runc')
@@ -227,6 +229,20 @@ class CodeExecutor:
         """
         requested_runtime = self.config.container_runtime
         security_mode = self.config.security_mode
+
+        if use_gpu:
+            if security_mode == "strict":
+                raise RuntimeUnavailableError(
+                    "GPU workloads require gVisor to be disabled, but security_mode='strict' "
+                    "requires gVisor. Use security_mode='permissive' for GPU sessions/jobs."
+                )
+
+            if requested_runtime == "runsc":
+                logger.info(
+                    "GPU enabled for %s workload; forcing runtime to runc (gVisor disabled)",
+                    workload,
+                )
+            return "runc"
 
         # If runc is explicitly requested, allow it (user knows what they're doing)
         if requested_runtime == "runc":
@@ -261,6 +277,45 @@ class CodeExecutor:
         logger.warning("WARNING: DO NOT USE FOR UNTRUSTED CODE")
         logger.warning("=" * 60)
         return "runc"
+
+    def resolve_runtime_for_job_type(self, job_type: JobType, workload: str = "job") -> str:
+        """Resolve runtime for a specific job type, accounting for GPU requirements."""
+        return self._resolve_runtime(use_gpu=job_type.gpu_enabled, workload=workload)
+
+    def build_gpu_flags(self, job_type: JobType) -> List[str]:
+        """Build Docker CLI GPU flags for a job type."""
+        if not job_type.gpu_enabled:
+            return []
+
+        vendor = (job_type.gpu_vendor or "").lower()
+        if vendor == "nvidia":
+            if job_type.gpu_device_ids:
+                return [f"--gpus=device={','.join(job_type.gpu_device_ids)}"]
+            if job_type.gpu_count is not None:
+                return [f"--gpus={job_type.gpu_count}"]
+            return ["--gpus=all"]
+
+        if vendor == "amd":
+            return ["--device=/dev/kfd", "--device=/dev/dri"]
+
+        raise RuntimeUnavailableError(f"Unsupported GPU vendor: {job_type.gpu_vendor}")
+
+    def build_gpu_env_vars(self, job_type: JobType) -> Dict[str, str]:
+        """Build environment variables used for GPU device selection."""
+        if not job_type.gpu_enabled or not job_type.gpu_device_ids:
+            return {}
+
+        device_list = ",".join(job_type.gpu_device_ids)
+        vendor = (job_type.gpu_vendor or "").lower()
+
+        if vendor == "nvidia":
+            return {"CUDA_VISIBLE_DEVICES": device_list}
+        if vendor == "amd":
+            return {
+                "ROCR_VISIBLE_DEVICES": device_list,
+                "HIP_VISIBLE_DEVICES": device_list,
+            }
+        return {}
 
     def _get_job_type(self, job_type_name: Optional[str]) -> JobType:
         """
@@ -819,6 +874,20 @@ class CodeExecutor:
                 "For true network isolation, use pre-built images via 'tako-vm build'."
             )
 
+        try:
+            runtime = self.resolve_runtime_for_job_type(job_type=job_type, workload="job")
+            gpu_flags = self.build_gpu_flags(job_type)
+            gpu_env_vars = self.build_gpu_env_vars(job_type)
+        except RuntimeUnavailableError as e:
+            safe_error = sanitize_error(str(e))
+            return {
+                "success": False,
+                "error": safe_error,
+                "stdout": "",
+                "stderr": safe_error,
+                "exit_code": -1,
+            }
+
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako", job_id)
 
@@ -849,8 +918,11 @@ class CodeExecutor:
         # Only specify runtime explicitly for gVisor (runsc)
         # runc is the default Docker runtime, so we don't need to specify it explicitly
         # (and some Docker configurations may not accept --runtime=runc)
-        if self._runtime == "runsc":
-            cmd.append(f"--runtime={self._runtime}")
+        if runtime == "runsc":
+            cmd.append("--runtime=runsc")
+
+        # GPU access flags (if enabled by job type)
+        cmd.extend(gpu_flags)
 
         # Mount uv cache volume for faster repeated installs
         if has_runtime_deps:
@@ -908,6 +980,10 @@ class CodeExecutor:
             if not validate_env_value(value):
                 logger.warning(f"Skipping environment variable with unsafe value: {key}")
                 continue
+            cmd.append(f"--env={key}={value}")
+
+        # Add GPU selection env vars (safe, generated by server)
+        for key, value in gpu_env_vars.items():
             cmd.append(f"--env={key}={value}")
 
         # Pass requirements for runtime installation via uv

--- a/tako_vm/job_types.json
+++ b/tako_vm/job_types.json
@@ -11,7 +11,14 @@
       "cpu_limit": 1.0,
       "timeout": 30,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     },
     {
       "name": "data-processing",
@@ -27,7 +34,14 @@
       "cpu_limit": 2.0,
       "timeout": 60,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     },
     {
       "name": "ml-inference",
@@ -43,7 +57,14 @@
       "cpu_limit": 2.0,
       "timeout": 120,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     },
     {
       "name": "test-with-secrets",
@@ -59,7 +80,14 @@
       "cpu_limit": 0.5,
       "timeout": 10,
       "startup_timeout": 120,
-      "network_enabled": false
+      "network_enabled": false,
+      "session_enabled": false,
+      "gpu": {
+        "enabled": false,
+        "vendor": null,
+        "count": null,
+        "device_ids": []
+      }
     }
   ]
 }

--- a/tako_vm/job_types.py
+++ b/tako_vm/job_types.py
@@ -62,6 +62,21 @@ class JobType:
     network_enabled: bool = False
     """Allow network access (default: no network for security)."""
 
+    session_enabled: bool = False
+    """Allow this job type to be used for long-running sessions."""
+
+    gpu_enabled: bool = False
+    """Enable GPU access for this job type."""
+
+    gpu_vendor: Optional[str] = None
+    """GPU vendor ('nvidia' or 'amd')."""
+
+    gpu_count: Optional[int] = None
+    """Number of GPUs (NVIDIA only)."""
+
+    gpu_device_ids: list[str] = field(default_factory=list)
+    """Specific GPU device IDs/UUIDs to expose."""
+
     @property
     def image_name(self) -> str:
         """Docker image name for this job type."""
@@ -81,12 +96,38 @@ class JobType:
             "timeout": self.timeout,
             "startup_timeout": self.startup_timeout,
             "network_enabled": self.network_enabled,
+            "session_enabled": self.session_enabled,
+            "gpu": {
+                "enabled": self.gpu_enabled,
+                "vendor": self.gpu_vendor,
+                "count": self.gpu_count,
+                "device_ids": self.gpu_device_ids,
+            },
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> JobType:
         """Create from dictionary."""
-        return cls(**data)
+        gpu = data.get("gpu") or {}
+
+        return cls(
+            name=data["name"],
+            requirements=list(data.get("requirements", [])),
+            python_version=data.get("python_version", "3.11"),
+            base_image=data.get("base_image"),
+            shared_code=list(data.get("shared_code", [])),
+            environment=dict(data.get("environment", {})),
+            memory_limit=data.get("memory_limit", "512m"),
+            cpu_limit=float(data.get("cpu_limit", 1.0)),
+            timeout=int(data.get("timeout", 30)),
+            startup_timeout=int(data.get("startup_timeout", 120)),
+            network_enabled=bool(data.get("network_enabled", False)),
+            session_enabled=bool(data.get("session_enabled", False)),
+            gpu_enabled=bool(data.get("gpu_enabled", gpu.get("enabled", False))),
+            gpu_vendor=data.get("gpu_vendor", gpu.get("vendor")),
+            gpu_count=data.get("gpu_count", gpu.get("count")),
+            gpu_device_ids=list(data.get("gpu_device_ids", gpu.get("device_ids", []))),
+        )
 
     @classmethod
     def from_config(cls, config: JobTypeConfig) -> JobType:
@@ -111,6 +152,11 @@ class JobType:
             timeout=config.timeout,
             startup_timeout=config.startup_timeout,
             network_enabled=config.network_enabled,
+            session_enabled=config.session_enabled,
+            gpu_enabled=config.gpu.enabled,
+            gpu_vendor=config.gpu.vendor,
+            gpu_count=config.gpu.count,
+            gpu_device_ids=list(config.gpu.device_ids),
         )
 
     def to_config(self) -> JobTypeConfig:
@@ -120,7 +166,7 @@ class JobType:
         Returns:
             Pydantic JobTypeConfig instance
         """
-        from tako_vm.config import JobTypeConfig
+        from tako_vm.config import JobTypeConfig, JobTypeGPUConfig
 
         return JobTypeConfig(
             name=self.name,
@@ -134,6 +180,13 @@ class JobType:
             timeout=self.timeout,
             startup_timeout=self.startup_timeout,
             network_enabled=self.network_enabled,
+            session_enabled=self.session_enabled,
+            gpu=JobTypeGPUConfig(
+                enabled=self.gpu_enabled,
+                vendor=self.gpu_vendor,
+                count=self.gpu_count,
+                device_ids=list(self.gpu_device_ids),
+            ),
         )
 
 
@@ -172,15 +225,28 @@ class JobTypeRegistry:
         with open(self.config_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
-    def register(self, job_type: JobType) -> None:
+    def register(self, job_type: JobType, persist: bool = True) -> None:
         """
         Register a new job type.
 
         Args:
             job_type: Job type configuration
+            persist: Whether to save registry changes to disk
         """
         self._job_types[job_type.name] = job_type
-        self._save()
+        if persist:
+            self._save()
+
+    def register_many(self, job_types: list[JobType], persist: bool = True) -> None:
+        """Register multiple job types at once."""
+        if not job_types:
+            return
+
+        for job_type in job_types:
+            self._job_types[job_type.name] = job_type
+
+        if persist:
+            self._save()
 
     def get(self, name: str) -> Optional[JobType]:
         """
@@ -249,3 +315,29 @@ def init_default_job_types(registry: JobTypeRegistry) -> None:
     for jt in DEFAULT_JOB_TYPES:
         if registry.get(jt.name) is None:
             registry.register(jt)
+
+
+def merge_config_job_types(
+    registry: JobTypeRegistry, config_job_types: list["JobTypeConfig"]
+) -> int:
+    """
+    Merge config-defined job types into a runtime registry.
+
+    Job types from config override any existing registry entry with the same name.
+    Changes are applied in memory only (no persistence to job_types.json).
+
+    Args:
+        registry: Runtime job type registry
+        config_job_types: Job types loaded from TakoVM config
+
+    Returns:
+        Number of config job types merged
+    """
+    if not config_job_types:
+        return 0
+
+    runtime_job_types = [
+        JobType.from_config(job_type_config) for job_type_config in config_job_types
+    ]
+    registry.register_many(runtime_job_types, persist=False)
+    return len(runtime_job_types)

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -490,3 +490,61 @@ class DeadLetterEntry(BaseModel):
 
     correlation_id: Optional[str] = Field(default=None, max_length=64)
     """Correlation ID for tracing."""
+
+
+SessionStatus = Literal[
+    "creating",
+    "running",
+    "terminated",
+    "failed",
+    "expired",
+]
+
+SessionEventDirection = Literal["in", "out", "system"]
+
+
+class SessionRecord(BaseModel):
+    """Persistent metadata for a long-running session container."""
+
+    model_config = {"extra": "forbid"}
+
+    session_id: str = Field(default_factory=lambda: str(uuid.uuid4()), min_length=1, max_length=64)
+    status: SessionStatus = "creating"
+    job_type: str = Field(default="default", min_length=1, max_length=64)
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    last_activity_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: Optional[datetime] = None
+
+    idle_timeout_seconds: int = Field(default=1800, ge=30, le=86400)
+    ttl_seconds: int = Field(default=86400, ge=60, le=604800)
+
+    container_name: str = Field(..., min_length=1, max_length=128)
+    container_id: Optional[str] = Field(default=None, max_length=128)
+    image_name: str = Field(..., min_length=1, max_length=255)
+    runtime: str = Field(..., min_length=1, max_length=16)
+
+    gpu_enabled: bool = False
+    gpu_vendor: Optional[str] = Field(default=None, max_length=16)
+
+    workspace_dir: str = Field(..., min_length=1, max_length=1024)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    error_message: Optional[str] = Field(default=None, max_length=4096)
+    terminated_reason: Optional[str] = Field(default=None, max_length=256)
+
+
+class SessionEvent(BaseModel):
+    """Input/output event persisted for session polling."""
+
+    model_config = {"extra": "forbid"}
+
+    id: Optional[int] = Field(default=None, ge=0)
+    session_id: str = Field(..., min_length=1, max_length=64)
+    direction: SessionEventDirection
+    event_type: str = Field(default="message", min_length=1, max_length=64)
+    payload: Any = None
+    file_name: Optional[str] = Field(default=None, max_length=255)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tako_vm/server/__init__.py
+++ b/tako_vm/server/__init__.py
@@ -11,6 +11,7 @@ from tako_vm.server.correlation import (
     set_correlation_id,
 )
 from tako_vm.server.queue import QueuedJob, WorkerPool
+from tako_vm.server.sessions import SessionManager, SessionManagerError
 
 __all__ = [
     # App
@@ -18,6 +19,8 @@ __all__ = [
     # Queue
     "WorkerPool",
     "QueuedJob",
+    "SessionManager",
+    "SessionManagerError",
     # Correlation ID utilities
     "get_correlation_id",
     "set_correlation_id",

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field, field_validator
 from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.execution.health import get_circuit_breaker, startup_cleanup
 from tako_vm.execution.worker import CodeExecutor, check_gvisor_available
-from tako_vm.job_types import JobTypeRegistry
+from tako_vm.job_types import JobTypeRegistry, merge_config_job_types
 from tako_vm.models import ExecutionRecord, sha256_content, sha256_json
 from tako_vm.security import sanitize_error
 from tako_vm.server.correlation import (
@@ -169,6 +169,9 @@ async def lifespan(app: FastAPI):
     # Configure log level from config
     _configure_log_level(state.config.log_level)
     state.registry = JobTypeRegistry()
+    merged_job_types = merge_config_job_types(state.registry, state.config.job_types)
+    if merged_job_types:
+        logger.info("Loaded %s job type(s) from config", merged_job_types)
     state.executor = CodeExecutor(registry=state.registry, config=state.config)
     state.storage = ExecutionStorage(state.config.database_url)
     await state.storage.init()
@@ -409,6 +412,9 @@ class JobTypeResponse(BaseModel):
     memory_limit: str
     cpu_limit: float
     timeout: int
+    session_enabled: bool
+    gpu_enabled: bool
+    gpu_vendor: Optional[str] = None
     image_exists: bool
 
 
@@ -1305,6 +1311,9 @@ async def list_job_types():
                 memory_limit=jt.memory_limit,
                 cpu_limit=jt.cpu_limit,
                 timeout=jt.timeout,
+                session_enabled=jt.session_enabled,
+                gpu_enabled=jt.gpu_enabled,
+                gpu_vendor=jt.gpu_vendor,
                 image_exists=builder.image_exists(jt),
             )
         )
@@ -1336,6 +1345,9 @@ async def get_job_type(name: str):
         memory_limit=jt.memory_limit,
         cpu_limit=jt.cpu_limit,
         timeout=jt.timeout,
+        session_enabled=jt.session_enabled,
+        gpu_enabled=jt.gpu_enabled,
+        gpu_vendor=jt.gpu_vendor,
         image_exists=builder.image_exists(jt),
     )
 

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -29,7 +29,7 @@ from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.execution.health import get_circuit_breaker, startup_cleanup
 from tako_vm.execution.worker import CodeExecutor, check_gvisor_available
 from tako_vm.job_types import JobTypeRegistry, merge_config_job_types
-from tako_vm.models import ExecutionRecord, sha256_content, sha256_json
+from tako_vm.models import ExecutionRecord, SessionEvent, SessionRecord, sha256_content, sha256_json
 from tako_vm.security import sanitize_error
 from tako_vm.server.correlation import (
     CorrelationIdMiddleware,
@@ -38,6 +38,7 @@ from tako_vm.server.correlation import (
 )
 from tako_vm.server.limits import ApiProtectionMiddleware
 from tako_vm.server.queue import WorkerPool
+from tako_vm.server.sessions import SessionManager, SessionManagerError
 from tako_vm.storage import ExecutionStorage
 
 # Configure logging with correlation ID support
@@ -119,6 +120,7 @@ class AppState:
     executor: CodeExecutor
     storage: ExecutionStorage
     worker_pool: WorkerPool
+    session_manager: SessionManager
     idempotency_locks: IdempotencyLockManager
 
 
@@ -183,6 +185,13 @@ async def lifespan(app: FastAPI):
         queue_wait_timeout=state.config.queue_wait_timeout,
     )
     await state.worker_pool.start()
+    state.session_manager = SessionManager(
+        config=state.config,
+        storage=state.storage,
+        registry=state.registry,
+        executor=state.executor,
+    )
+    await state.session_manager.start()
 
     # Start periodic cleanup task
     cleanup_task = asyncio.create_task(
@@ -200,6 +209,7 @@ async def lifespan(app: FastAPI):
         await cleanup_task
     except asyncio.CancelledError:
         pass
+    await state.session_manager.stop()
     await state.worker_pool.stop()
     await state.storage.close()
 
@@ -297,6 +307,7 @@ QueueStatus = Literal[
 ]
 HealthStatus = Literal["healthy", "degraded"]
 RelationshipType = Literal["rerun", "fork"]
+SessionStatusType = Literal["creating", "running", "terminated", "failed", "expired"]
 
 
 class AsyncExecuteResponse(BaseModel):
@@ -484,6 +495,137 @@ class CancelResponse(BaseModel):
 
     status: Literal["cancelled"] = Field(..., description="Cancellation status")
     job_id: str = Field(..., description="ID of the cancelled job")
+
+
+class SessionCreateRequest(BaseModel):
+    """Request model for creating a long-running session."""
+
+    model_config = {"extra": "forbid"}
+
+    job_type: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-zA-Z0-9_-]+(@[a-zA-Z0-9_.@:-]+)?$",
+        description="Session-enabled job type name",
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Optional session metadata")
+    idle_timeout_seconds: Optional[int] = Field(
+        default=None,
+        ge=30,
+        le=86400,
+        description="Optional idle timeout override (seconds)",
+    )
+    ttl_seconds: Optional[int] = Field(
+        default=None,
+        ge=60,
+        le=604800,
+        description="Optional max session lifetime override (seconds)",
+    )
+
+
+class SessionSendRequest(BaseModel):
+    """Request model for posting input to a session inbox."""
+
+    model_config = {"extra": "forbid"}
+
+    payload: Any = Field(..., description="JSON payload delivered to the session inbox")
+    event_type: str = Field(
+        default="input",
+        min_length=1,
+        max_length=64,
+        description="Event type label for this input payload",
+    )
+
+
+class SessionResponse(BaseModel):
+    """Response model for session status."""
+
+    model_config = {"extra": "forbid"}
+
+    session_id: str
+    status: SessionStatusType
+    job_type: str
+    created_at: str
+    started_at: Optional[str] = None
+    ended_at: Optional[str] = None
+    runtime: str
+    gpu_enabled: bool
+    gpu_vendor: Optional[str] = None
+    idle_timeout_seconds: int
+    ttl_seconds: int
+    error_message: Optional[str] = None
+    terminated_reason: Optional[str] = None
+
+    @classmethod
+    def from_record(cls, record: SessionRecord) -> "SessionResponse":
+        return cls(
+            session_id=record.session_id,
+            status=record.status,
+            job_type=record.job_type,
+            created_at=record.created_at.isoformat(),
+            started_at=record.started_at.isoformat() if record.started_at else None,
+            ended_at=record.ended_at.isoformat() if record.ended_at else None,
+            runtime=record.runtime,
+            gpu_enabled=record.gpu_enabled,
+            gpu_vendor=record.gpu_vendor,
+            idle_timeout_seconds=record.idle_timeout_seconds,
+            ttl_seconds=record.ttl_seconds,
+            error_message=record.error_message,
+            terminated_reason=record.terminated_reason,
+        )
+
+
+class SessionEventResponse(BaseModel):
+    """Response model for a session mailbox event."""
+
+    model_config = {"extra": "forbid"}
+
+    id: Optional[int]
+    direction: Literal["in", "out", "system"]
+    event_type: str
+    payload: Any
+    created_at: str
+
+    @classmethod
+    def from_event(cls, event: SessionEvent) -> "SessionEventResponse":
+        return cls(
+            id=event.id,
+            direction=event.direction,
+            event_type=event.event_type,
+            payload=event.payload,
+            created_at=event.created_at.isoformat(),
+        )
+
+
+class SessionSendResponse(BaseModel):
+    """Response model for session inbox writes."""
+
+    model_config = {"extra": "forbid"}
+
+    session_id: str
+    event_id: Optional[int]
+    status: Literal["queued"]
+
+
+class SessionEventsResponse(BaseModel):
+    """Response model for polling session events with cursor pagination."""
+
+    model_config = {"extra": "forbid"}
+
+    session_id: str
+    status: SessionStatusType
+    events: List[SessionEventResponse]
+    next_cursor: int
+
+
+class SessionTerminateResponse(BaseModel):
+    """Response model for session termination."""
+
+    model_config = {"extra": "forbid"}
+
+    session_id: str
+    status: SessionStatusType
 
 
 class DLQStatsResponse(BaseModel):
@@ -993,6 +1135,109 @@ async def cancel_job(job_id: str):
         raise HTTPException(status_code=404, detail="Job not found or already completed")
 
     return CancelResponse(status="cancelled", job_id=job_id)
+
+
+@app.post("/sessions", response_model=SessionResponse)
+async def create_session(request: SessionCreateRequest):
+    """Create a long-running session container with mailbox mounts."""
+    try:
+        record = await state.session_manager.create_session(
+            job_type_name=request.job_type,
+            metadata=request.metadata,
+            idle_timeout_seconds=request.idle_timeout_seconds,
+            ttl_seconds=request.ttl_seconds,
+        )
+        return SessionResponse.from_record(record)
+    except SessionManagerError as e:
+        raise HTTPException(status_code=e.status_code, detail=sanitize_error(str(e))) from e
+    except Exception as e:
+        logger.error("Session creation failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=sanitize_error(str(e))) from e
+
+
+@app.get("/sessions", response_model=PaginatedResponse)
+async def list_sessions(
+    status: Optional[str] = Query(default=None, description="Filter by session status"),
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+):
+    """List long-running sessions with pagination."""
+    actual_limit = min(limit, 1000)
+    records = await state.session_manager.list_sessions(
+        status=status,
+        limit=actual_limit + 1,
+        offset=offset,
+    )
+    has_more = len(records) > actual_limit
+    if has_more:
+        records = records[:actual_limit]
+
+    return PaginatedResponse(
+        items=[SessionResponse.from_record(record) for record in records],
+        limit=actual_limit,
+        offset=offset,
+        has_more=has_more,
+        count=len(records),
+    )
+
+
+@app.get("/sessions/{session_id}", response_model=SessionResponse)
+async def get_session(session_id: str):
+    """Get current session status and runtime metadata."""
+    record = await state.session_manager.get_session(session_id, refresh=True)
+    if not record:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return SessionResponse.from_record(record)
+
+
+@app.post("/sessions/{session_id}/send", response_model=SessionSendResponse)
+async def send_session_event(session_id: str, request: SessionSendRequest):
+    """Write a message into the session inbox."""
+    try:
+        event = await state.session_manager.send_event(
+            session_id=session_id,
+            payload=request.payload,
+            event_type=request.event_type,
+        )
+        return SessionSendResponse(session_id=session_id, event_id=event.id, status="queued")
+    except SessionManagerError as e:
+        raise HTTPException(status_code=e.status_code, detail=sanitize_error(str(e))) from e
+
+
+@app.get("/sessions/{session_id}/events", response_model=SessionEventsResponse)
+async def poll_session_events(
+    session_id: str,
+    after: int = Query(default=0, ge=0, description="Event cursor ID (exclusive)"),
+    limit: int = Query(default=100, ge=1, le=1000, description="Maximum events to return"),
+):
+    """Poll session mailbox events after a cursor."""
+    try:
+        session, events = await state.session_manager.poll_events(
+            session_id=session_id,
+            after_id=after,
+            limit=limit,
+        )
+        next_cursor = after
+        if events:
+            next_cursor = max(event.id or after for event in events)
+        return SessionEventsResponse(
+            session_id=session_id,
+            status=session.status,
+            events=[SessionEventResponse.from_event(event) for event in events],
+            next_cursor=next_cursor,
+        )
+    except SessionManagerError as e:
+        raise HTTPException(status_code=e.status_code, detail=sanitize_error(str(e))) from e
+
+
+@app.post("/sessions/{session_id}/terminate", response_model=SessionTerminateResponse)
+async def terminate_session(session_id: str):
+    """Terminate a running session and remove its container."""
+    try:
+        session = await state.session_manager.terminate_session(session_id=session_id)
+        return SessionTerminateResponse(session_id=session_id, status=session.status)
+    except SessionManagerError as e:
+        raise HTTPException(status_code=e.status_code, detail=sanitize_error(str(e))) from e
 
 
 def _get_replay_data(record: ExecutionRecord) -> tuple:

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -29,7 +29,14 @@ from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.execution.health import get_circuit_breaker, startup_cleanup
 from tako_vm.execution.worker import CodeExecutor, check_gvisor_available
 from tako_vm.job_types import JobTypeRegistry, merge_config_job_types
-from tako_vm.models import ExecutionRecord, SessionEvent, SessionRecord, sha256_content, sha256_json
+from tako_vm.models import (
+    ExecutionRecord,
+    SessionEvent,
+    SessionRecord,
+    SessionStatus,
+    sha256_content,
+    sha256_json,
+)
 from tako_vm.security import sanitize_error
 from tako_vm.server.correlation import (
     CorrelationIdMiddleware,
@@ -307,7 +314,7 @@ QueueStatus = Literal[
 ]
 HealthStatus = Literal["healthy", "degraded"]
 RelationshipType = Literal["rerun", "fork"]
-SessionStatusType = Literal["creating", "running", "terminated", "failed", "expired"]
+SessionStatusType = SessionStatus
 
 
 class AsyncExecuteResponse(BaseModel):

--- a/tako_vm/server/sessions.py
+++ b/tako_vm/server/sessions.py
@@ -1,0 +1,589 @@
+"""Session manager for long-running container workloads."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import subprocess
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tako_vm.config import TakoVMConfig
+from tako_vm.constants import WORKSPACE_DIR
+from tako_vm.execution.docker import generate_container_name, is_native_linux
+from tako_vm.execution.worker import CodeExecutor, RuntimeUnavailableError
+from tako_vm.job_types import JobType, JobTypeRegistry
+from tako_vm.models import SessionEvent, SessionRecord
+from tako_vm.security import (
+    sanitize_error,
+    validate_docker_image,
+    validate_env_key,
+    validate_env_value,
+)
+from tako_vm.storage import ExecutionStorage
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManagerError(Exception):
+    """Raised when session operations fail."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class SessionManager:
+    """Manage lifecycle and mailbox I/O for long-running sessions."""
+
+    def __init__(
+        self,
+        config: TakoVMConfig,
+        storage: ExecutionStorage,
+        registry: JobTypeRegistry,
+        executor: CodeExecutor,
+    ):
+        self.config = config
+        self.storage = storage
+        self.registry = registry
+        self.executor = executor
+
+        self._reaper_task: Optional[asyncio.Task[None]] = None
+
+    async def start(self) -> None:
+        """Start background maintenance tasks."""
+        if not self.config.sessions_enabled:
+            return
+        if self._reaper_task is not None:
+            return
+        self._reaper_task = asyncio.create_task(self._reaper_loop(), name="session-reaper")
+
+    async def stop(self) -> None:
+        """Stop background maintenance tasks."""
+        if self._reaper_task is None:
+            return
+
+        self._reaper_task.cancel()
+        try:
+            await self._reaper_task
+        except asyncio.CancelledError:
+            pass
+        self._reaper_task = None
+
+    async def create_session(
+        self,
+        job_type_name: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+        idle_timeout_seconds: Optional[int] = None,
+        ttl_seconds: Optional[int] = None,
+    ) -> SessionRecord:
+        """Create and start a new long-running session container."""
+        if not self.config.sessions_enabled:
+            raise SessionManagerError("Sessions are disabled by configuration", status_code=403)
+
+        job_type = self._get_job_type(job_type_name)
+        if not job_type.session_enabled:
+            raise SessionManagerError(
+                f"Job type '{job_type.name}' is not enabled for sessions", status_code=400
+            )
+
+        image_name = job_type.base_image or self.config.docker_image
+        if not validate_docker_image(image_name):
+            raise SessionManagerError(f"Invalid image configured for job type '{job_type.name}'")
+
+        idle_timeout = idle_timeout_seconds or self.config.session_idle_timeout_seconds
+        ttl = ttl_seconds or self.config.session_max_ttl_seconds
+        self._validate_session_timeouts(idle_timeout, ttl)
+
+        session_id = str(uuid.uuid4())
+        container_name = generate_container_name("tako-session", session_id)
+        created_at = datetime.now(timezone.utc)
+
+        try:
+            runtime = self.executor.resolve_runtime_for_job_type(job_type, workload="session")
+            gpu_flags = self.executor.build_gpu_flags(job_type)
+            gpu_env = self.executor.build_gpu_env_vars(job_type)
+        except RuntimeUnavailableError as e:
+            raise SessionManagerError(str(e), status_code=400) from e
+
+        workspace_dir, inbox_dir, outbox_dir = self._prepare_workspace(session_id)
+
+        session = SessionRecord(
+            session_id=session_id,
+            status="creating",
+            job_type=job_type.name,
+            created_at=created_at,
+            last_activity_at=created_at,
+            expires_at=created_at + timedelta(seconds=ttl),
+            idle_timeout_seconds=idle_timeout,
+            ttl_seconds=ttl,
+            container_name=container_name,
+            image_name=image_name,
+            runtime=runtime,
+            gpu_enabled=job_type.gpu_enabled,
+            gpu_vendor=job_type.gpu_vendor,
+            workspace_dir=str(workspace_dir),
+            metadata=metadata or {},
+        )
+        await self.storage.save_session(session)
+
+        command = self._build_create_command(
+            session=session,
+            job_type=job_type,
+            runtime=runtime,
+            inbox_dir=inbox_dir,
+            outbox_dir=outbox_dir,
+            gpu_flags=gpu_flags,
+            gpu_env=gpu_env,
+        )
+
+        result = await self._run_subprocess(command, timeout=self.config.default_startup_timeout)
+        if result.returncode != 0:
+            session.status = "failed"
+            session.ended_at = datetime.now(timezone.utc)
+            session.error_message = sanitize_error((result.stderr or result.stdout).strip())
+            await self.storage.save_session(session)
+            self._cleanup_workspace(workspace_dir)
+            raise SessionManagerError(
+                f"Failed to start session container: {session.error_message}",
+                status_code=500,
+            )
+
+        session.status = "running"
+        session.started_at = datetime.now(timezone.utc)
+        session.container_id = result.stdout.strip() or None
+        await self.storage.save_session(session)
+
+        await self.storage.save_session_event(
+            SessionEvent(
+                session_id=session.session_id,
+                direction="system",
+                event_type="session_started",
+                payload={
+                    "job_type": session.job_type,
+                    "runtime": session.runtime,
+                    "gpu_enabled": session.gpu_enabled,
+                    "gpu_vendor": session.gpu_vendor,
+                },
+            )
+        )
+
+        return session
+
+    async def get_session(self, session_id: str, refresh: bool = True) -> Optional[SessionRecord]:
+        """Get a session by ID, optionally refreshing container state."""
+        session = await self.storage.get_session(session_id)
+        if not session:
+            return None
+
+        if refresh:
+            session = await self._refresh_session_status(session)
+        return session
+
+    async def list_sessions(
+        self,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[SessionRecord]:
+        """List sessions with optional status filter."""
+        return await self.storage.list_sessions(status=status, limit=limit, offset=offset)
+
+    async def send_event(
+        self,
+        session_id: str,
+        payload: Any,
+        event_type: str = "input",
+    ) -> SessionEvent:
+        """Write an input message to a session inbox and persist event metadata."""
+        session = await self.get_session(session_id, refresh=True)
+        if not session:
+            raise SessionManagerError("Session not found", status_code=404)
+        if session.status != "running":
+            raise SessionManagerError(
+                f"Session is not running (status={session.status})",
+                status_code=409,
+            )
+
+        payload_json = json.dumps(payload, ensure_ascii=False)
+        payload_size = len(payload_json.encode("utf-8"))
+        if payload_size > self.config.session_max_message_bytes:
+            raise SessionManagerError(
+                "Message payload exceeds session_max_message_bytes",
+                status_code=413,
+            )
+
+        file_name = f"msg-{int(time.time() * 1000)}-{uuid.uuid4().hex[:10]}.json"
+        event = SessionEvent(
+            session_id=session.session_id,
+            direction="in",
+            event_type=event_type,
+            payload=payload,
+            file_name=file_name,
+            created_at=datetime.now(timezone.utc),
+        )
+
+        inbox_file = Path(session.workspace_dir) / "inbox" / file_name
+        envelope = {
+            "event_type": event_type,
+            "payload": payload,
+            "created_at": event.created_at.isoformat(),
+        }
+        self._write_json_atomically(inbox_file, envelope)
+
+        saved = await self.storage.save_session_event(event)
+        await self.storage.touch_session(session.session_id)
+        return saved
+
+    async def poll_events(
+        self,
+        session_id: str,
+        after_id: int = 0,
+        limit: int = 100,
+    ) -> Tuple[SessionRecord, List[SessionEvent]]:
+        """Poll outbound session events after a cursor."""
+        session = await self.get_session(session_id, refresh=True)
+        if not session:
+            raise SessionManagerError("Session not found", status_code=404)
+
+        await self._ingest_outbox(session)
+
+        bounded_limit = max(1, min(limit, self.config.session_max_events_per_poll))
+        events = await self.storage.list_session_events(
+            session_id=session.session_id,
+            after_id=after_id,
+            limit=bounded_limit,
+        )
+
+        if events:
+            await self.storage.touch_session(session.session_id)
+            session = await self.get_session(session.session_id, refresh=False) or session
+
+        return session, events
+
+    async def terminate_session(self, session_id: str, reason: str = "terminated") -> SessionRecord:
+        """Stop and mark a session as terminated/expired."""
+        session = await self.storage.get_session(session_id)
+        if not session:
+            raise SessionManagerError("Session not found", status_code=404)
+
+        if session.status in {"terminated", "expired", "failed"}:
+            return session
+
+        result = await self._run_subprocess(
+            ["docker", "rm", "-f", session.container_name],
+            timeout=20,
+        )
+
+        if result.returncode != 0 and "No such container" not in (result.stderr or ""):
+            logger.warning(
+                "Failed to remove session container %s: %s",
+                session.container_name,
+                sanitize_error((result.stderr or result.stdout).strip()),
+            )
+
+        session.status = "expired" if reason.startswith("expired") else "terminated"
+        session.ended_at = datetime.now(timezone.utc)
+        session.last_activity_at = session.ended_at
+        session.terminated_reason = reason
+        await self.storage.save_session(session)
+
+        await self.storage.save_session_event(
+            SessionEvent(
+                session_id=session.session_id,
+                direction="system",
+                event_type="session_ended",
+                payload={"reason": reason, "status": session.status},
+                created_at=session.ended_at,
+            )
+        )
+
+        self._cleanup_workspace(Path(session.workspace_dir))
+        return session
+
+    def _get_job_type(self, job_type_name: Optional[str]) -> JobType:
+        """Resolve session job type and require an explicit registry match."""
+        if not job_type_name:
+            raise SessionManagerError("job_type is required for session creation")
+
+        lookup_name = job_type_name.split("@", 1)[0]
+        job_type = self.registry.get(lookup_name)
+        if not job_type:
+            raise SessionManagerError(f"Job type '{lookup_name}' not found", status_code=404)
+        return job_type
+
+    def _validate_session_timeouts(self, idle_timeout_seconds: int, ttl_seconds: int) -> None:
+        """Validate per-session timeout overrides against global bounds."""
+        if idle_timeout_seconds < 30:
+            raise SessionManagerError("idle_timeout_seconds must be at least 30")
+        if ttl_seconds < 60:
+            raise SessionManagerError("ttl_seconds must be at least 60")
+        if idle_timeout_seconds > ttl_seconds:
+            raise SessionManagerError("idle_timeout_seconds must be <= ttl_seconds")
+        if idle_timeout_seconds > self.config.session_max_ttl_seconds:
+            raise SessionManagerError("idle_timeout_seconds exceeds server session_max_ttl_seconds")
+        if ttl_seconds > self.config.session_max_ttl_seconds:
+            raise SessionManagerError("ttl_seconds exceeds server session_max_ttl_seconds")
+
+    def _prepare_workspace(self, session_id: str) -> Tuple[Path, Path, Path]:
+        """Create and return workspace/inbox/outbox directories."""
+        workspace_dir = Path(WORKSPACE_DIR) / f"tako-session-{session_id}"
+        inbox_dir = workspace_dir / "inbox"
+        outbox_dir = workspace_dir / "outbox"
+
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        outbox_dir.mkdir(parents=True, exist_ok=True)
+
+        inbox_dir.chmod(0o777)
+        outbox_dir.chmod(0o777)
+
+        return workspace_dir, inbox_dir, outbox_dir
+
+    def _build_create_command(
+        self,
+        session: SessionRecord,
+        job_type: JobType,
+        runtime: str,
+        inbox_dir: Path,
+        outbox_dir: Path,
+        gpu_flags: List[str],
+        gpu_env: Dict[str, str],
+    ) -> List[str]:
+        """Build docker run command for a detached session container."""
+        limits = self.config.container_limits
+
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            f"--name={session.container_name}",
+            "--label=tako-vm-session=true",
+            f"--label=tako-vm-session-id={session.session_id}",
+            "--init",
+            "--read-only",
+        ]
+
+        if self.config.enable_cap_restrictions:
+            cmd.extend(["--cap-drop=ALL", "--cap-add=SETUID", "--cap-add=SETGID"])
+
+        if runtime == "runsc":
+            cmd.append("--runtime=runsc")
+
+        cmd.extend(gpu_flags)
+
+        if job_type.network_enabled:
+            cmd.append("--network=bridge")
+        else:
+            cmd.append("--network=none")
+
+        if self.config.enable_userns:
+            cmd.append("--user=1000:1000")
+
+        cmd.extend(
+            [
+                f"--memory={job_type.memory_limit}",
+                f"--memory-swap={job_type.memory_limit}",
+                f"--cpus={job_type.cpu_limit}",
+                f"--pids-limit={limits.pids_limit}",
+                f"--ulimit=nofile={limits.nofile_soft}:{limits.nofile_hard}",
+                f"--ulimit=nproc={limits.nproc_soft}:{limits.nproc_hard}",
+                f"--ulimit=fsize={limits.fsize}",
+                f"--mount=type=bind,source={inbox_dir.absolute()},target=/session/inbox",
+                f"--mount=type=bind,source={outbox_dir.absolute()},target=/session/outbox",
+                f"--tmpfs=/tmp:rw,noexec,nosuid,size={limits.tmpfs_size}",
+            ]
+        )
+
+        if self.config.session_model_cache_volume:
+            cmd.append(
+                "--mount=type=volume,"
+                f"source={self.config.session_model_cache_volume},target=/models"
+            )
+
+        if self.config.enable_seccomp and self.config.seccomp_profile_path:
+            if is_native_linux() and self.config.seccomp_profile_path.exists():
+                cmd.append(f"--security-opt=seccomp={self.config.seccomp_profile_path}")
+
+        for key, value in job_type.environment.items():
+            if not validate_env_key(key):
+                logger.warning("Skipping invalid environment variable key: %s", key)
+                continue
+            if not validate_env_value(value):
+                logger.warning("Skipping unsafe environment variable value for key: %s", key)
+                continue
+            cmd.append(f"--env={key}={value}")
+
+        cmd.extend(
+            [
+                f"--env=TAKO_SESSION_ID={session.session_id}",
+                "--env=TAKO_SESSION_INBOX=/session/inbox",
+                "--env=TAKO_SESSION_OUTBOX=/session/outbox",
+            ]
+        )
+
+        if self.config.session_model_cache_volume:
+            cmd.append("--env=TAKO_SESSION_MODEL_CACHE=/models")
+
+        for key, value in gpu_env.items():
+            cmd.append(f"--env={key}={value}")
+
+        cmd.append(session.image_name)
+        return cmd
+
+    async def _run_subprocess(
+        self, cmd: List[str], timeout: int
+    ) -> subprocess.CompletedProcess[str]:
+        """Execute a subprocess command in a thread to avoid blocking the loop."""
+        return await asyncio.to_thread(
+            subprocess.run,
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    async def _refresh_session_status(self, session: SessionRecord) -> SessionRecord:
+        """Refresh session status from Docker container state."""
+        if session.status not in {"creating", "running"}:
+            return session
+
+        inspect = await self._run_subprocess(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{.State.Status}}\t{{.State.ExitCode}}",
+                session.container_name,
+            ],
+            timeout=10,
+        )
+
+        if inspect.returncode != 0:
+            stderr = inspect.stderr or ""
+            if "No such object" in stderr or "No such container" in stderr:
+                session.status = "failed"
+                session.ended_at = datetime.now(timezone.utc)
+                session.error_message = "Session container is not running"
+                await self.storage.save_session(session)
+                return session
+            return session
+
+        output = inspect.stdout.strip()
+        if not output:
+            return session
+
+        state_text, _, exit_code_text = output.partition("\t")
+
+        if state_text == "running":
+            if session.status == "creating":
+                session.status = "running"
+                session.started_at = datetime.now(timezone.utc)
+                await self.storage.save_session(session)
+            return session
+
+        if state_text in {"exited", "dead"}:
+            session.status = "failed"
+            session.ended_at = datetime.now(timezone.utc)
+            session.error_message = f"Container exited with code {exit_code_text or '?'}"
+            await self.storage.save_session(session)
+            return session
+
+        return session
+
+    async def _ingest_outbox(self, session: SessionRecord) -> None:
+        """Ingest JSON message files from outbox into session_events table."""
+        outbox_dir = Path(session.workspace_dir) / "outbox"
+        if not outbox_dir.exists():
+            return
+
+        files = sorted(outbox_dir.glob("*.json"))
+        for path in files:
+            try:
+                content = path.read_text(encoding="utf-8")
+                try:
+                    payload = json.loads(content)
+                except json.JSONDecodeError:
+                    payload = {
+                        "raw": content,
+                        "parse_error": "invalid_json",
+                        "file_name": path.name,
+                    }
+
+                event_type = "message"
+                if isinstance(payload, dict):
+                    maybe_event_type = payload.get("event_type")
+                    if isinstance(maybe_event_type, str) and maybe_event_type.strip():
+                        event_type = maybe_event_type.strip()[:64]
+
+                await self.storage.save_session_event(
+                    SessionEvent(
+                        session_id=session.session_id,
+                        direction="out",
+                        event_type=event_type,
+                        payload=payload,
+                        file_name=path.name,
+                        created_at=datetime.now(timezone.utc),
+                    )
+                )
+
+                try:
+                    path.unlink()
+                except OSError:
+                    logger.debug("Failed to remove processed outbox file: %s", path)
+            except Exception as e:
+                logger.warning("Failed to ingest outbox file %s: %s", path, sanitize_error(str(e)))
+
+    async def _reaper_loop(self) -> None:
+        """Expire idle or over-TTL sessions."""
+        interval = 30
+        while True:
+            try:
+                await asyncio.sleep(interval)
+
+                running_sessions = await self.storage.list_sessions(status="running", limit=1000)
+                now = datetime.now(timezone.utc)
+
+                for session in running_sessions:
+                    ttl_exceeded = (now - session.created_at).total_seconds() >= session.ttl_seconds
+                    idle_exceeded = (
+                        now - session.last_activity_at
+                    ).total_seconds() >= session.idle_timeout_seconds
+
+                    if ttl_exceeded:
+                        await self.terminate_session(
+                            session.session_id,
+                            reason="expired_ttl",
+                        )
+                    elif idle_exceeded:
+                        await self.terminate_session(
+                            session.session_id,
+                            reason="expired_idle",
+                        )
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Session reaper error: %s", sanitize_error(str(e)), exc_info=True)
+
+    def _write_json_atomically(self, path: Path, payload: Dict[str, Any]) -> None:
+        """Atomically write JSON data to disk."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_suffix(path.suffix + ".tmp")
+        temp_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        temp_path.replace(path)
+
+    def _cleanup_workspace(self, workspace: Path) -> None:
+        """Remove session workspace directory."""
+        try:
+            shutil.rmtree(workspace)
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.debug(
+                "Failed to cleanup session workspace %s: %s", workspace, sanitize_error(str(e))
+            )

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -22,6 +22,8 @@ from .models import (
     InputArtifact,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
 )
 
 logger = logging.getLogger(__name__)
@@ -130,7 +132,61 @@ MIGRATIONS: list[tuple[str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_dlq_error_type ON dead_letter_queue(error_type);
         CREATE INDEX IF NOT EXISTS idx_dlq_job_id ON dead_letter_queue(job_id);
         """,
-    )
+    ),
+    (
+        "0002_sessions",
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            job_type TEXT NOT NULL,
+
+            created_at TIMESTAMPTZ NOT NULL,
+            started_at TIMESTAMPTZ,
+            ended_at TIMESTAMPTZ,
+            last_activity_at TIMESTAMPTZ NOT NULL,
+            expires_at TIMESTAMPTZ,
+
+            idle_timeout_seconds INTEGER NOT NULL,
+            ttl_seconds INTEGER NOT NULL,
+
+            container_name TEXT NOT NULL,
+            container_id TEXT,
+            image_name TEXT NOT NULL,
+            runtime TEXT NOT NULL,
+
+            gpu_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+            gpu_vendor TEXT,
+
+            workspace_dir TEXT NOT NULL,
+            metadata_json JSONB,
+
+            error_message TEXT,
+            terminated_reason TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+        CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity_at);
+
+        CREATE TABLE IF NOT EXISTS session_events (
+            id BIGSERIAL PRIMARY KEY,
+            session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+            direction TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            payload_json JSONB,
+            file_name TEXT,
+            created_at TIMESTAMPTZ NOT NULL
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_session_events_unique_file
+            ON session_events(session_id, file_name);
+        CREATE INDEX IF NOT EXISTS idx_session_events_session_id_id
+            ON session_events(session_id, id);
+        CREATE INDEX IF NOT EXISTS idx_session_events_created_at
+            ON session_events(created_at DESC);
+        """,
+    ),
 ]
 
 
@@ -483,6 +539,189 @@ class ExecutionStorage:
             relationship=row.get("relationship"),
         )
 
+    async def save_session(self, session: SessionRecord) -> None:
+        """Insert or update a session record."""
+        metadata_json = Jsonb(session.metadata) if session.metadata is not None else None
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO sessions (
+                    session_id, status, job_type,
+                    created_at, started_at, ended_at, last_activity_at, expires_at,
+                    idle_timeout_seconds, ttl_seconds,
+                    container_name, container_id, image_name, runtime,
+                    gpu_enabled, gpu_vendor,
+                    workspace_dir, metadata_json,
+                    error_message, terminated_reason
+                ) VALUES (
+                    %s, %s, %s,
+                    %s, %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s,
+                    %s, %s
+                )
+                ON CONFLICT (session_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    job_type = EXCLUDED.job_type,
+                    created_at = EXCLUDED.created_at,
+                    started_at = EXCLUDED.started_at,
+                    ended_at = EXCLUDED.ended_at,
+                    last_activity_at = EXCLUDED.last_activity_at,
+                    expires_at = EXCLUDED.expires_at,
+                    idle_timeout_seconds = EXCLUDED.idle_timeout_seconds,
+                    ttl_seconds = EXCLUDED.ttl_seconds,
+                    container_name = EXCLUDED.container_name,
+                    container_id = EXCLUDED.container_id,
+                    image_name = EXCLUDED.image_name,
+                    runtime = EXCLUDED.runtime,
+                    gpu_enabled = EXCLUDED.gpu_enabled,
+                    gpu_vendor = EXCLUDED.gpu_vendor,
+                    workspace_dir = EXCLUDED.workspace_dir,
+                    metadata_json = EXCLUDED.metadata_json,
+                    error_message = EXCLUDED.error_message,
+                    terminated_reason = EXCLUDED.terminated_reason
+                """,
+                (
+                    session.session_id,
+                    session.status,
+                    session.job_type,
+                    session.created_at,
+                    session.started_at,
+                    session.ended_at,
+                    session.last_activity_at,
+                    session.expires_at,
+                    session.idle_timeout_seconds,
+                    session.ttl_seconds,
+                    session.container_name,
+                    session.container_id,
+                    session.image_name,
+                    session.runtime,
+                    session.gpu_enabled,
+                    session.gpu_vendor,
+                    session.workspace_dir,
+                    metadata_json,
+                    session.error_message,
+                    session.terminated_reason,
+                ),
+            )
+
+    async def get_session(self, session_id: str) -> Optional[SessionRecord]:
+        """Retrieve a session by ID."""
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                "SELECT * FROM sessions WHERE session_id = %s", (session_id,)
+            )
+            row = await cursor.fetchone()
+
+        if not row:
+            return None
+        return self._row_to_session(cast(RowMapping, row))
+
+    async def list_sessions(
+        self,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[SessionRecord]:
+        """List sessions with optional status filter."""
+        query = "SELECT * FROM sessions WHERE 1=1"
+        params: List[Any] = []
+
+        if status:
+            query += " AND status = %s"
+            params.append(status)
+
+        query += " ORDER BY created_at DESC LIMIT %s OFFSET %s"
+        params.extend([limit, offset])
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(query, params)
+            rows = await cursor.fetchall()
+
+        return [self._row_to_session(cast(RowMapping, row)) for row in rows]
+
+    async def touch_session(self, session_id: str, touched_at: Optional[datetime] = None) -> None:
+        """Update last activity timestamp for a session."""
+        now = touched_at or datetime.now(timezone.utc)
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            await conn.execute(
+                "UPDATE sessions SET last_activity_at = %s WHERE session_id = %s",
+                (now, session_id),
+            )
+
+    async def save_session_event(self, event: SessionEvent) -> SessionEvent:
+        """Insert a session event and return persisted row (dedupes by file_name)."""
+        payload_json = Jsonb(event.payload) if event.payload is not None else None
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                INSERT INTO session_events (
+                    session_id, direction, event_type, payload_json, file_name, created_at
+                ) VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (session_id, file_name) DO NOTHING
+                RETURNING *
+                """,
+                (
+                    event.session_id,
+                    event.direction,
+                    event.event_type,
+                    payload_json,
+                    event.file_name,
+                    event.created_at,
+                ),
+            )
+            row = await cursor.fetchone()
+
+            if row:
+                return self._row_to_session_event(cast(RowMapping, row))
+
+            if event.file_name:
+                existing_cursor = await conn.execute(
+                    """
+                    SELECT * FROM session_events
+                    WHERE session_id = %s AND file_name = %s
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """,
+                    (event.session_id, event.file_name),
+                )
+                existing = await existing_cursor.fetchone()
+                if existing:
+                    return self._row_to_session_event(cast(RowMapping, existing))
+
+        return event
+
+    async def list_session_events(
+        self,
+        session_id: str,
+        after_id: int = 0,
+        limit: int = 100,
+    ) -> List[SessionEvent]:
+        """List session events after a cursor ID."""
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT * FROM session_events
+                WHERE session_id = %s AND id > %s
+                ORDER BY id ASC
+                LIMIT %s
+                """,
+                (session_id, after_id, limit),
+            )
+            rows = await cursor.fetchall()
+
+        return [self._row_to_session_event(cast(RowMapping, row)) for row in rows]
+
     async def save_version(self, version: JobVersion) -> None:
         """Save job version record."""
         pool = self._get_pool()
@@ -602,6 +841,45 @@ class ExecutionStorage:
             dockerfile_hash=row["dockerfile_hash"],
             requirements_hash=row["requirements_hash"],
             image_ref=row["image_ref"],
+        )
+
+    def _row_to_session(self, row: RowMapping) -> SessionRecord:
+        """Convert database row to SessionRecord."""
+        metadata = _decode_json_field(row.get("metadata_json")) or {}
+        return SessionRecord(
+            session_id=row["session_id"],
+            status=row["status"],
+            job_type=row["job_type"],
+            created_at=row["created_at"],
+            started_at=row.get("started_at"),
+            ended_at=row.get("ended_at"),
+            last_activity_at=row["last_activity_at"],
+            expires_at=row.get("expires_at"),
+            idle_timeout_seconds=row["idle_timeout_seconds"],
+            ttl_seconds=row["ttl_seconds"],
+            container_name=row["container_name"],
+            container_id=row.get("container_id"),
+            image_name=row["image_name"],
+            runtime=row["runtime"],
+            gpu_enabled=bool(row.get("gpu_enabled", False)),
+            gpu_vendor=row.get("gpu_vendor"),
+            workspace_dir=row["workspace_dir"],
+            metadata=metadata,
+            error_message=row.get("error_message"),
+            terminated_reason=row.get("terminated_reason"),
+        )
+
+    def _row_to_session_event(self, row: RowMapping) -> SessionEvent:
+        """Convert database row to SessionEvent."""
+        payload = _decode_json_field(row.get("payload_json"))
+        return SessionEvent(
+            id=row["id"],
+            session_id=row["session_id"],
+            direction=row["direction"],
+            event_type=row["event_type"],
+            payload=payload,
+            file_name=row.get("file_name"),
+            created_at=row["created_at"],
         )
 
     async def add_to_dlq(self, entry: DeadLetterEntry) -> int:

--- a/tako_vm/version.py
+++ b/tako_vm/version.py
@@ -57,6 +57,11 @@ class VersionManager:
                 "base_image": job_type.base_image,
                 "environment": dict(sorted(job_type.environment.items())),
                 "shared_code": sorted(job_type.shared_code),
+                "session_enabled": job_type.session_enabled,
+                "gpu_enabled": job_type.gpu_enabled,
+                "gpu_vendor": job_type.gpu_vendor,
+                "gpu_count": job_type.gpu_count,
+                "gpu_device_ids": sorted(job_type.gpu_device_ids),
             },
             sort_keys=True,
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,6 +155,9 @@ class TestJobTypes:
         assert data["name"] == "default"
         assert "requirements" in data
         assert "python_version" in data
+        assert "session_enabled" in data
+        assert "gpu_enabled" in data
+        assert "gpu_vendor" in data
 
     def test_job_type_not_found(self, client):
         """Non-existent job type returns 404."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,12 @@ Tests job submission, status checking, and result retrieval
 using FastAPI's TestClient (no running server required).
 """
 
+import asyncio
 import importlib
+import json
+import subprocess
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -765,3 +769,105 @@ class TestSessionsApi:
         assert poll_data["next_cursor"] == 8
         assert len(poll_data["events"]) == 1
         assert poll_data["events"][0]["event_type"] == "reply"
+
+
+class TestSessionsApiIntegration:
+    """Integration-style session API tests with minimal mocking."""
+
+    def _configure_real_session_manager(self, monkeypatch, tmp_path):
+        app_module = importlib.import_module("tako_vm.server.app")
+        job_type_cls = importlib.import_module("tako_vm.job_types").JobType
+        state = cast(Any, app_module.state)
+
+        state.config.sessions_enabled = True
+        state.config.session_max_events_per_poll = 10
+        state.registry.register(
+            job_type_cls(
+                name="session-live",
+                session_enabled=True,
+                base_image="code-executor:latest",
+            ),
+            persist=False,
+        )
+
+        monkeypatch.setattr("tako_vm.server.sessions.WORKSPACE_DIR", str(tmp_path))
+
+        async def fake_run(cmd, timeout):
+            del timeout
+            if cmd[:2] == ["docker", "run"]:
+                return subprocess.CompletedProcess(cmd, 0, "container-live\n", "")
+            if cmd[:2] == ["docker", "inspect"]:
+                return subprocess.CompletedProcess(cmd, 0, "running\t0", "")
+            if cmd[:2] == ["docker", "rm"]:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(state.session_manager, "_run_subprocess", fake_run)
+        return state
+
+    def test_session_lifecycle_endpoints_with_real_manager(self, client, monkeypatch, tmp_path):
+        """Create/send/poll/terminate endpoints work end-to-end via SessionManager."""
+        state = self._configure_real_session_manager(monkeypatch, tmp_path)
+
+        create_response = client.post(
+            "/sessions",
+            json={"job_type": "session-live", "metadata": {"flow": "integration"}},
+        )
+        assert create_response.status_code == 200
+        session_data = create_response.json()
+        session_id = session_data["session_id"]
+        assert session_data["status"] == "running"
+
+        get_response = client.get(f"/sessions/{session_id}")
+        assert get_response.status_code == 200
+        assert get_response.json()["status"] == "running"
+
+        send_response = client.post(
+            f"/sessions/{session_id}/send",
+            json={"event_type": "input", "payload": {"prompt": "hello"}},
+        )
+        assert send_response.status_code == 200
+        assert send_response.json()["status"] == "queued"
+
+        record = asyncio.run(state.storage.get_session(session_id))
+        assert record is not None
+        outbox_file = Path(record.workspace_dir) / "outbox" / "event-1.json"
+        outbox_file.write_text(
+            json.dumps({"event_type": "reply", "text": "world"}),
+            encoding="utf-8",
+        )
+
+        poll_response = client.get(
+            f"/sessions/{session_id}/events", params={"after": 0, "limit": 20}
+        )
+        assert poll_response.status_code == 200
+        poll_data = poll_response.json()
+        assert len(poll_data["events"]) >= 1
+        assert any(event["event_type"] == "reply" for event in poll_data["events"])
+
+        terminate_response = client.post(f"/sessions/{session_id}/terminate")
+        assert terminate_response.status_code == 200
+        assert terminate_response.json()["status"] == "terminated"
+
+        final_response = client.get(f"/sessions/{session_id}")
+        assert final_response.status_code == 200
+        assert final_response.json()["status"] == "terminated"
+
+    def test_send_session_event_enforces_payload_limit(self, client, monkeypatch, tmp_path):
+        """Session send endpoint returns 413 for oversized payloads."""
+        state = self._configure_real_session_manager(monkeypatch, tmp_path)
+        state.config.session_max_message_bytes = 16
+
+        create_response = client.post(
+            "/sessions",
+            json={"job_type": "session-live"},
+        )
+        assert create_response.status_code == 200
+        session_id = create_response.json()["session_id"]
+
+        send_response = client.post(
+            f"/sessions/{session_id}/send",
+            json={"event_type": "input", "payload": {"message": "x" * 200}},
+        )
+        assert send_response.status_code == 413
+        assert "session_max_message_bytes" in send_response.json()["detail"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,15 @@ Tests job submission, status checking, and result retrieval
 using FastAPI's TestClient (no running server required).
 """
 
+import importlib
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
+
 import pytest
 from fastapi.testclient import TestClient
+
+if TYPE_CHECKING:
+    from tako_vm.models import SessionStatus
 
 
 @pytest.fixture
@@ -625,3 +632,136 @@ class TestIdempotency:
             json={"code": "print(1)", "idempotency_key": "invalid key with spaces"},
         )
         assert response.status_code == 422
+
+
+class TestSessionsApi:
+    """Tests for session API endpoint behavior."""
+
+    def _make_session_record(self, session_id: str, status: "SessionStatus" = "running"):
+        from tako_vm.models import SessionRecord
+
+        now = datetime.now(timezone.utc)
+        return SessionRecord(
+            session_id=session_id,
+            status=status,
+            job_type="session-job",
+            created_at=now,
+            started_at=now,
+            last_activity_at=now,
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            container_name=f"tako-session-{session_id}",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=f"/tmp/{session_id}",
+        )
+
+    def test_create_session_success(self, client, monkeypatch):
+        """POST /sessions returns serialized session record."""
+        app_module = importlib.import_module("tako_vm.server.app")
+
+        async def fake_create_session(*args, **kwargs):
+            del args, kwargs
+            return self._make_session_record("session-123", status="running")
+
+        session_manager = cast(Any, app_module.state).session_manager
+        monkeypatch.setattr(session_manager, "create_session", fake_create_session)
+
+        response = client.post("/sessions", json={"job_type": "session-job"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session_id"] == "session-123"
+        assert data["status"] == "running"
+        assert data["runtime"] == "runc"
+
+    def test_create_session_error_mapping(self, client, monkeypatch):
+        """SessionManagerError is surfaced as HTTPException with status code."""
+        app_module = importlib.import_module("tako_vm.server.app")
+        session_manager_error_cls = importlib.import_module(
+            "tako_vm.server.sessions"
+        ).SessionManagerError
+
+        async def fake_create_session(*args, **kwargs):
+            del args, kwargs
+            raise session_manager_error_cls("Sessions are disabled", status_code=403)
+
+        session_manager = cast(Any, app_module.state).session_manager
+        monkeypatch.setattr(session_manager, "create_session", fake_create_session)
+
+        response = client.post("/sessions", json={"job_type": "session-job"})
+        assert response.status_code == 403
+        assert "disabled" in response.json()["detail"].lower()
+
+    def test_list_sessions_pagination(self, client, monkeypatch):
+        """GET /sessions applies has_more logic with limit+1 fetch."""
+        app_module = importlib.import_module("tako_vm.server.app")
+
+        async def fake_list_sessions(*args, **kwargs):
+            del args, kwargs
+            return [
+                self._make_session_record("session-a", status="running"),
+                self._make_session_record("session-b", status="running"),
+            ]
+
+        session_manager = cast(Any, app_module.state).session_manager
+        monkeypatch.setattr(session_manager, "list_sessions", fake_list_sessions)
+
+        response = client.get("/sessions", params={"limit": 1, "offset": 0})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["has_more"] is True
+        assert len(data["items"]) == 1
+
+    def test_send_and_poll_session_events(self, client, monkeypatch):
+        """Session send and poll endpoints serialize mailbox events."""
+        app_module = importlib.import_module("tako_vm.server.app")
+        session_event_cls = importlib.import_module("tako_vm.models").SessionEvent
+
+        now = datetime.now(timezone.utc)
+
+        async def fake_send_event(*args, **kwargs):
+            del args, kwargs
+            return session_event_cls(
+                id=7,
+                session_id="session-abc",
+                direction="in",
+                event_type="input",
+                payload={"message": "hi"},
+                created_at=now,
+            )
+
+        async def fake_poll_events(*args, **kwargs):
+            del args, kwargs
+            session = self._make_session_record("session-abc", status="running")
+            events = [
+                session_event_cls(
+                    id=8,
+                    session_id="session-abc",
+                    direction="out",
+                    event_type="reply",
+                    payload={"text": "hello"},
+                    created_at=now,
+                )
+            ]
+            return session, events
+
+        session_manager = cast(Any, app_module.state).session_manager
+        monkeypatch.setattr(session_manager, "send_event", fake_send_event)
+        monkeypatch.setattr(session_manager, "poll_events", fake_poll_events)
+
+        send_response = client.post(
+            "/sessions/session-abc/send",
+            json={"event_type": "input", "payload": {"message": "hi"}},
+        )
+        assert send_response.status_code == 200
+        assert send_response.json()["event_id"] == 7
+        assert send_response.json()["status"] == "queued"
+
+        poll_response = client.get("/sessions/session-abc/events", params={"after": 0, "limit": 10})
+        assert poll_response.status_code == 200
+        poll_data = poll_response.json()
+        assert poll_data["status"] == "running"
+        assert poll_data["next_cursor"] == 8
+        assert len(poll_data["events"]) == 1
+        assert poll_data["events"][0]["event_type"] == "reply"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,6 +498,42 @@ class TestShowConfigFunction:
 
         reset_config()
 
+    def test_show_config_with_gpu_job_type(self, capsys):
+        """show_config prints session/gpu details for job types."""
+        from tako_vm import config as config_module
+        from tako_vm.cli import show_config
+        from tako_vm.config import JobTypeConfig, JobTypeGPUConfig, TakoVMConfig, reset_config
+
+        reset_config()
+
+        mock_config = TakoVMConfig.model_validate(
+            {
+                "security_mode": "permissive",
+                "sessions_enabled": True,
+                "job_types": [
+                    JobTypeConfig(
+                        name="gpu-job",
+                        session_enabled=True,
+                        gpu=JobTypeGPUConfig(enabled=True, vendor="nvidia", count=1),
+                    ).model_dump()
+                ],
+            }
+        )
+
+        with patch.object(config_module, "get_config", return_value=mock_config):
+            with patch.object(config_module, "get_config_path", return_value=None):
+                args = MagicMock()
+                args.json = False
+                args.show_defaults = False
+                show_config(args)
+
+        captured = capsys.readouterr()
+        assert "[Sessions]" in captured.out
+        assert "session_enabled: True" in captured.out
+        assert "gpu: enabled" in captured.out
+
+        reset_config()
+
 
 class TestRunServerFunction:
     """Tests for run_server() function."""
@@ -674,6 +710,7 @@ class TestCLISubprocessExtended:
         assert "[Limits]" in result.stdout
         assert "[Container Limits]" in result.stdout
         assert "[Docker]" in result.stdout
+        assert "[Sessions]" in result.stdout
 
     def test_validate_yaml_syntax_error(self):
         """validate command detects YAML syntax errors."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from tako_vm.config import (
     ConfigurationError,
     ContainerLimits,
     JobTypeConfig,
+    JobTypeGPUConfig,
     TakoVMConfig,
     find_config_file,
     get_config,
@@ -164,6 +165,62 @@ class TestJobTypeConfig:
         with pytest.raises(ValueError) as exc_info:
             JobTypeConfig(name="test", memory_limit="64g")
         assert "at most 32g" in str(exc_info.value)
+
+
+class TestJobTypeGPUConfig:
+    """Tests for JobTypeGPUConfig validation."""
+
+    def test_job_type_gpu_config_defaults(self):
+        """GPU config defaults to disabled with no selection."""
+        config = JobTypeGPUConfig()
+        assert config.enabled is False
+        assert config.vendor is None
+        assert config.count is None
+        assert config.device_ids == []
+
+    def test_job_type_gpu_config_nvidia_count(self):
+        """NVIDIA GPU config accepts count selection."""
+        config = JobTypeGPUConfig(enabled=True, vendor="NVIDIA", count=2)
+        assert config.enabled is True
+        assert config.vendor == "nvidia"
+        assert config.count == 2
+
+    def test_job_type_gpu_config_rejects_missing_vendor(self):
+        """Enabled GPU config requires vendor."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(enabled=True)
+        assert "gpu.vendor is required" in str(exc_info.value)
+
+    def test_job_type_gpu_config_rejects_count_with_device_ids(self):
+        """GPU config forbids combining count and device_ids."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(
+                enabled=True,
+                vendor="nvidia",
+                count=1,
+                device_ids=["GPU-123"],
+            )
+        assert "mutually exclusive" in str(exc_info.value)
+
+    def test_job_type_gpu_config_rejects_amd_count(self):
+        """AMD GPU config does not support count selection."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(enabled=True, vendor="amd", count=1)
+        assert "only supported" in str(exc_info.value)
+
+    def test_job_type_gpu_config_rejects_fields_when_disabled(self):
+        """GPU details are rejected unless enabled=true."""
+        with pytest.raises(ValueError) as exc_info:
+            JobTypeGPUConfig(enabled=False, vendor="nvidia")
+        assert "gpu.enabled must be true" in str(exc_info.value)
+
+    def test_job_type_gpu_config_device_ids_validation(self):
+        """Device IDs are stripped and validated."""
+        config = JobTypeGPUConfig(enabled=True, vendor="nvidia", device_ids=[" GPU-1 ", "GPU-2"])
+        assert config.device_ids == ["GPU-1", "GPU-2"]
+
+        with pytest.raises(ValueError):
+            JobTypeGPUConfig(enabled=True, vendor="nvidia", device_ids=["bad,id"])
 
 
 class TestTakoVMConfig:

--- a/tests/test_job_types.py
+++ b/tests/test_job_types.py
@@ -1,0 +1,119 @@
+"""Tests for job type schema and merge behavior."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from tako_vm.config import JobTypeConfig, JobTypeGPUConfig
+from tako_vm.job_types import JobType, JobTypeRegistry, merge_config_job_types
+
+
+def test_job_type_from_dict_reads_nested_gpu_config():
+    """from_dict supports nested gpu object in JSON config."""
+    job_type = JobType.from_dict(
+        {
+            "name": "gpu-job",
+            "session_enabled": True,
+            "gpu": {
+                "enabled": True,
+                "vendor": "nvidia",
+                "count": 2,
+                "device_ids": [],
+            },
+        }
+    )
+
+    assert job_type.name == "gpu-job"
+    assert job_type.session_enabled is True
+    assert job_type.gpu_enabled is True
+    assert job_type.gpu_vendor == "nvidia"
+    assert job_type.gpu_count == 2
+
+
+def test_job_type_from_dict_supports_legacy_gpu_top_level_fields():
+    """Top-level gpu_* fields remain supported for compatibility."""
+    job_type = JobType.from_dict(
+        {
+            "name": "legacy-gpu",
+            "gpu_enabled": True,
+            "gpu_vendor": "amd",
+            "gpu_device_ids": ["0", "1"],
+        }
+    )
+
+    assert job_type.gpu_enabled is True
+    assert job_type.gpu_vendor == "amd"
+    assert job_type.gpu_device_ids == ["0", "1"]
+
+
+def test_job_type_config_roundtrip_preserves_gpu_and_session_fields():
+    """Dataclass <-> pydantic conversion preserves new fields."""
+    original = JobType(
+        name="roundtrip",
+        session_enabled=True,
+        gpu_enabled=True,
+        gpu_vendor="nvidia",
+        gpu_count=1,
+        gpu_device_ids=[],
+    )
+
+    config_model = original.to_config()
+    restored = JobType.from_config(config_model)
+
+    assert restored.name == "roundtrip"
+    assert restored.session_enabled is True
+    assert restored.gpu_enabled is True
+    assert restored.gpu_vendor == "nvidia"
+    assert restored.gpu_count == 1
+
+
+def test_merge_config_job_types_overrides_in_memory_without_persistence():
+    """Config merge updates runtime registry without rewriting job_types.json."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "job_types.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "job_types": [
+                        {
+                            "name": "default",
+                            "timeout": 30,
+                            "session_enabled": False,
+                            "gpu": {
+                                "enabled": False,
+                                "vendor": None,
+                                "count": None,
+                                "device_ids": [],
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        registry = JobTypeRegistry(config_path=config_path)
+        original_on_disk = config_path.read_text(encoding="utf-8")
+
+        merged_count = merge_config_job_types(
+            registry,
+            [
+                JobTypeConfig(
+                    name="default",
+                    timeout=99,
+                    session_enabled=True,
+                    gpu=JobTypeGPUConfig(enabled=True, vendor="nvidia", count=1),
+                )
+            ],
+        )
+
+        assert merged_count == 1
+        merged = registry.get("default")
+        assert merged is not None
+        assert merged.timeout == 99
+        assert merged.session_enabled is True
+        assert merged.gpu_enabled is True
+        assert merged.gpu_vendor == "nvidia"
+
+        # Persist=False means disk config should be untouched.
+        assert config_path.read_text(encoding="utf-8") == original_on_disk

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,8 @@ from tako_vm.models import (
     JobStatus,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
     sha256_content,
     sha256_json,
 )
@@ -416,3 +418,47 @@ class TestDeadLetterEntry:
         for error_type in valid_types:
             entry = DeadLetterEntry(job_id="job", job_data={}, error_type=error_type)
             assert entry.error_type == error_type
+
+
+class TestSessionModels:
+    """Tests for session-related models."""
+
+    def test_session_record_defaults(self):
+        """SessionRecord initializes with expected defaults."""
+        record = SessionRecord(
+            container_name="tako-session-1",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir="/tmp/session-1",
+        )
+
+        assert record.status == "creating"
+        assert record.job_type == "default"
+        assert record.gpu_enabled is False
+        assert record.metadata == {}
+
+    def test_session_record_validates_status_literal(self):
+        """SessionRecord enforces allowed status values."""
+        with pytest.raises(ValidationError):
+            SessionRecord(
+                status="unknown",  # type: ignore[arg-type]
+                container_name="tako-session-1",
+                image_name="code-executor:latest",
+                runtime="runc",
+                workspace_dir="/tmp/session-1",
+            )
+
+    def test_session_event_defaults(self):
+        """SessionEvent defaults event type to message."""
+        event = SessionEvent(session_id="session-1", direction="out", payload={"ok": True})
+        assert event.event_type == "message"
+        assert event.file_name is None
+
+    def test_session_event_validates_direction_literal(self):
+        """SessionEvent enforces direction literals."""
+        with pytest.raises(ValidationError):
+            SessionEvent(
+                session_id="session-1",
+                direction="sideways",  # type: ignore[arg-type]
+                payload={"bad": True},
+            )

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -44,6 +44,7 @@ async def test_schema_migrations_written(temp_data_dir):
             versions = [row[0] for row in cur.fetchall()]
 
     assert "0001_initial" in versions
+    assert "0002_sessions" in versions
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -14,6 +14,7 @@ from tako_vm.execution import (
     RuntimeUnavailableError,
     reset_gvisor_check,
 )
+from tako_vm.job_types import JobType
 
 
 @pytest.fixture(autouse=True)
@@ -234,3 +235,102 @@ class TestPlatformDetection:
         from tako_vm.execution.worker import is_native_linux
 
         assert is_native_linux() is False
+
+
+class TestGpuRuntimePolicy:
+    """Tests for GPU-specific runtime resolution and Docker flags."""
+
+    @pytest.fixture(autouse=True)
+    def mock_gvisor_available(self, monkeypatch):
+        """Mock gVisor as available for baseline executor initialization."""
+        monkeypatch.setattr(worker_module, "_gvisor_available", True)
+
+    def test_gpu_workload_rejected_in_strict_mode(self):
+        """GPU workloads are blocked when strict mode requires gVisor."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
+        gpu_job = JobType(name="gpu-job", gpu_enabled=True, gpu_vendor="nvidia")
+
+        with pytest.raises(RuntimeUnavailableError) as exc_info:
+            executor.resolve_runtime_for_job_type(gpu_job)
+
+        assert "GPU workloads require gVisor to be disabled" in str(exc_info.value)
+
+    def test_gpu_workload_forces_runc_in_permissive_mode(self):
+        """GPU workloads always use runc in permissive mode."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+        gpu_job = JobType(name="gpu-job", gpu_enabled=True, gpu_vendor="nvidia")
+
+        assert executor.resolve_runtime_for_job_type(gpu_job) == "runc"
+
+    def test_build_gpu_flags_for_nvidia_variants(self):
+        """NVIDIA flag generation supports all/count/device selection."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+
+        assert executor.build_gpu_flags(
+            JobType(name="all", gpu_enabled=True, gpu_vendor="nvidia")
+        ) == ["--gpus=all"]
+        assert executor.build_gpu_flags(
+            JobType(name="count", gpu_enabled=True, gpu_vendor="nvidia", gpu_count=2)
+        ) == ["--gpus=2"]
+        assert executor.build_gpu_flags(
+            JobType(
+                name="devices",
+                gpu_enabled=True,
+                gpu_vendor="nvidia",
+                gpu_device_ids=["GPU-1", "GPU-2"],
+            )
+        ) == ["--gpus=device=GPU-1,GPU-2"]
+
+    def test_build_gpu_flags_for_amd(self):
+        """AMD jobs mount required device nodes."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+        flags = executor.build_gpu_flags(JobType(name="amd", gpu_enabled=True, gpu_vendor="amd"))
+        assert flags == ["--device=/dev/kfd", "--device=/dev/dri"]
+
+    def test_build_gpu_env_vars_for_device_selection(self):
+        """Device selection env vars are vendor-specific."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+
+        nvidia_env = executor.build_gpu_env_vars(
+            JobType(
+                name="nvidia",
+                gpu_enabled=True,
+                gpu_vendor="nvidia",
+                gpu_device_ids=["0", "2"],
+            )
+        )
+        assert nvidia_env == {"CUDA_VISIBLE_DEVICES": "0,2"}
+
+        amd_env = executor.build_gpu_env_vars(
+            JobType(
+                name="amd",
+                gpu_enabled=True,
+                gpu_vendor="amd",
+                gpu_device_ids=["card0"],
+            )
+        )
+        assert amd_env == {
+            "ROCR_VISIBLE_DEVICES": "card0",
+            "HIP_VISIBLE_DEVICES": "card0",
+        }
+
+    def test_build_gpu_flags_rejects_unknown_vendor(self):
+        """Unsupported GPU vendor raises a runtime error."""
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="permissive")
+        )
+
+        with pytest.raises(RuntimeUnavailableError) as exc_info:
+            executor.build_gpu_flags(JobType(name="bad", gpu_enabled=True, gpu_vendor="intel"))
+
+        assert "Unsupported GPU vendor" in str(exc_info.value)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,259 @@
+"""Tests for SessionManager core behavior."""
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+
+import pytest
+
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution.worker import CodeExecutor
+from tako_vm.job_types import JobType, JobTypeRegistry
+from tako_vm.models import SessionRecord
+from tako_vm.server.sessions import SessionManager, SessionManagerError
+from tako_vm.storage import ExecutionStorage
+
+
+def _build_runtime_components(
+    storage: ExecutionStorage,
+    *,
+    sessions_enabled: bool = True,
+    session_max_events_per_poll: int = 100,
+) -> tuple[TakoVMConfig, JobTypeRegistry, CodeExecutor, SessionManager]:
+    config = TakoVMConfig.model_validate(
+        {
+            "container_runtime": "runc",
+            "security_mode": "permissive",
+            "sessions_enabled": sessions_enabled,
+            "session_max_events_per_poll": session_max_events_per_poll,
+        }
+    )
+    registry = JobTypeRegistry()
+    registry.register(
+        JobType(
+            name="session-job",
+            session_enabled=True,
+            network_enabled=False,
+        ),
+        persist=False,
+    )
+    executor = CodeExecutor(registry=registry, config=config)
+    manager = SessionManager(config=config, storage=storage, registry=registry, executor=executor)
+    return config, registry, executor, manager
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_running_record_and_started_event(
+    temp_data_dir, monkeypatch, tmp_path
+):
+    """Successful create_session stores running state and startup event."""
+    storage = ExecutionStorage(os.environ["TAKO_VM_DATABASE_URL"])
+    await storage.init()
+    try:
+        _, _, _, manager = _build_runtime_components(storage)
+        monkeypatch.setattr("tako_vm.server.sessions.WORKSPACE_DIR", str(tmp_path))
+
+        async def fake_run(cmd, timeout):
+            del timeout
+            return subprocess.CompletedProcess(cmd, 0, "container-abc\n", "")
+
+        monkeypatch.setattr(manager, "_run_subprocess", fake_run)
+
+        session = await manager.create_session(job_type_name="session-job")
+
+        assert session.status == "running"
+        assert session.container_id == "container-abc"
+
+        loaded = await storage.get_session(session.session_id)
+        assert loaded is not None
+        assert loaded.status == "running"
+
+        events = await storage.list_session_events(session.session_id)
+        assert len(events) == 1
+        assert events[0].event_type == "session_started"
+        assert events[0].direction == "system"
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejected_when_sessions_disabled(temp_data_dir):
+    """Session creation is blocked by config when sessions_enabled=false."""
+    storage = ExecutionStorage(os.environ["TAKO_VM_DATABASE_URL"])
+    await storage.init()
+    try:
+        _, _, _, manager = _build_runtime_components(storage, sessions_enabled=False)
+        with pytest.raises(SessionManagerError) as exc_info:
+            await manager.create_session(job_type_name="session-job")
+        assert exc_info.value.status_code == 403
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_send_event_writes_inbox_file_and_updates_last_activity(
+    temp_data_dir, monkeypatch, tmp_path
+):
+    """send_event persists metadata and writes a mailbox envelope."""
+    storage = ExecutionStorage(os.environ["TAKO_VM_DATABASE_URL"])
+    await storage.init()
+    try:
+        _, _, _, manager = _build_runtime_components(storage)
+
+        workspace = tmp_path / "session"
+        inbox = workspace / "inbox"
+        outbox = workspace / "outbox"
+        inbox.mkdir(parents=True)
+        outbox.mkdir(parents=True)
+
+        now = datetime.now(timezone.utc)
+        session = SessionRecord(
+            session_id="session-send",
+            status="running",
+            job_type="session-job",
+            created_at=now,
+            last_activity_at=now,
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            container_name="tako-session-session-send",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=str(workspace),
+        )
+        await storage.save_session(session)
+
+        async def fake_run(cmd, timeout):
+            del timeout
+            if cmd[:2] == ["docker", "inspect"]:
+                return subprocess.CompletedProcess(cmd, 0, "running\t0", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(manager, "_run_subprocess", fake_run)
+
+        loaded_before = await storage.get_session(session.session_id)
+        assert loaded_before is not None
+        before = loaded_before.last_activity_at
+        saved_event = await manager.send_event(
+            session_id=session.session_id,
+            payload={"message": "hello"},
+            event_type="input",
+        )
+        loaded_after = await storage.get_session(session.session_id)
+        assert loaded_after is not None
+        after = loaded_after.last_activity_at
+
+        assert saved_event.id is not None
+        assert saved_event.direction == "in"
+        assert after >= before
+
+        inbox_files = list(inbox.glob("*.json"))
+        assert len(inbox_files) == 1
+        envelope = json.loads(inbox_files[0].read_text(encoding="utf-8"))
+        assert envelope["event_type"] == "input"
+        assert envelope["payload"] == {"message": "hello"}
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_events_ingests_outbox_and_handles_invalid_json(
+    temp_data_dir, monkeypatch, tmp_path
+):
+    """poll_events ingests outbox files and normalizes malformed payloads."""
+    storage = ExecutionStorage(os.environ["TAKO_VM_DATABASE_URL"])
+    await storage.init()
+    try:
+        _, _, _, manager = _build_runtime_components(storage, session_max_events_per_poll=10)
+
+        workspace = tmp_path / "session-poll"
+        inbox = workspace / "inbox"
+        outbox = workspace / "outbox"
+        inbox.mkdir(parents=True)
+        outbox.mkdir(parents=True)
+
+        session = SessionRecord(
+            session_id="session-poll",
+            status="running",
+            job_type="session-job",
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            container_name="tako-session-session-poll",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=str(workspace),
+        )
+        await storage.save_session(session)
+
+        (outbox / "event-good.json").write_text(
+            json.dumps({"event_type": "reply", "text": "ok"}),
+            encoding="utf-8",
+        )
+        (outbox / "event-bad.json").write_text("{not-json", encoding="utf-8")
+
+        async def fake_run(cmd, timeout):
+            del timeout
+            if cmd[:2] == ["docker", "inspect"]:
+                return subprocess.CompletedProcess(cmd, 0, "running\t0", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(manager, "_run_subprocess", fake_run)
+
+        _, events = await manager.poll_events(session_id=session.session_id, after_id=0, limit=100)
+
+        assert len(events) == 2
+        assert {event.event_type for event in events} == {"reply", "message"}
+
+        bad_payload = next(event.payload for event in events if event.file_name == "event-bad.json")
+        assert bad_payload["parse_error"] == "invalid_json"
+
+        assert not list(outbox.glob("*.json"))
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_terminate_session_marks_status_and_cleans_workspace(
+    temp_data_dir, monkeypatch, tmp_path
+):
+    """terminate_session updates status, emits event, and removes workspace."""
+    storage = ExecutionStorage(os.environ["TAKO_VM_DATABASE_URL"])
+    await storage.init()
+    try:
+        _, _, _, manager = _build_runtime_components(storage)
+
+        workspace = tmp_path / "session-term"
+        (workspace / "inbox").mkdir(parents=True)
+        (workspace / "outbox").mkdir(parents=True)
+
+        session = SessionRecord(
+            session_id="session-term",
+            status="running",
+            job_type="session-job",
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            container_name="tako-session-session-term",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=str(workspace),
+        )
+        await storage.save_session(session)
+
+        async def fake_run(cmd, timeout):
+            del timeout
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(manager, "_run_subprocess", fake_run)
+
+        terminated = await manager.terminate_session(session.session_id, reason="expired_idle")
+
+        assert terminated.status == "expired"
+        assert terminated.terminated_reason == "expired_idle"
+        assert not workspace.exists()
+
+        events = await storage.list_session_events(session.session_id)
+        assert len(events) == 1
+        assert events[0].event_type == "session_ended"
+        assert events[0].payload["reason"] == "expired_idle"
+    finally:
+        await storage.close()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -19,6 +19,9 @@ from tako_vm.models import (
     InputArtifact,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
+    SessionStatus,
 )
 from tako_vm.storage import ExecutionStorage
 
@@ -412,6 +415,108 @@ class TestJobVersions:
 
         versions = storage.list_versions("test-job")
         assert len(versions) == 3
+
+
+class TestSessionStorage:
+    """Tests for session persistence operations."""
+
+    @staticmethod
+    def _make_session(session_id: str, status: SessionStatus = "running") -> SessionRecord:
+        now = datetime.now(timezone.utc)
+        return SessionRecord(
+            session_id=session_id,
+            status=status,
+            job_type="default",
+            created_at=now,
+            last_activity_at=now,
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            container_name=f"tako-session-{session_id}",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=f"/tmp/{session_id}",
+            metadata={"source": "test"},
+        )
+
+    def test_save_and_get_session(self, storage):
+        """Can save and retrieve a session record."""
+        session = self._make_session("session-1")
+        storage.save_session(session)
+
+        loaded = storage.get_session("session-1")
+        assert loaded is not None
+        assert loaded.session_id == "session-1"
+        assert loaded.status == "running"
+        assert loaded.metadata["source"] == "test"
+
+    def test_list_sessions_with_status_filter(self, storage):
+        """Can list sessions filtered by status."""
+        storage.save_session(self._make_session("running-1", status="running"))
+        storage.save_session(self._make_session("terminated-1", status="terminated"))
+
+        running = storage.list_sessions(status="running")
+        assert len(running) == 1
+        assert running[0].session_id == "running-1"
+
+    def test_touch_session_updates_last_activity(self, storage):
+        """touch_session updates last_activity_at timestamp."""
+        session = self._make_session("session-touch")
+        storage.save_session(session)
+
+        touched_at = datetime.now(timezone.utc) + timedelta(seconds=5)
+        storage.touch_session("session-touch", touched_at=touched_at)
+
+        loaded = storage.get_session("session-touch")
+        assert loaded is not None
+        assert loaded.last_activity_at == touched_at
+
+    def test_save_session_event_dedupes_by_file_name(self, storage):
+        """Duplicate file_name inserts return existing event row."""
+        storage.save_session(self._make_session("session-events"))
+
+        first = storage.save_session_event(
+            SessionEvent(
+                session_id="session-events",
+                direction="out",
+                event_type="message",
+                payload={"value": 1},
+                file_name="event-1.json",
+            )
+        )
+        second = storage.save_session_event(
+            SessionEvent(
+                session_id="session-events",
+                direction="out",
+                event_type="message",
+                payload={"value": 2},
+                file_name="event-1.json",
+            )
+        )
+
+        assert first.id is not None
+        assert second.id == first.id
+
+        events = storage.list_session_events("session-events")
+        assert len(events) == 1
+        assert events[0].file_name == "event-1.json"
+
+    def test_list_session_events_after_cursor(self, storage):
+        """Can list events using an after_id cursor."""
+        storage.save_session(self._make_session("session-cursor"))
+
+        event1 = storage.save_session_event(
+            SessionEvent(session_id="session-cursor", direction="in", payload={"n": 1})
+        )
+        event2 = storage.save_session_event(
+            SessionEvent(session_id="session-cursor", direction="out", payload={"n": 2})
+        )
+
+        assert event1.id is not None
+        assert event2.id is not None
+
+        later_events = storage.list_session_events("session-cursor", after_id=event1.id)
+        assert len(later_events) == 1
+        assert later_events[0].id == event2.id
 
 
 class TestDeadLetterQueue:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,47 @@
+"""Tests for job type digest computation."""
+
+from dataclasses import replace
+
+from tako_vm.job_types import JobType
+from tako_vm.version import VersionManager
+
+
+def _version_manager() -> VersionManager:
+    # compute_digest() is pure and does not access storage.
+    return VersionManager(storage=None)  # type: ignore[arg-type]
+
+
+def test_compute_digest_changes_when_session_or_gpu_settings_change():
+    """Digest includes session and GPU fields."""
+    manager = _version_manager()
+    base = JobType(name="model-job")
+
+    base_digest = manager.compute_digest(base)
+    session_digest = manager.compute_digest(replace(base, session_enabled=True))
+    gpu_digest = manager.compute_digest(
+        replace(base, gpu_enabled=True, gpu_vendor="nvidia", gpu_count=1)
+    )
+
+    assert base_digest != session_digest
+    assert base_digest != gpu_digest
+    assert session_digest != gpu_digest
+
+
+def test_compute_digest_is_stable_for_reordered_gpu_device_ids():
+    """Device IDs are normalized for deterministic hashes."""
+    manager = _version_manager()
+
+    a = JobType(
+        name="gpu-job",
+        gpu_enabled=True,
+        gpu_vendor="nvidia",
+        gpu_device_ids=["GPU-2", "GPU-1"],
+    )
+    b = JobType(
+        name="gpu-job",
+        gpu_enabled=True,
+        gpu_vendor="nvidia",
+        gpu_device_ids=["GPU-1", "GPU-2"],
+    )
+
+    assert manager.compute_digest(a) == manager.compute_digest(b)


### PR DESCRIPTION
This PR exposes session functionality to users through HTTP API, CLI config output, and docs, while preserving the core logic introduced in earlier stacked PRs.

## What Changed
- API integration in `tako_vm/server/app.py`
  - app state now initializes/stops `SessionManager` in lifespan
  - added request/response models for sessions
  - added endpoints:
    - `POST /sessions`
    - `GET /sessions`
    - `GET /sessions/{session_id}`
    - `POST /sessions/{session_id}/send`
    - `GET /sessions/{session_id}/events`
    - `POST /sessions/{session_id}/terminate`
  - improved status typing reuse (`SessionStatus` alias from models)
- CLI updates in `tako_vm/cli.py`
  - show session settings in `show-config`
  - show per-job-type session/GPU details
- Added server export in `tako_vm/server/__init__.py`
- Documentation/examples updates:
  - `README.md`
  - `docs/api/rest.md`
  - `docs/getting-started/configuration.md`
  - `docs/guide/environments.md`
  - `tako_vm.yaml.example`

## Tests Added/Updated
- `tests/test_api.py`
  - endpoint-level tests for session APIs
  - integration-style session API tests that use real `SessionManager` path with only subprocess boundary mocked
  - payload limit (413) verification
- `tests/test_cli.py`
  - confirms `[Sessions]` section and session/GPU job-type display

## How To Review
1. Review endpoint contracts and error mapping in `tako_vm/server/app.py`.
2. Verify lifecycle wiring in app startup/shutdown.
3. Review `tests/test_api.py`:
   - first endpoint mapping tests
   - then integration-style session lifecycle tests for durability
4. Review CLI output and docs for consistency with API/config behavior.

## Suggested Verification
- `ruff check tako_vm tests`
- `pytest tests/test_api.py tests/test_cli.py -v`

## Out of Scope
- No new storage schema or manager core logic beyond prior PRs.
- No changes to GPU runtime policy beyond prior PRs.