### PR TITLE
Prepare package for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  # Build and push Docker images to GHCR
+  docker:
+    name: Push Docker images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image: executor
+            dockerfile: docker/Dockerfile.executor
+          - image: server
+            dockerfile: docker/Dockerfile.server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="${VERSION%%.*}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ steps.version.outputs.major }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Publish Python package to PyPI
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # trusted publishing (OIDC)
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tako-vm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build --sdist --wheel
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,10 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/example/tako-vm"
-Documentation = "https://github.com/example/tako-vm#readme"
-Repository = "https://github.com/example/tako-vm"
-Issues = "https://github.com/example/tako-vm/issues"
+Homepage = "https://github.com/las7/tako-vm"
+Documentation = "https://github.com/las7/tako-vm#readme"
+Repository = "https://github.com/las7/tako-vm"
+Issues = "https://github.com/las7/tako-vm/issues"
 
 [project.scripts]
 tako-vm = "tako_vm.cli:main"
@@ -110,7 +110,7 @@ markers = [
 ]
 
 [dependency-groups]
-dev = [
+tools = [
     "pre-commit>=4.3.0",
     "pyright>=1.1.408",
 ]

--- a/tako_vm/__init__.py
+++ b/tako_vm/__init__.py
@@ -25,6 +25,10 @@ Core modules:
 - config: Configuration management
 """
 
+from importlib.metadata import version as _pkg_version
+
+__version__ = _pkg_version("tako-vm")
+
 # Suppress LibreSSL warnings on macOS (urllib3 v2 requires OpenSSL 1.1.1+)
 import warnings
 
@@ -90,4 +94,6 @@ __all__ = [
     "SDKExecutionError",
     "ExecutionError",  # Backward compatibility alias for SDKExecutionError
     "ValidationError",
+    # Version
+    "__version__",
 ]

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -6,6 +6,7 @@ Loads configuration from YAML file with optional env var overrides.
 """
 
 import os
+from importlib.resources import files as _resource_files
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
@@ -398,7 +399,9 @@ class TakoVMConfig(BaseModel):
         if self.seccomp_profile_path_str:
             self._resolved_seccomp_profile_path = Path(self.seccomp_profile_path_str)
         else:
-            self._resolved_seccomp_profile_path = Path(__file__).parent / "seccomp_profile.json"
+            self._resolved_seccomp_profile_path = Path(
+                str(_resource_files("tako_vm").joinpath("seccomp_profile.json"))
+            )
 
         return self
 

--- a/tako_vm/job_types.py
+++ b/tako_vm/job_types.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from importlib.resources import files as _resource_files
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -205,7 +206,7 @@ class JobTypeRegistry:
             config_path: Path to config file. Defaults to job_types.json in package dir.
         """
         if config_path is None:
-            config_path = Path(__file__).parent / "job_types.json"
+            config_path = Path(str(_resource_files("tako_vm").joinpath("job_types.json")))
         self.config_path = config_path
         self._job_types: dict[str, JobType] = {}
         self._load()

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -178,7 +178,12 @@ class Sandbox:
         if not self.auto_build:
             raise RuntimeError(
                 f"Docker image '{self.config.image}' not found. "
-                f"Build it with: docker build -t {self.config.image} -f docker/Dockerfile.executor ."
+                f"Either pull the pre-built image:\n"
+                f"  docker pull ghcr.io/las7/tako-vm/executor:latest && "
+                f"docker tag ghcr.io/las7/tako-vm/executor:latest {self.config.image}\n"
+                f"Or clone the repo and build it:\n"
+                f"  git clone https://github.com/las7/tako-vm.git && "
+                f"cd tako-vm && docker build -t {self.config.image} -f docker/Dockerfile.executor ."
             )
 
         # Try to build the image
@@ -192,15 +197,25 @@ class Sandbox:
         package_dir = self._find_package_dir()
         if not package_dir:
             raise RuntimeError(
-                f"Cannot auto-build image: tako-vm package directory not found. "
-                f"Build manually: docker build -t {self.config.image} -f docker/Dockerfile.executor ."
+                f"Cannot auto-build image: tako-vm source directory not found. "
+                f"Either pull the pre-built image:\n"
+                f"  docker pull ghcr.io/las7/tako-vm/executor:latest && "
+                f"docker tag ghcr.io/las7/tako-vm/executor:latest {self.config.image}\n"
+                f"Or clone the repo and build it:\n"
+                f"  git clone https://github.com/las7/tako-vm.git && "
+                f"cd tako-vm && docker build -t {self.config.image} -f docker/Dockerfile.executor ."
             )
 
         dockerfile = package_dir / "docker" / "Dockerfile.executor"
         if not dockerfile.exists():
             raise RuntimeError(
                 f"Cannot auto-build image: Dockerfile not found at {dockerfile}. "
-                f"Build manually: docker build -t {self.config.image} -f docker/Dockerfile.executor ."
+                f"Either pull the pre-built image:\n"
+                f"  docker pull ghcr.io/las7/tako-vm/executor:latest && "
+                f"docker tag ghcr.io/las7/tako-vm/executor:latest {self.config.image}\n"
+                f"Or clone the repo and build it:\n"
+                f"  git clone https://github.com/las7/tako-vm.git && "
+                f"cd tako-vm && docker build -t {self.config.image} -f docker/Dockerfile.executor ."
             )
 
         print(f"Building executor image '{self.config.image}'... (one-time setup)")

--- a/uv.lock
+++ b/uv.lock
@@ -1503,7 +1503,7 @@ server = [
 ]
 
 [package.dev-dependencies]
-dev = [
+tools = [
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyright" },
@@ -1532,7 +1532,7 @@ requires-dist = [
 provides-extras = ["server", "all", "dev", "docs"]
 
 [package.metadata.requires-dev]
-dev = [
+tools = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyright", specifier = ">=1.1.408" },
 ]


### PR DESCRIPTION
## Summary
- Fix project URLs to point to `las7/tako-vm`
- Add `__version__` via `importlib.metadata`
- Rename `dependency-group` `dev` → `tools` to avoid conflict with `optional-dependencies.dev`
- Use `importlib.resources` for data file loading instead of `__file__`
- Improve Docker image error messages with `docker pull` / clone instructions
- Add release workflow: publishes to PyPI (trusted publishing) and GHCR (executor + server multi-arch images)

## Setup required before first release
1. Create `pypi` environment in repo Settings → Environments
2. Register trusted publisher at https://pypi.org/manage/account/publishing/
3. Tag and push: `git tag v2.0.0 && git push origin v2.0.0`

## Test plan
- [x] `uv build` produces valid wheel and sdist
- [x] `ruff check` passes
- [ ] Verify CI passes on this PR
- [ ] After merge, test release workflow with a tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)