### PR TITLE
Fix README inaccuracies, bump to v0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@
   <a href="https://github.com/las7/TakoVM/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>
 
-Run AI-generated code in isolated Docker containers with gVisor sandboxing.
+Run AI-generated code in isolated Docker containers with optional gVisor sandboxing.
 Job queues, retries, and execution history included.
 
-**Requires:** [Docker](https://docs.docker.com/get-docker/) and Python 3.9+
-
 ```bash
-pip install "tako-vm[server]"   # install with server dependencies
+# Install (requires Docker + Python 3.9+)
+pip install "tako-vm[server]"
 tako-vm setup                   # pull the executor Docker image
 tako-vm server                  # start server (auto-starts PostgreSQL via Docker)
 ```
@@ -30,7 +29,7 @@ curl -X POST http://localhost:8000/execute \
   -d '{"code": "print(1 + 1)"}'
 ```
 
-Or use directly as a library (no server or PostgreSQL needed):
+Or use as a library (no server needed): `pip install tako-vm`
 
 ```python
 from tako_vm import Sandbox
@@ -61,147 +60,6 @@ Sandbox solutions like [e2b](https://e2b.dev) and [microsandbox](https://github.
 - **Network isolation** - No network by default, optional allowlist per job type
 - **Self-hosted** - Your machine, offline-capable, zero per-execution cost
 
-## Installation
-
-### Prerequisites
-
-- Docker 20.10+
-- Python 3.9+
-
-### From PyPI
-
-```bash
-uv pip install tako-vm    # or: pip install tako-vm
-tako-vm setup             # pulls the executor Docker image from GHCR
-```
-
-`tako-vm setup` checks that Docker is running, pulls the executor image, and verifies it works.
-
-### For server mode (adds FastAPI + uvicorn)
-
-```bash
-uv pip install "tako-vm[server]"
-```
-
-### From source (development)
-
-```bash
-git clone https://github.com/las7/TakoVM.git && cd TakoVM
-uv sync --all-extras
-docker build -t code-executor:latest -f docker/Dockerfile.executor .
-```
-
-## Quick Start: Library Mode
-
-No server or database needed — just Docker.
-
-```bash
-uv pip install tako-vm
-tako-vm setup
-```
-
-```python
-from tako_vm import Sandbox
-
-# Basic execution
-with Sandbox() as sb:
-    result = sb.run("print('Hello from sandbox!')")
-    print(result.stdout)
-
-# With dependencies (installed via uv, cached for speed)
-with Sandbox() as sb:
-    result = sb.run("""
-import pandas as pd
-print(pd.__version__)
-""", requirements=["pandas"])
-
-# With input/output data
-with Sandbox() as sb:
-    result = sb.run("""
-import json
-with open("/input/data.json") as f:
-    data = json.load(f)
-result = {"sum": data["x"] + data["y"]}
-with open("/output/result.json", "w") as f:
-    json.dump(result, f)
-""", input_data={"x": 10, "y": 20})
-    print(result.output)  # {"sum": 30}
-
-# Network access (disabled by default)
-with Sandbox(network_enabled=True) as sb:
-    result = sb.run("""
-import urllib.request
-resp = urllib.request.urlopen("https://httpbin.org/get")
-print(resp.status)
-""")
-```
-
-Your code runs in a container with these paths:
-- `/input/data.json` - Your `input_data` as JSON (read-only)
-- `/output/` - Write output files here, returned as `result.output`
-- `/tmp/` - Temporary files (read-write)
-
-## Quick Start: Server Mode
-
-For production workloads with job queuing, retries, and execution history.
-
-Requires Docker (for PostgreSQL + executor containers):
-
-```bash
-# Install with server dependencies
-uv pip install "tako-vm[server]"
-tako-vm setup
-
-# Start server (auto-starts local PostgreSQL via Docker)
-tako-vm server
-```
-
-`tako-vm server` automatically pulls and starts a PostgreSQL container on port 55432 when no database is configured. To manage the database separately:
-
-```bash
-tako-vm dev up           # Start PostgreSQL only
-tako-vm dev status       # Check if it's running
-tako-vm dev down         # Stop it
-```
-
-```bash
-# Execute code via API
-curl -X POST http://localhost:8000/execute \
-  -H "Content-Type: application/json" \
-  -d '{"code": "print(1 + 1)", "requirements": ["requests"]}'
-```
-
-For an existing PostgreSQL instance:
-
-```bash
-export TAKO_VM_DATABASE_URL=postgresql://user:pass@host:5432/tako_vm
-tako-vm server
-```
-
-## SDK
-
-```python
-from dataclasses import dataclass
-import tako_vm
-
-tako_vm.configure('http://localhost:8000')
-
-@dataclass
-class Input:
-    x: int
-    y: int
-
-@dataclass
-class Output:
-    result: int
-
-def add(input: Input) -> Output:
-    return Output(result=input.x + input.y)
-
-result = tako_vm.send(add, Input(10, 20))
-print(result.result)  # 30
-```
-
 ## CLI
 
 ```bash
@@ -221,247 +79,19 @@ tako-vm version                   # Show version
 tako-vm --config my.yaml server   # Use specific config file
 ```
 
-## Configuration
+## Documentation
 
-Tako VM uses YAML configuration with Pydantic validation. All values have sensible defaults.
-
-```yaml
-# tako_vm.yaml
-production_mode: false
-max_workers: 4
-default_timeout: 30
-max_timeout: 300
-```
-
-### Config file search order
-
-1. `TAKO_VM_CONFIG` environment variable
-2. `./tako_vm.yaml`
-3. `./config/tako_vm.yaml`
-4. `~/.tako_vm/config.yaml`
-5. `/etc/tako_vm/config.yaml`
-
-### Environment variables
-
-All optional — override config file values or built-in defaults.
-
-```bash
-export TAKO_VM_CONFIG=/path/to/config.yaml
-export TAKO_VM_DATA_DIR=/var/lib/tako_vm
-export TAKO_VM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/tako_vm
-export TAKO_VM_SECURITY_MODE=permissive   # strict or permissive
-export TAKO_VM_API_RATE_LIMIT_ENABLED=true
-```
-
-### Container limits
-
-```yaml
-container_limits:
-  pids_limit: 100        # max processes (10-1000)
-  nofile_soft: 256       # file descriptors (64-65536)
-  nofile_hard: 256
-  nproc_soft: 50         # process limit (10-1000)
-  nproc_hard: 50
-  fsize: 104857600       # max file size: 100MB (1MB-1GB)
-  tmpfs_size: "100m"     # /tmp size (10m-2g)
-```
-
-See [tako_vm.yaml.example](tako_vm.yaml.example) for all options.
-
-## Job Types
-
-Job types are pre-configured execution environments with specific dependencies and limits.
-
-### Built-in types
-
-| Type | Packages | Network | Use Case |
-|------|----------|---------|----------|
-| `default` | stdlib only | isolated | Simple scripts |
-| `data-processing` | pandas, numpy | isolated | Data manipulation |
-| `ml-inference` | numpy, scikit-learn | isolated | ML inference |
-| `api-client` | requests, httpx | enabled | External API calls |
-
-### Custom job types
-
-```yaml
-job_types:
-  - name: data-processing
-    requirements:
-      - pandas
-      - numpy
-    memory_limit: "1g"
-    cpu_limit: 2.0
-    timeout: 60
-
-  - name: api-client
-    requirements:
-      - requests
-      - httpx
-    network_enabled: true
-```
-
-### How dependencies work
-
-Tako VM uses **runtime dependency installation** with [uv](https://github.com/astral-sh/uv):
-
-1. A single base image (`code-executor:latest`) handles all job types
-2. When a job runs, dependencies are installed via `uv pip install` (~10x faster than pip)
-3. Dependencies are cached in a Docker volume for repeated installs
-
-For true network isolation with dependencies, pre-build images:
-
-```bash
-tako-vm build job-type data-processing
-```
-
-## API
-
-### Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/execute` | POST | Execute code synchronously |
-| `/execute/async` | POST | Submit job, returns job ID |
-| `/jobs/{id}` | GET | Get job status |
-| `/jobs/{id}/result` | GET | Wait for job result |
-| `/jobs/{id}/cancel` | POST | Cancel pending/running job |
-| `/jobs/{id}/rerun` | POST | Rerun with same code and inputs |
-| `/jobs/{id}/fork` | POST | Fork with new code, same inputs |
-| `/jobs/{id}/artifacts/{name}` | GET | Download artifact |
-| `/job-types` | GET | List available job types |
-| `/health` | GET | Health check |
-| `/pool/stats` | GET | Worker pool status |
-| `/dlq/stats` | GET | Dead letter queue stats |
-
-### Timing
-
-Every response includes a timing breakdown:
-
-```json
-{
-  "status": "succeeded",
-  "timing": {
-    "startup_ms": 2500,
-    "dep_install_ms": 2100,
-    "execution_ms": 150,
-    "total_ms": 2650,
-    "phase_at_exit": "completed"
-  }
-}
-```
-
-Timeouts are configured separately for startup (`startup_timeout`) and code execution (`timeout`).
-
-### Idempotency
-
-```bash
-curl -X POST http://localhost:8000/execute/async \
-  -H "Content-Type: application/json" \
-  -d '{"code": "...", "input_data": {}, "idempotency_key": "my-unique-key"}'
-```
-
-See [docs/api/rest.md](docs/api/rest.md) for complete API reference.
-
-## Security
-
-**Layers applied to every container:**
-
-| Feature | Description |
-|---------|-------------|
-| gVisor Runtime | Userspace kernel isolation (default, `runsc`) |
-| Network Isolation | `--network=none` by default |
-| Read-Only Filesystem | `--read-only` with tmpfs for /tmp |
-| Seccomp Filtering | Blocks 47+ dangerous syscalls |
-| Resource Limits | Memory, CPU, file size, process count |
-| Non-Root Execution | Code runs as uid 1000 via gosu |
-| Capability Drop | `--cap-drop=ALL` (except SETUID/SETGID for gosu) |
-
-### Security modes
-
-```yaml
-# Production (require gVisor)
-security_mode: strict
-container_runtime: runsc
-
-# Development (allow fallback if gVisor not available)
-security_mode: permissive
-container_runtime: runsc
-```
-
-See [docs/security/honest-assessment.md](docs/security/honest-assessment.md) for threat model analysis.
-
-## Development
-
-### Running tests
-
-```bash
-# Clone and install
-git clone https://github.com/las7/TakoVM.git && cd TakoVM
-uv sync --all-extras
-docker build -t code-executor:latest -f docker/Dockerfile.executor .
-
-# Run tests without PostgreSQL (skips DB-dependent tests)
-TAKO_VM_SECURITY_MODE=permissive pytest tests/ -v
-
-# Run full test suite with PostgreSQL
-tako-vm dev up
-TAKO_VM_DATABASE_URL=postgresql://postgres:postgres@localhost:55432/tako_vm \
-  TAKO_VM_SECURITY_MODE=permissive pytest tests/ -v
-
-# Lint
-ruff check tako_vm/ tests/
-ruff format --check tako_vm/ tests/
-```
-
-### Docker images
-
-Pre-built images are published to GHCR on every release:
-
-```bash
-# Executor (used by Sandbox to run code)
-docker pull ghcr.io/las7/takovm/executor:latest
-
-# Server (API server with all dependencies)
-docker pull ghcr.io/las7/takovm/server:latest
-```
-
-### Docker Compose
-
-For a full local stack (server + PostgreSQL):
-
-```bash
-docker compose up -d
-curl http://localhost:8000/health
-```
-
-## Project Structure
-
-```
-tako-vm/
-├── tako_vm/
-│   ├── server/              # HTTP API layer
-│   │   ├── app.py           # FastAPI application
-│   │   ├── queue.py         # Worker pool & job queue
-│   │   └── limits.py        # Rate limiting & payload protection
-│   ├── execution/           # Docker execution layer
-│   │   ├── worker.py        # Container executor
-│   │   └── builder.py       # Image builder (for pre-built images)
-│   ├── sdk/                 # Python SDK
-│   │   └── client.py        # TakoVM client
-│   ├── cli.py               # CLI entry point
-│   ├── config.py            # Pydantic configuration
-│   ├── models.py            # Data models
-│   ├── sandbox.py           # Direct Docker execution (library mode)
-│   ├── storage.py           # PostgreSQL persistence
-│   └── job_types.py         # Job type definitions
-├── docker/
-│   ├── Dockerfile.executor  # Base executor image
-│   ├── Dockerfile.server    # API server image
-│   └── entrypoint.sh        # Container entrypoint
-├── tests/                   # Test suite (230+ tests)
-├── docs/                    # Documentation
-└── tako_vm.yaml.example     # Example configuration
-```
+| Topic | Link |
+|-------|------|
+| Installation | [docs/getting-started/installation.md](docs/getting-started/installation.md) |
+| Quick Start | [docs/getting-started/quickstart.md](docs/getting-started/quickstart.md) |
+| Configuration | [docs/getting-started/configuration.md](docs/getting-started/configuration.md) |
+| REST API | [docs/api/rest.md](docs/api/rest.md) |
+| Python SDK | [docs/api/sdk.md](docs/api/sdk.md) |
+| Job Types & Environments | [docs/guide/environments.md](docs/guide/environments.md) |
+| Security | [docs/deployment/security.md](docs/deployment/security.md) |
+| Deployment | [docs/deployment/how-to-deploy.md](docs/deployment/how-to-deploy.md) |
+| Config Reference | [tako_vm.yaml.example](tako_vm.yaml.example) |
 
 ## License
 

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -613,7 +613,7 @@ GET /health
     "success_count": 5,
     "last_failure": null
   },
-  "version": "2.0.0",
+  "version": "0.1.4",
   "production_mode": false,
   "queue_stats": {
     "pending": 0,

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -309,7 +309,7 @@ For higher security, consider:
 
 ## gVisor Runtime
 
-Tako VM uses gVisor (runsc) by default for strong container isolation. gVisor provides a userspace kernel that intercepts and emulates syscalls, adding a significant security boundary beyond standard Docker.
+Tako VM supports gVisor (runsc) for strong container isolation. gVisor provides a userspace kernel that intercepts and emulates syscalls, adding a significant security boundary beyond standard Docker. By default, Tako VM runs in `permissive` mode, which falls back to runc if gVisor is not installed.
 
 ### Why gVisor?
 
@@ -322,7 +322,7 @@ Tako VM uses gVisor (runsc) by default for strong container isolation. gVisor pr
 
 ### Installation
 
-gVisor is required for `strict` security mode (default). Install it following the [official gVisor installation guide](https://gvisor.dev/docs/user_guide/install/).
+gVisor is required for `strict` security mode. Install it following the [official gVisor installation guide](https://gvisor.dev/docs/user_guide/install/).
 
 **Ubuntu/Debian:**
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -55,7 +55,7 @@ This builds the base execution container with Python 3.11 and uv.
 
 ```bash
 tako-vm version
-# tako-vm 2.0.0
+# tako-vm 0.1.4
 
 tako-vm --help
 # Shows all available commands
@@ -83,7 +83,7 @@ Expected output:
 {
   "status": "healthy",
   "docker_available": true,
-  "version": "2.0.0"
+  "version": "0.1.4"
 }
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -45,7 +45,7 @@ print("Done!")
 The first run builds the Docker image automatically (~30 seconds one-time setup).
 
 !!! note "gVisor on Linux"
-    Tako VM uses gVisor by default for strong isolation. If gVisor is not installed, set `TAKO_VM_SECURITY_MODE=permissive` or configure `security_mode: permissive` in your config file. See [Security](../deployment/security.md#gvisor-runtime) for installation instructions.
+    Tako VM defaults to `permissive` mode, which falls back to runc if gVisor is not installed. For production, set `security_mode: strict` to require gVisor. See [Security](../deployment/security.md#gvisor-runtime) for installation instructions.
 
 ## Server Mode (For Production)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: Tako VM
 site_description: Job queue infrastructure for Python AI agents
-site_url: https://tako-vm.dev
+site_url: https://las7.github.io/TakoVM/
 site_author: Tako VM
 
-repo_url: https://github.com/example/tako-vm
-repo_name: tako-vm
+repo_url: https://github.com/las7/TakoVM
+repo_name: TakoVM
 edit_uri: edit/main/docs/
 
 theme:
@@ -99,4 +99,4 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/example/tako-vm
+      link: https://github.com/las7/TakoVM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tako-vm"
-version = "0.1.3"
+version = "0.1.4"
 description = "Secure Python code execution in isolated Docker containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1464,7 +1464,7 @@ wheels = [
 
 [[package]]
 name = "tako-vm"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- **README slimmed from ~410 to ~95 lines** — removed sections duplicated in docs/, replaced with a Documentation links table
- Library mode shown as a brief alternative to the server hero block
- CLI section restored with all commands (`--json`, `validate <file>`, `--config`)
- Version bump from 0.1.3 to 0.1.4
- Fixed placeholder version `2.0.0` in docs (installation.md, rest.md)
- Fixed gVisor described as "default" in docs — now correctly says permissive is the default (security.md, quickstart.md)
- Fixed mkdocs.yml URLs from `example/tako-vm` to `las7/TakoVM`

## Test plan
- [x] `ruff check` passes
- [x] All tests pass (255 passed, 45 skipped)
- [x] All 9 documentation links in README verified to exist
- [x] CLI confirmed working from fresh PyPI venv install
- [ ] Publish 0.1.4 to PyPI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)