### PR TITLE
Fix docs audit issues: production_mode, gVisor defaults, non-existent CLI

### DIFF
--- a/docs/deployment/how-to-deploy.md
+++ b/docs/deployment/how-to-deploy.md
@@ -357,7 +357,7 @@ docker build -t code-executor:latest .
 
 # Create production config
 cat > tako_vm.yaml << 'EOF'
-production_mode: false
+production_mode: true
 max_workers: 4
 EOF
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -30,12 +30,14 @@ enable_seccomp: true
 In production mode, images must be pre-built:
 
 ```bash
-# Build all registered environments
-python -m tako_vm.execution.builder --init-defaults all
+# Build images via the REST API (requires a running server)
+curl -X POST http://localhost:8000/job-types/data-processing/build
 
 # Verify images exist
 docker images | grep tako-vm
 ```
+
+!!! note "CLI support for building images is planned — see [GitHub #30](https://github.com/las7/TakoVM/issues/30)."
 
 ## Running with Systemd
 

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -302,7 +302,7 @@ Tako VM does NOT protect against:
 | Timing attacks | Execution time visible |
 
 For higher security, consider:
-- gVisor (default in Tako VM)
+- gVisor (supported by Tako VM)
 - Kata Containers
 - Dedicated execution hosts
 - VM-based isolation

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -256,7 +256,7 @@ Tako VM separates startup time from code execution time:
 
 ## gVisor and Security Modes
 
-Tako VM uses gVisor (runsc) by default for strong container isolation:
+Tako VM supports gVisor (runsc) for strong container isolation:
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -122,12 +122,11 @@ for jt in response.json():
 In development mode, images are auto-built on first use. To pre-build:
 
 ```bash
-# Build all job types
-python -m tako_vm.container_builder --build-all
-
-# Build specific job type
-python -m tako_vm.container_builder --build data-processing
+# Build images via the REST API (requires a running server)
+curl -X POST http://localhost:8000/job-types/data-processing/build
 ```
+
+!!! note "CLI support for building images is planned — see [GitHub #30](https://github.com/las7/TakoVM/issues/30)."
 
 Images are named `tako-vm-{name}:latest`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ print(response.json())
                     └─────────────┘
 ```
 
-**Security:** Tako VM uses gVisor (runsc) by default for strong container isolation with a userspace kernel.
+**Security:** Tako VM supports gVisor (runsc) for strong container isolation with a userspace kernel. Defaults to `permissive` mode, which falls back to standard Docker (runc) if gVisor is not installed.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Fixes 3 documentation issues found during a comprehensive docs audit:

- **Fix `production_mode: false` in deploy script** — quick-start script claimed to create "production config" but set `production_mode: false`. Closes #35
- **Fix gVisor incorrectly claimed as default** in `index.md`, `configuration.md`, and `security.md` — actual default is `permissive` mode which falls back to runc. Closes #36
- **Replace non-existent `python -m` CLI commands** in `production.md` and `environments.md` with REST API references, noting that CLI support is tracked in #30. Closes #37

## Files changed
- `docs/deployment/how-to-deploy.md` — production_mode: true
- `docs/index.md` — "supports gVisor" instead of "uses gVisor by default"
- `docs/getting-started/configuration.md` — same gVisor wording fix
- `docs/deployment/security.md` — "supported by Tako VM" instead of "default in Tako VM"
- `docs/deployment/production.md` — REST API build command instead of non-existent CLI
- `docs/guide/environments.md` — same CLI fix

## Test plan
- [x] `grep -rn "gVisor.*by default" docs/` returns 0 results
- [x] `grep -rn "python -m tako_vm" docs/` returns 0 results
- [x] All modified docs read naturally in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)