### PR TITLE
Fix all 9 remaining documentation audit issues

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -195,16 +195,20 @@ GET /jobs/{job_id}
 
 ### Status Values
 
-| Status | Description |
-|--------|-------------|
-| `pending` | Queued, waiting for worker (queue status) |
-| `running` | Currently executing |
-| `queued` | Job queued (record status) |
-| `succeeded` | Completed successfully |
-| `failed` | Failed with error |
-| `timeout` | Exceeded time limit |
-| `oom` | Out of memory |
-| `cancelled` | Cancelled by user |
+There are two status systems. When you submit an async job, the **queue** tracks it as `pending` → `running` → `completed`. The **execution record** uses more granular statuses:
+
+| Status | Where | Description |
+|--------|-------|-------------|
+| `pending` | Queue | Waiting for a worker to pick up the job |
+| `running` | Both | Currently executing |
+| `queued` | Record | Job created and persisted, not yet started |
+| `succeeded` | Record | Completed successfully |
+| `failed` | Record | Failed with error |
+| `timeout` | Record | Exceeded time limit |
+| `oom` | Record | Out of memory |
+| `cancelled` | Record | Cancelled by user |
+
+When polling `/jobs/{id}`, you'll typically see: `queued` → `running` → `succeeded`/`failed`/`timeout`/`oom`.
 
 ---
 

--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -178,6 +178,20 @@ result = tako_vm.send(func, input_data, timeout=None, job_type=None)
 - `ValidationError`: Invalid input/output types
 - `ExecutionError`: Execution failed
 
+!!! important "How `send()` works"
+    The function you pass to `send()` does **not** run locally. Instead:
+
+    1. The function's source code is extracted via `inspect.getsource()`
+    2. The input dataclass is serialized to JSON and written to `/input/data.json`
+    3. The code is sent to the Tako VM server and executed in an isolated Docker container
+    4. The output is deserialized back into your output dataclass
+
+    This means:
+
+    - **Do not reference local variables** outside the function — they won't exist in the container
+    - **Imports must be inside the function** or available in the container's Python environment
+    - **The return type annotation** determines how `/output/result.json` is parsed back
+
 ---
 
 ### `tako_vm.send_raw()`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,9 +154,9 @@ Security Layers:
       │                                                │
       ▼                                                ▼
 ┌──────────────────┐                         ┌──────────────────┐
-│ tako-vm build    │                         │ Job submitted    │
-│ job-type         │                         │ with job_type    │
-│ data-processing  │                         │                  │
+│ Pre-build image  │                         │ Job submitted    │
+│ via REST API or  │                         │ with job_type    │
+│ docker build     │                         │                  │
 └────────┬─────────┘                         └────────┬─────────┘
          │                                            │
          ▼                                            ▼

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -1,0 +1,150 @@
+# Operations Runbook
+
+Procedures for diagnosing and recovering from common production issues.
+
+## Diagnostic Endpoints
+
+```bash
+# Server health
+curl http://localhost:8000/health
+
+# Worker pool status (queue depth, active workers)
+curl http://localhost:8000/pool/stats
+
+# Dead letter queue stats
+curl http://localhost:8000/dlq/stats
+```
+
+## Common Scenarios
+
+### High Queue Depth
+
+**Symptom:** `/pool/stats` shows `queue_depth` growing, jobs take longer to start.
+
+**Diagnosis:**
+```bash
+# Check current stats
+curl -s http://localhost:8000/pool/stats | python3 -m json.tool
+
+# Check if workers are stuck
+docker ps --filter "name=tako-" --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}"
+```
+
+**Recovery:**
+1. If workers are idle but queue is full → restart the server
+2. If all workers are busy → increase `max_workers` in config and restart
+3. If containers are stuck → kill stale containers:
+   ```bash
+   # Find containers running longer than expected
+   docker ps --filter "name=tako-" --format "{{.ID}} {{.RunningFor}}" | grep -E "hours|days"
+   ```
+
+### Circuit Breaker Open
+
+**Symptom:** Jobs return 503 immediately. Health endpoint shows `"docker_available": false`.
+
+**Diagnosis:**
+```bash
+# Check Docker daemon
+docker info > /dev/null 2>&1 && echo "Docker OK" || echo "Docker DOWN"
+
+# Check Docker socket permissions
+ls -la /var/run/docker.sock
+```
+
+**Recovery:**
+1. Restart Docker daemon: `sudo systemctl restart docker`
+2. Wait for Tako VM health check to detect Docker is back (automatic)
+3. If persistent, restart Tako VM server
+
+### Dead Letter Queue Growing
+
+**Symptom:** `/dlq/stats` shows increasing count.
+
+**Diagnosis:**
+```bash
+# Check DLQ contents
+curl -s http://localhost:8000/dlq/stats | python3 -m json.tool
+```
+
+**Recovery:**
+1. Review DLQ entries for common failure patterns
+2. Fix the root cause (usually Docker issues or resource exhaustion)
+3. DLQ entries are informational — they indicate jobs that failed due to infrastructure errors (not user code errors)
+
+### Database Connection Failures
+
+**Symptom:** Server returns 500 errors. Logs show PostgreSQL connection errors.
+
+**Diagnosis:**
+```bash
+# Check if auto-managed PostgreSQL is running
+docker ps --filter "name=tako-postgres"
+
+# Test connectivity
+pg_isready -h localhost -p 55432
+```
+
+**Recovery:**
+1. If using auto-managed PostgreSQL: restart Tako VM server (it will recreate the container)
+2. If using external PostgreSQL: check connection string in `database_url` config
+3. Verify the database is reachable from the Tako VM host
+
+### Disk Full
+
+**Symptom:** Jobs fail with write errors. Docker containers fail to start.
+
+**Diagnosis:**
+```bash
+# Check disk usage
+df -h
+
+# Check Docker disk usage
+docker system df
+```
+
+**Recovery:**
+```bash
+# Clean up stopped containers and unused images
+docker system prune -f
+
+# Remove old Tako VM artifacts if stored locally
+# (location depends on your TAKO_VM_DATA_DIR config)
+```
+
+### Out of Memory
+
+**Symptom:** Jobs return `oom` status. Host becomes slow.
+
+**Diagnosis:**
+```bash
+# Check host memory
+free -h
+
+# Check container memory limits
+docker stats --no-stream --filter "name=tako-"
+```
+
+**Recovery:**
+1. Reduce `max_workers` to lower concurrent memory usage
+2. Lower per-container memory limits in config (`container_memory_mb`)
+3. Add more RAM to the host
+
+## Key Metrics to Monitor
+
+| Metric | Source | Warning Threshold |
+|--------|--------|-------------------|
+| Queue depth | `/pool/stats` → `queue_depth` | > `max_workers` × 2 |
+| DLQ count | `/dlq/stats` → `count` | > 0 (investigate) |
+| Docker health | `/health` → `docker_available` | `false` |
+| Active workers | `/pool/stats` → `active_workers` | = `max_workers` sustained |
+| Disk usage | `df -h` | > 80% |
+| Memory usage | `free -h` | > 85% |
+
+## Log Locations
+
+| Deployment | Location |
+|------------|----------|
+| Direct (systemd) | `journalctl -u tako-vm` |
+| Docker Compose | `docker-compose logs -f tako-vm` |
+| Kubernetes | `kubectl logs -l app=tako-vm` |

--- a/docs/deployment/scaling.md
+++ b/docs/deployment/scaling.md
@@ -1,6 +1,19 @@
 # Tako VM Scaling Guide
 
-This document outlines strategies for scaling Tako VM beyond the default configuration.
+This document covers scaling Tako VM. The first section describes what works today; later sections describe planned features that are not yet implemented.
+
+## What Works Today
+
+Tako VM supports **single-node vertical scaling** by increasing workers and queue size. Multi-node horizontal scaling is not yet available.
+
+| Capability | Status |
+|-----------|--------|
+| Increase workers (up to 64) | Available |
+| Increase queue size | Available |
+| gVisor runtime | Available |
+| Container pooling | Planned |
+| Distributed workers (multi-node) | Planned |
+| Lighter isolation (nsjail, Firecracker) | Planned |
 
 ## Current Configuration
 
@@ -35,6 +48,9 @@ max_queue_size: 1000
 ---
 
 ### 2. Container Pooling (High Impact)
+
+!!! warning "Not yet implemented"
+    Container pooling is a planned feature. The design below is aspirational.
 
 **Status**: Planned
 
@@ -115,6 +131,9 @@ class ContainerPool:
 ---
 
 ### 3. Distributed Workers (Horizontal Scaling)
+
+!!! warning "Not yet implemented"
+    Distributed workers require Redis and external PostgreSQL. This is a planned feature.
 
 **Status**: Planned
 
@@ -223,6 +242,9 @@ With container pooling + distribution: **1000+ jobs/sec**
 ---
 
 ### 4. Lighter Isolation Options
+
+!!! warning "Not yet implemented"
+    Alternative isolation backends are a planned feature. Only Docker and gVisor are supported today.
 
 **Status**: Planned
 

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -7,9 +7,9 @@
 3. Container starts, `entrypoint.sh` runs `uv pip install pandas numpy`
 4. Code runs as `sandbox` user (uid 1000) via `gosu`
 
-For network-isolated jobs with deps, use pre-built images:
+For network-isolated jobs with deps, use pre-built images via the REST API:
 ```bash
-tako-vm build job-type data-processing
+curl -X POST http://localhost:8000/job-types/data-processing/build
 # Then set base_image in job type config
 ```
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -182,6 +182,9 @@ Job types define pre-configured execution environments:
 
 When you define a job type, Tako VM builds a Docker image with the specified packages pre-installed (`tako-vm-{name}:latest`).
 
+!!! warning "Security: Environment Variables"
+    If your job type config includes `environment` variables, be aware that user code can read them via `/proc/self/environ`. Never put secrets (API keys, tokens) in job type environment variables. See [Security Mitigations](../security/mitigations.md).
+
 ## Container Limits
 
 | Limit | Description | Default | Range |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,10 +2,21 @@
 
 ## Prerequisites
 
-- **Docker** 20.10 or later
-- **Python** 3.9 or later
-- **[uv](https://github.com/astral-sh/uv)**
-- **gVisor** (recommended for production) - See [gVisor installation](https://gvisor.dev/docs/user_guide/install/)
+Before installing Tako VM, verify you have the following:
+
+| Requirement | Minimum Version | Check Command | Required? |
+|-------------|----------------|---------------|-----------|
+| **Docker** | 20.10+ | `docker --version` | Yes |
+| **Python** | 3.9+ | `python3 --version` | Yes |
+| **[uv](https://github.com/astral-sh/uv)** | any | `uv --version` | Recommended (pip also works) |
+| **gVisor** | any | `docker run --runtime=runsc --rm hello-world` | Production only |
+
+!!! note "Quick pre-flight check"
+    ```bash
+    docker info > /dev/null 2>&1 && echo "Docker: OK" || echo "Docker: NOT RUNNING"
+    python3 --version
+    ```
+    Docker must be **running** (not just installed). On macOS/Windows, start Docker Desktop first.
 
 ## Install Tako VM
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,6 +19,9 @@ tako-vm server --port 9000
 !!! note "gVisor on Linux"
     Tako VM defaults to `permissive` mode, which falls back to runc if gVisor is not installed. For production, set `security_mode: strict` to require gVisor. See [Security](../deployment/security.md#gvisor-runtime) for installation instructions.
 
+!!! warning "Security: Environment Variables"
+    Do not pass secrets (API keys, tokens, passwords) as job type environment variables. User code can read them via `/proc/self/environ`. Pass sensitive data through `input_data` instead, which is scoped to a single job. See [Security Mitigations](../security/mitigations.md) for details.
+
 ## Execute Code
 
 ### Using curl

--- a/docs/guide/async-jobs.md
+++ b/docs/guide/async-jobs.md
@@ -63,16 +63,20 @@ print(f"Status: {status['status']}")
 
 ### Status Values
 
+The initial response from `/execute/async` returns `pending` (queue status). When you poll `/jobs/{id}`, you'll see **execution record** statuses:
+
 | Status | Description |
 |--------|-------------|
-| `pending` | Queued, waiting for worker (queue status) |
+| `queued` | Job persisted, waiting for a worker |
 | `running` | Currently executing |
-| `queued` | Job queued (record status) |
 | `succeeded` | Completed successfully |
 | `failed` | Failed with error |
 | `timeout` | Exceeded time limit |
 | `oom` | Out of memory |
 | `cancelled` | Cancelled by user |
+
+!!! tip "Polling tip"
+    When writing polling logic, check for terminal states: `succeeded`, `failed`, `timeout`, `oom`, `cancelled`.
 
 ## Wait for Result
 

--- a/docs/guide/custom-libraries.md
+++ b/docs/guide/custom-libraries.md
@@ -43,10 +43,10 @@ For the base executor image:
 docker build -t code-executor:latest -f docker/Dockerfile.executor .
 ```
 
-For job-type-specific images:
+For job-type-specific images, use the REST API:
 
 ```bash
-tako-vm build job-type data-processing
+curl -X POST http://localhost:8000/job-types/data-processing/build
 ```
 
 ## Directory Structure

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -1,0 +1,218 @@
+# Tutorial: Build a Data Processing Pipeline
+
+This tutorial walks through building a complete application with Tako VM — from setup to processing results.
+
+## What We'll Build
+
+A simple service that:
+
+1. Accepts CSV data
+2. Processes it in an isolated container (computes statistics)
+3. Returns the results
+
+## Prerequisites
+
+```bash
+pip install "tako-vm[server]" requests
+tako-vm setup
+tako-vm server  # leave running in a terminal
+```
+
+## Step 1: Basic Execution
+
+Start with a simple test to verify everything works:
+
+```python
+import requests
+
+response = requests.post("http://localhost:8000/execute", json={
+    "code": "print('Tako VM is working!')"
+})
+result = response.json()
+assert result["success"], f"Failed: {result.get('stderr')}"
+print(result["stdout"])  # "Tako VM is working!"
+```
+
+## Step 2: Process Input Data
+
+Pass data in, get structured results back:
+
+```python
+import requests
+
+code = """
+import json
+
+with open("/input/data.json") as f:
+    data = json.load(f)
+
+items = data["items"]
+stats = {
+    "count": len(items),
+    "sum": sum(items),
+    "mean": sum(items) / len(items),
+    "min": min(items),
+    "max": max(items),
+}
+
+with open("/output/result.json", "w") as f:
+    json.dump(stats, f)
+
+print(f"Processed {len(items)} items")
+"""
+
+response = requests.post("http://localhost:8000/execute", json={
+    "code": code,
+    "input_data": {"items": [10, 20, 30, 40, 50]}
+})
+
+result = response.json()
+print(f"Success: {result['success']}")
+print(f"Stats: {result['output']}")
+# Stats: {'count': 5, 'sum': 150, 'mean': 30.0, 'min': 10, 'max': 50}
+print(f"Stdout: {result['stdout']}")
+# Stdout: Processed 5 items
+```
+
+## Step 3: Use Async for Longer Jobs
+
+For jobs that take more than a few seconds, use async execution:
+
+```python
+import requests
+import time
+
+# Submit the job (returns immediately)
+response = requests.post("http://localhost:8000/execute/async", json={
+    "code": """
+import time, json
+time.sleep(3)  # simulate heavy processing
+with open("/output/result.json", "w") as f:
+    json.dump({"status": "done", "processed": 1000}, f)
+""",
+    "input_data": {}
+})
+job = response.json()
+job_id = job["job_id"]
+print(f"Job submitted: {job_id}")
+
+# Poll for completion
+while True:
+    status = requests.get(f"http://localhost:8000/jobs/{job_id}").json()
+    if status["status"] in ("succeeded", "failed", "timeout", "oom"):
+        break
+    print(f"  Status: {status['status']}")
+    time.sleep(1)
+
+# Get the result
+result = requests.get(f"http://localhost:8000/jobs/{job_id}/result").json()
+print(f"Result: {result['output']}")
+```
+
+## Step 4: Handle Errors
+
+Always check for failures:
+
+```python
+import requests
+
+response = requests.post("http://localhost:8000/execute", json={
+    "code": "raise ValueError('something went wrong')",
+    "input_data": {}
+})
+
+result = response.json()
+if not result["success"]:
+    print(f"Job failed (exit code {result['exit_code']})")
+    print(f"Error: {result['stderr']}")
+else:
+    print(f"Output: {result['output']}")
+```
+
+## Step 5: Use Dependencies
+
+Need third-party packages? Pass them in `requirements`:
+
+```python
+import requests
+
+code = """
+import pandas as pd
+import json
+
+with open("/input/data.json") as f:
+    data = json.load(f)
+
+df = pd.DataFrame(data["records"])
+summary = df.describe().to_dict()
+
+with open("/output/result.json", "w") as f:
+    json.dump(summary, f)
+"""
+
+response = requests.post("http://localhost:8000/execute", json={
+    "code": code,
+    "input_data": {
+        "records": [
+            {"name": "Alice", "score": 85},
+            {"name": "Bob", "score": 92},
+            {"name": "Charlie", "score": 78},
+        ]
+    },
+    "requirements": ["pandas"]
+})
+
+result = response.json()
+print(result["output"])
+```
+
+## Step 6: Batch Processing
+
+Process multiple items by submitting async jobs and collecting results:
+
+```python
+import requests
+import time
+
+# Submit batch of jobs
+items = [
+    {"x": 1, "y": 2},
+    {"x": 10, "y": 20},
+    {"x": 100, "y": 200},
+]
+
+job_ids = []
+for item in items:
+    resp = requests.post("http://localhost:8000/execute/async", json={
+        "code": """
+import json
+with open("/input/data.json") as f:
+    data = json.load(f)
+result = {"sum": data["x"] + data["y"], "product": data["x"] * data["y"]}
+with open("/output/result.json", "w") as f:
+    json.dump(result, f)
+""",
+        "input_data": item
+    })
+    job_ids.append(resp.json()["job_id"])
+
+print(f"Submitted {len(job_ids)} jobs")
+
+# Wait for all to complete
+results = []
+for job_id in job_ids:
+    result = requests.get(
+        f"http://localhost:8000/jobs/{job_id}/result?wait=true&timeout=30"
+    ).json()
+    results.append(result["output"])
+
+print("Results:", results)
+# Results: [{'sum': 3, 'product': 2}, {'sum': 30, 'product': 200}, {'sum': 300, 'product': 20000}]
+```
+
+## Next Steps
+
+- [REST API Reference](../api/rest.md) — all endpoints and options
+- [Environments](environments.md) — pre-configured job types
+- [Error Handling](error-handling.md) — robust error handling patterns
+- [Async Jobs](async-jobs.md) — advanced async patterns

--- a/docs/security/mitigations.md
+++ b/docs/security/mitigations.md
@@ -1,375 +1,81 @@
-# Security Mitigations for /proc Exposure
+# Security Mitigations
 
-This document provides actionable steps to mitigate the /proc filesystem exposure vulnerability identified in the [Equixly security research](https://equixly.com/blog/2025/11/04/path-traversal-ai-containers/).
+This document describes mitigations for the [/proc filesystem exposure vulnerability](proc-exposure-vulnerability.md) identified in the [Equixly security research](https://equixly.com/blog/2025/11/04/path-traversal-ai-containers/).
 
-## Quick Reference
+## Summary
 
-| Mitigation | Priority | Effort | Impact |
-|-----------|----------|--------|--------|
-| Enable seccomp profile | **HIGH** | Low | Blocks dangerous syscalls |
-| Mask /proc paths | **HIGH** | Medium | Hides sensitive /proc files |
-| Remove env var secrets | **CRITICAL** | Medium | Prevents secret leakage |
-| Document limitations | **HIGH** | Low | User awareness |
-| Add AppArmor/SELinux | Medium | High | Additional MAC layer |
+User code running inside Tako VM containers can read `/proc/self/environ` and other `/proc` paths, potentially leaking environment variables and process metadata. The mitigations below reduce this risk.
 
-## 1. Enable Seccomp Profile (Priority: HIGH)
+## Current Protections (Implemented)
 
-### Implementation
+These protections are active in the current release:
 
-The seccomp profile is located at `tako_vm/seccomp_profile.json`:
+### Seccomp Profile
 
-```json
-{
-  "defaultAction": "SCMP_ACT_ERRNO",
-  "defaultErrnoRet": 1,
-  "archMap": [
-    {
-      "architecture": "SCMP_ARCH_X86_64",
-      "subArchitectures": ["SCMP_ARCH_X86", "SCMP_ARCH_X32"]
-    },
-    {
-      "architecture": "SCMP_ARCH_AARCH64",
-      "subArchitectures": ["SCMP_ARCH_ARM"]
-    }
-  ],
-  "syscalls": [
-    {
-      "names": [
-        "accept", "accept4", "access", "arch_prctl", "bind", "brk",
-        "capget", "capset", "chdir", "chmod", "chown", "clock_getres",
-        "clock_gettime", "clock_nanosleep", "close", "connect", "copy_file_range",
-        "creat", "dup", "dup2", "dup3", "epoll_create", "epoll_create1",
-        "epoll_ctl", "epoll_ctl_old", "epoll_pwait", "epoll_wait", "epoll_wait_old",
-        "eventfd", "eventfd2", "execve", "execveat", "exit", "exit_group",
-        "faccessat", "faccessat2", "fadvise64", "fallocate", "fanotify_mark",
-        "fchdir", "fchmod", "fchmodat", "fchown", "fchownat", "fcntl", "fdatasync",
-        "fgetxattr", "flistxattr", "flock", "fork", "fremovexattr", "fsetxattr",
-        "fstat", "fstatfs", "fsync", "ftruncate", "futex", "getcpu", "getcwd",
-        "getdents", "getdents64", "getegid", "geteuid", "getgid", "getgroups",
-        "getitimer", "getpeername", "getpgid", "getpgrp", "getpid", "getppid",
-        "getpriority", "getrandom", "getresgid", "getresuid", "getrlimit",
-        "get_robust_list", "getrusage", "getsid", "getsockname", "getsockopt",
-        "get_thread_area", "gettid", "gettimeofday", "getuid", "getxattr",
-        "inotify_add_watch", "inotify_init", "inotify_init1", "inotify_rm_watch",
-        "io_cancel", "ioctl", "io_destroy", "io_getevents", "ioprio_get",
-        "ioprio_set", "io_setup", "io_submit", "kill", "lchown", "lgetxattr",
-        "link", "linkat", "listen", "listxattr", "llistxattr", "lremovexattr",
-        "lseek", "lsetxattr", "lstat", "madvise", "memfd_create", "mincore",
-        "mkdir", "mkdirat", "mknod", "mknodat", "mlock", "mlock2", "mlockall",
-        "mmap", "mprotect", "mq_getsetattr", "mq_notify", "mq_open", "mq_timedreceive",
-        "mq_timedsend", "mq_unlink", "mremap", "msgctl", "msgget", "msgrcv",
-        "msgsnd", "msync", "munlock", "munlockall", "munmap", "nanosleep",
-        "newfstatat", "open", "openat", "pause", "pipe", "pipe2", "poll",
-        "ppoll", "prctl", "pread64", "preadv", "preadv2", "prlimit64", "pselect6",
-        "pwrite64", "pwritev", "pwritev2", "read", "readahead", "readlink",
-        "readlinkat", "readv", "recv", "recvfrom", "recvmmsg", "recvmsg",
-        "remap_file_pages", "removexattr", "rename", "renameat", "renameat2",
-        "restart_syscall", "rmdir", "rt_sigaction", "rt_sigpending", "rt_sigprocmask",
-        "rt_sigqueueinfo", "rt_sigreturn", "rt_sigsuspend", "rt_sigtimedwait",
-        "rt_tgsigqueueinfo", "sched_getaffinity", "sched_getattr", "sched_getparam",
-        "sched_get_priority_max", "sched_get_priority_min", "sched_getscheduler",
-        "sched_rr_get_interval", "sched_setaffinity", "sched_setattr", "sched_setparam",
-        "sched_setscheduler", "sched_yield", "seccomp", "select", "semctl",
-        "semget", "semop", "semtimedop", "send", "sendfile", "sendmmsg", "sendmsg",
-        "sendto", "setfsgid", "setfsuid", "setgid", "setgroups", "setitimer",
-        "setpgid", "setpriority", "setregid", "setresgid", "setresuid", "setreuid",
-        "setrlimit", "set_robust_list", "setsid", "setsockopt", "set_thread_area",
-        "set_tid_address", "setuid", "setxattr", "shmat", "shmctl", "shmdt",
-        "shmget", "shutdown", "sigaltstack", "signalfd", "signalfd4", "socket",
-        "socketpair", "splice", "stat", "statfs", "statx", "symlink", "symlinkat",
-        "sync", "sync_file_range", "syncfs", "sysinfo", "tee", "tgkill", "time",
-        "timer_create", "timer_delete", "timerfd_create", "timerfd_gettime",
-        "timerfd_settime", "timer_getoverrun", "timer_gettime", "timer_settime",
-        "times", "tkill", "truncate", "umask", "uname", "unlink", "unlinkat",
-        "utime", "utimensat", "utimes", "vfork", "vmsplice", "wait4", "waitid",
-        "write", "writev"
-      ],
-      "action": "SCMP_ACT_ALLOW"
-    },
-    {
-      "names": ["ptrace", "process_vm_readv", "process_vm_writev"],
-      "action": "SCMP_ACT_ERRNO",
-      "errnoRet": 1
-    }
-  ]
-}
+A seccomp profile (`tako_vm/seccomp_profile.json`) restricts dangerous syscalls like `ptrace`, `process_vm_readv`, and `process_vm_writev`. Enable it in your config:
+
+```yaml
+enable_seccomp: true
 ```
 
-### Update worker.py
+!!! warning "Seccomp does not block /proc reads"
+    Seccomp filters syscalls, not file paths. The `open` and `read` syscalls must be allowed for Python to function, so `/proc` files remain readable. Seccomp blocks other dangerous operations like process debugging.
 
-```python
-# In _run_container method (tako_vm/execution/worker.py)
+### Container Hardening
 
-# Add seccomp profile ALWAYS (not just when enabled)
-seccomp_path = Path(__file__).parent / "seccomp_profile.json"
-if seccomp_path.exists():
-    cmd.append(f"--security-opt=seccomp={seccomp_path}")
-else:
-    logger.warning("Default seccomp profile not found at %s", seccomp_path)
+Every container runs with:
+
+- `--cap-drop=ALL` — all Linux capabilities removed
+- `--read-only` — read-only root filesystem
+- `--network=none` — no network access (by default)
+- Non-root execution (uid 1000 via gosu)
+- Resource limits (memory, CPU, PIDs, file size)
+
+### gVisor Runtime
+
+When using gVisor (`container_runtime: runsc`), the userspace kernel provides an additional isolation boundary. gVisor intercepts syscalls and limits what `/proc` exposes compared to the host kernel.
+
+## Recommended Actions
+
+### Do Not Pass Secrets as Environment Variables
+
+This is the single most important mitigation. User code can read `/proc/self/environ` to extract any environment variable set on the container.
+
+**Instead of:**
+```yaml
+job_types:
+  - name: api-client
+    environment:
+      API_KEY: "sk-secret-123"  # Readable via /proc!
 ```
 
-### Update config.py
+**Use:**
+- Pass secrets through `/input/data.json` (mounted read-only, scoped to one job)
+- Use your platform's secret management (Vault, AWS Secrets Manager)
+- Use pre-built images with secrets baked in at build time (not at runtime)
 
-```python
-# Change default from False to True
-enable_seccomp: bool = True  # Enable by default
+### Enable gVisor for Production
 
-# Point to default profile
-seccomp_profile_path: Optional[Path] = Field(
-    default=Path(__file__).parent / "seccomp_profile.json",
-    description="Path to seccomp profile JSON"
-)
+gVisor's `/proc` implementation is more restricted than the host kernel's. Set:
+
+```yaml
+container_runtime: runsc
+security_mode: strict
 ```
 
-## 2. Mask Sensitive /proc Paths (Priority: HIGH)
+## Planned Mitigations
 
-### Option A: Use Docker's built-in masking (Docker 20.10+)
+These are tracked as future work:
 
-```python
-# In _run_container method
-cmd.extend([
-    # Mask environment variables
-    "--security-opt=mask=/proc/self/environ",
-    "--security-opt=mask=/proc/*/environ",
-])
-```
-
-### Option B: Custom AppArmor profile
-
-Create `config/apparmor-takvm` profile:
-
-```
-#include <tunables/global>
-
-profile takvm flags=(attach_disconnected,mediate_deleted) {
-  #include <abstractions/base>
-  #include <abstractions/python>
-
-  # Allow reading most of /proc
-  /proc/** r,
-
-  # DENY access to sensitive /proc paths
-  deny /proc/*/environ r,
-  deny /proc/self/environ r,
-  deny /proc/*/fd/** r,
-  deny /proc/self/fd/** r,
-
-  # Allow normal operations
-  /code/** r,
-  /input/** r,
-  /output/** rw,
-  /tmp/** rw,
-
-  # Python runtime
-  /usr/bin/python* rix,
-  /usr/lib/python*/** r,
-}
-```
-
-Apply in Docker:
-
-```python
-cmd.append("--security-opt=apparmor=takvm")
-```
-
-## 3. Remove Secrets from Environment Variables (Priority: CRITICAL)
-
-### Current Problem
-
-```python
-# INSECURE: Secrets passed as environment variables
-for key, value in job_type.environment.items():
-    cmd.append(f"--env={key}={value}")
-```
-
-### Solution: Use Read-Only Config Files
-
-```python
-def _prepare_config_file(self, job_type: JobType, input_dir: Path) -> None:
-    """Write job type configuration to read-only file instead of env vars."""
-    if job_type.environment:
-        config_data = {
-            "environment": job_type.environment,
-        }
-
-        config_file = input_dir / "_config.json"
-        config_file.write_text(json.dumps(config_data))
-        config_file.chmod(0o444)  # Read-only
-
-# In _run_container method:
-self._prepare_config_file(job_type, input_dir)
-
-# User code reads config from file:
-# with open('/input/_config.json') as f:
-#     config = json.load(f)
-```
-
-### Update Documentation
-
-Add to user-facing docs:
-
-```markdown
-## Accessing Configuration
-
-Configuration values are provided in `/input/_config.json` (not environment variables):
-
-```python
-import json
-
-with open('/input/_config.json') as f:
-    config = json.load(f)
-
-api_key = config['environment'].get('API_KEY')
-```
-
-**Security Note:** Never pass secrets via job submission. Use your platform's
-secret management for sensitive credentials.
-```
-
-## 4. Runtime Dependency Isolation (Priority: MEDIUM)
-
-### Current Problem
-
-```python
-# TAKO_REQUIREMENTS exposed in environment
-cmd.append(f"--env=TAKO_REQUIREMENTS={reqs_str}")
-```
-
-### Solution: Pre-install deps in entrypoint from file
-
-```bash
-# In docker/entrypoint.sh
-
-# Read requirements from file instead of env var
-if [ -f /input/_requirements.txt ]; then
-    uv pip install -r /input/_requirements.txt
-fi
-```
-
-```python
-# In _run_container method
-if validated_reqs:
-    reqs_file = input_dir / "_requirements.txt"
-    reqs_file.write_text("\n".join(validated_reqs))
-    reqs_file.chmod(0o444)
-    # No longer need: cmd.append(f"--env=TAKO_REQUIREMENTS={reqs_str}")
-```
-
-## 5. Documentation Updates (Priority: HIGH)
-
-### Add to docs/deployment/security.md
-
-```markdown
-## Known Limitations
-
-### /proc Filesystem Access
-
-User code has read access to the `/proc` filesystem, which can expose:
-- Container process information
-- File descriptors of open files
-- Limited host system metadata
-
-**Mitigations:**
-1. Do NOT pass secrets via environment variables
-2. Use seccomp profiles to block dangerous syscalls
-3. Consider AppArmor/SELinux for additional restrictions
-
-**Reference:** [/proc Exposure Vulnerability Analysis](../security/proc-exposure-vulnerability.md)
-```
-
-### Add to README.md
-
-```markdown
-## Security Considerations
-
-Tako VM uses Docker for isolation but has known limitations:
-
-- ⚠️ User code can read `/proc` filesystem (process info, file descriptors)
-- ✅ Network isolated by default (`--network=none`)
-- ✅ Read-only root filesystem
-- ✅ Runs as non-root user (uid 1000)
-- ✅ Seccomp profile blocks dangerous syscalls
-
-**For production use:**
-1. Enable all security features in `tako_vm.yaml`
-2. Never pass secrets via environment variables
-3. Use pre-built images for network-isolated execution
-4. Monitor execution logs for suspicious activity
-
-See [Security Documentation](docs/deployment/security.md) for details.
-```
-
-## 6. Testing Mitigations
-
-Create `tests/test_security_mitigations.py`:
-
-```python
-def test_proc_environ_blocked_with_seccomp(executor):
-    """Verify /proc/self/environ is blocked when seccomp is enabled."""
-    code = """
-try:
-    with open('/proc/self/environ', 'rb') as f:
-        data = f.read()
-    result = "FAIL: /proc/self/environ is readable"
-except PermissionError:
-    result = "PASS: /proc/self/environ is blocked"
-except Exception as e:
-    result = f"PASS: Access prevented ({type(e).__name__})"
-
-with open('/output/result.json', 'w') as f:
-    import json
-    json.dump({"result": result}, f)
-"""
-    # Test with seccomp enabled
-    executor.config.enable_seccomp = True
-    job = {"code": code, "input_data": {}}
-    result = executor.execute_job(job)
-
-    assert "PASS" in result["output"]["result"]
-```
-
-## Implementation Roadmap
-
-1. **Phase 1 - Quick Wins (Week 1)**
-   - [ ] Add seccomp profile to `config/`
-   - [ ] Enable seccomp by default in config.py
-   - [ ] Update documentation with limitations
-   - [ ] Add warning to logs when env vars contain "secret", "key", "token", "password"
-
-2. **Phase 2 - Environment Variable Migration (Week 2)**
-   - [ ] Implement config file approach for job_type.environment
-   - [ ] Update entrypoint.sh to read requirements from file
-   - [ ] Migrate examples to use config files
-   - [ ] Add deprecation warning for env var secrets
-
-3. **Phase 3 - Advanced Hardening (Week 3-4)**
-   - [ ] Add AppArmor profile option
-   - [ ] Implement /proc masking
-   - [ ] Add security audit logging
-   - [ ] Create security test suite
-
-4. **Phase 4 - Production Hardening (Week 5+)**
-   - [ ] Add runtime security monitoring
-   - [ ] Implement secret scanning in submissions
-   - [ ] Add rate limiting and abuse detection
-   - [ ] Security audit by third party
-
-## Testing Plan
-
-```bash
-# Run security tests
-pytest tests/test_proc_exposure.py -v
-
-# Run with mitigations enabled
-TAKO_VM_ENABLE_SECCOMP=true pytest tests/test_security_mitigations.py -v
-
-# Verify no secrets in logs
-grep -r "password\|secret\|token" ~/.tako_vm/logs/
-```
+| Mitigation | Description | Status |
+|-----------|-------------|--------|
+| `/proc` path masking | Use Docker `--security-opt=mask=` to hide sensitive `/proc` paths | Planned |
+| AppArmor profile | Deny access to `/proc/*/environ` and `/proc/*/fd/` | Planned |
+| Config file migration | Move job type environment vars from env to read-only files | Planned |
+| Requirements via file | Pass `TAKO_REQUIREMENTS` via file instead of env var | Planned |
 
 ## References
 
+- [/proc Exposure Vulnerability Analysis](proc-exposure-vulnerability.md)
 - [Equixly: The False Security of AI Containers](https://equixly.com/blog/2025/11/04/path-traversal-ai-containers/)
 - [Docker Security Best Practices](https://docs.docker.com/engine/security/)
-- [Linux Security Modules (LSM)](https://www.kernel.org/doc/html/latest/admin-guide/LSM/)
-- [Seccomp BPF](https://www.kernel.org/doc/html/latest/userspace-api/seccomp_filter.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - Quick Start: getting-started/quickstart.md
     - Configuration: getting-started/configuration.md
   - Guide:
+    - Tutorial: guide/tutorial.md
     - Basic Execution: guide/basic-execution.md
     - Async Jobs: guide/async-jobs.md
     - Environments: guide/environments.md
@@ -60,6 +61,7 @@ nav:
     - How to Deploy: deployment/how-to-deploy.md
     - Production Setup: deployment/production.md
     - Scaling: deployment/scaling.md
+    - Operations: deployment/operations.md
     - Security: deployment/security.md
   - Security:
     - Mitigations: security/mitigations.md


### PR DESCRIPTION
## Summary

Fixes all 9 remaining documentation issues from the comprehensive docs audit.

### Issues Fixed

| Issue | Fix |
|-------|-----|
| Closes #29 | Clarify `pending` vs `queued` status with tables explaining queue vs record systems |
| Closes #30 | Remove all `tako-vm build` CLI references, replace with REST API `POST /job-types/{name}/build` |
| Closes #31 | Add prerequisites checklist with version check commands to installation.md |
| Closes #32 | Rewrite mitigations.md from issue-tracker format to proper docs (implemented vs planned) |
| Closes #33 | Add operational runbook (`docs/deployment/operations.md`) with failure scenarios and recovery |
| Closes #34 | Add "What Works Today" section and warning banners for planned features in scaling.md |
| Closes #38 | Add end-to-end tutorial (`docs/guide/tutorial.md`) with 6-step data processing pipeline |
| Closes #39 | Explain SDK `send()` execution model — code runs remotely, not locally |
| Closes #40 | Add security warnings about env var `/proc` exposure to quickstart and configuration |

### Files changed
- `docs/api/rest.md` — status value clarification
- `docs/api/sdk.md` — send() execution model explanation
- `docs/architecture.md` — remove tako-vm build from diagram
- `docs/deployment/operations.md` — **new** operational runbook
- `docs/deployment/scaling.md` — current vs planned clarity
- `docs/development/troubleshooting.md` — remove tako-vm build ref
- `docs/getting-started/configuration.md` — security warning + gVisor wording
- `docs/getting-started/installation.md` — prerequisites checklist
- `docs/getting-started/quickstart.md` — security warning
- `docs/guide/async-jobs.md` — status value clarification
- `docs/guide/custom-libraries.md` — remove tako-vm build ref
- `docs/guide/tutorial.md` — **new** end-to-end tutorial
- `docs/security/mitigations.md` — full rewrite as proper docs
- `mkdocs.yml` — add tutorial and operations to nav

## Test plan
- [x] `grep -rn "tako-vm build" docs/` returns 0 results
- [x] All modified docs read naturally in context
- [x] New files (operations.md, tutorial.md) are linked in mkdocs.yml nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)