### PR TITLE
Add session endpoints for long-lived sandbox containers

### DIFF
--- a/tako_vm/__init__.py
+++ b/tako_vm/__init__.py
@@ -58,12 +58,25 @@ from tako_vm.sdk.client import (
     send,
     send_raw,
 )
+from tako_vm.session import (
+    DEFAULT_SERVER_URL,
+    LocalTakoSession,
+    RemoteTakoSession,
+    SessionExecResult,
+    TakoSession,
+)
 
 __all__ = [
     # Sandbox (library-first interface)
     "Sandbox",
     "SandboxResult",
     "sandbox_run",
+    # Long-lived session (for roaming agents)
+    "TakoSession",
+    "LocalTakoSession",
+    "RemoteTakoSession",
+    "SessionExecResult",
+    "DEFAULT_SERVER_URL",
     # Main SDK functions
     "send",
     "send_raw",

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -39,6 +39,7 @@ from tako_vm.server.correlation import (
 )
 from tako_vm.server.limits import ApiProtectionMiddleware
 from tako_vm.server.queue import WorkerPool
+from tako_vm.server.sessions import SessionManager, create_sessions_router
 from tako_vm.storage import ExecutionStorage
 
 # Configure logging with correlation ID support
@@ -121,10 +122,12 @@ class AppState:
     storage: ExecutionStorage
     worker_pool: WorkerPool
     idempotency_locks: IdempotencyLockManager
+    session_manager: SessionManager
 
 
 state = AppState()
 state.idempotency_locks = IdempotencyLockManager()
+state.session_manager = SessionManager()
 
 
 def _get_runtime_config() -> TakoVMConfig:
@@ -203,6 +206,7 @@ async def lifespan(app: FastAPI):
         pass
     await state.worker_pool.stop()
     await state.storage.close()
+    state.session_manager.shutdown()
 
 
 app = FastAPI(
@@ -217,6 +221,9 @@ app.add_middleware(ApiProtectionMiddleware, config_getter=_get_runtime_config)
 
 # Add correlation ID middleware (must be added before other middleware)
 app.add_middleware(CorrelationIdMiddleware)
+
+# Roaming-agent session endpoints
+app.include_router(create_sessions_router(state.session_manager))
 
 
 # Request/Response Models

--- a/tako_vm/server/sessions.py
+++ b/tako_vm/server/sessions.py
@@ -1,0 +1,283 @@
+"""Server-side session management for long-lived sandbox containers.
+
+Holds a dict of ``session_id → container_name`` in process memory and
+exposes four endpoints:
+
+- ``POST /sessions`` — start a container, return a session_id.
+- ``POST /sessions/{session_id}/exec`` — run a shell command in that
+  container and return stdout/stderr/exit_code.
+- ``DELETE /sessions/{session_id}`` — kill and remove the container.
+- ``GET /sessions/{session_id}`` — introspect a session (for debugging).
+
+The workspace path supplied in ``POST /sessions`` is bind-mounted into
+the container. The server and the path must be reachable at the same
+absolute path on the host so the host Docker daemon can resolve it when
+the tako-server container spawns sandbox siblings — the
+``/tmp/tako-vm-workspace/...`` convention in ``docker-compose.yml``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from tako_vm.constants import DEFAULT_IMAGE
+from tako_vm.execution.docker import generate_container_name, kill_container
+from tako_vm.session import (
+    DEFAULT_SESSION_TIMEOUT,
+    DEFAULT_WORKSPACE_MOUNT,
+    build_session_docker_command,
+    ensure_workspace_writable,
+    run_docker_exec,
+)
+
+logger = logging.getLogger(__name__)
+
+WORKSPACE_PREFIX_ALLOWLIST = ["/tmp/tako-vm-workspace", "/tmp/tako-vm-sessions"]
+
+
+@dataclass
+class _SessionRecord:
+    session_id: str
+    container_name: str
+    workspace: Path
+    workspace_mount: str
+    image: str
+    network_enabled: bool
+    info_extra: Dict[str, Any] = field(default_factory=dict)
+
+
+class SessionManager:
+    """In-memory registry of live sandbox sessions on this server."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, _SessionRecord] = {}
+        self._lock = threading.Lock()
+
+    def create(
+        self,
+        workspace: Path,
+        image: str,
+        memory_limit: str,
+        cpu_limit: float,
+        network_enabled: bool,
+        workspace_mount: str,
+        enable_cap_restrictions: bool,
+    ) -> _SessionRecord:
+        _validate_workspace(workspace)
+        ensure_workspace_writable(workspace)
+
+        session_id = uuid.uuid4().hex
+        container_name = generate_container_name("tako-session")
+        cmd = build_session_docker_command(
+            container_name=container_name,
+            workspace=workspace,
+            image=image,
+            memory_limit=memory_limit,
+            cpu_limit=cpu_limit,
+            network_enabled=network_enabled,
+            workspace_mount=workspace_mount,
+            enable_cap_restrictions=enable_cap_restrictions,
+        )
+        logger.info(
+            "Starting session %s (container=%s, workspace=%s)",
+            session_id,
+            container_name,
+            workspace,
+        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"docker run failed: {result.stderr.strip()}"
+            )
+
+        record = _SessionRecord(
+            session_id=session_id,
+            container_name=container_name,
+            workspace=workspace,
+            workspace_mount=workspace_mount,
+            image=image,
+            network_enabled=network_enabled,
+        )
+        with self._lock:
+            self._sessions[session_id] = record
+        return record
+
+    def get(self, session_id: str) -> Optional[_SessionRecord]:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def delete(self, session_id: str) -> bool:
+        with self._lock:
+            record = self._sessions.pop(session_id, None)
+        if record is None:
+            return False
+        kill_container(record.container_name)
+        return True
+
+    def list_ids(self) -> list[str]:
+        with self._lock:
+            return list(self._sessions.keys())
+
+    def shutdown(self) -> None:
+        """Kill every live session. Called on server shutdown."""
+        with self._lock:
+            records = list(self._sessions.values())
+            self._sessions.clear()
+        for r in records:
+            try:
+                kill_container(r.container_name)
+            except Exception:
+                logger.exception(
+                    "Error killing session container %s", r.container_name
+                )
+
+
+def _validate_workspace(workspace: Path) -> None:
+    resolved = workspace.resolve()
+    for allowed in WORKSPACE_PREFIX_ALLOWLIST:
+        allowed_path = Path(allowed).resolve()
+        try:
+            resolved.relative_to(allowed_path)
+            return
+        except ValueError:
+            continue
+    raise ValueError(
+        f"workspace must be under one of {WORKSPACE_PREFIX_ALLOWLIST}, got {resolved}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FastAPI request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateSessionRequest(BaseModel):
+    workspace: str = Field(
+        ...,
+        description=(
+            "Absolute host path of the workspace, under "
+            "/tmp/tako-vm-workspace/ so the server can bind-mount it."
+        ),
+    )
+    image: str = Field(default=DEFAULT_IMAGE)
+    memory_limit: str = Field(default="512m")
+    cpu_limit: float = Field(default=1.0, gt=0)
+    network_enabled: bool = Field(default=False)
+    workspace_mount: str = Field(default=DEFAULT_WORKSPACE_MOUNT)
+    enable_cap_restrictions: bool = Field(default=True)
+
+
+class CreateSessionResponse(BaseModel):
+    session_id: str
+    container_name: str
+    workspace: str
+    workspace_mount: str
+
+
+class ExecRequest(BaseModel):
+    command: str = Field(..., min_length=1, max_length=100_000)
+    cwd: Optional[str] = Field(default=None)
+    timeout: int = Field(default=DEFAULT_SESSION_TIMEOUT, gt=0, le=600)
+    env: Optional[Dict[str, str]] = Field(default=None)
+
+
+class ExecResponse(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int
+    duration_ms: int
+    timed_out: bool
+
+
+class SessionInfoResponse(BaseModel):
+    session_id: str
+    container_name: str
+    workspace: str
+    workspace_mount: str
+    image: str
+    network_enabled: bool
+
+
+def create_sessions_router(manager: SessionManager) -> APIRouter:
+    """Build the FastAPI router. Called from ``app.py`` with the singleton manager."""
+    router = APIRouter()
+
+    @router.post(
+        "/sessions",
+        response_model=CreateSessionResponse,
+        status_code=201,
+    )
+    def create_session(req: CreateSessionRequest) -> CreateSessionResponse:
+        try:
+            record = manager.create(
+                workspace=Path(req.workspace),
+                image=req.image,
+                memory_limit=req.memory_limit,
+                cpu_limit=req.cpu_limit,
+                network_enabled=req.network_enabled,
+                workspace_mount=req.workspace_mount,
+                enable_cap_restrictions=req.enable_cap_restrictions,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except RuntimeError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        return CreateSessionResponse(
+            session_id=record.session_id,
+            container_name=record.container_name,
+            workspace=str(record.workspace),
+            workspace_mount=record.workspace_mount,
+        )
+
+    @router.post("/sessions/{session_id}/exec", response_model=ExecResponse)
+    def exec_in_session(session_id: str, req: ExecRequest) -> ExecResponse:
+        record = manager.get(session_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="session not found")
+        cwd = req.cwd if req.cwd is not None else record.workspace_mount
+        result = run_docker_exec(
+            container_name=record.container_name,
+            command=req.command,
+            cwd=cwd,
+            timeout=req.timeout,
+            env=req.env,
+        )
+        return ExecResponse(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.exit_code,
+            duration_ms=result.duration_ms,
+            timed_out=result.timed_out,
+        )
+
+    @router.get("/sessions/{session_id}", response_model=SessionInfoResponse)
+    def get_session(session_id: str) -> SessionInfoResponse:
+        record = manager.get(session_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="session not found")
+        return SessionInfoResponse(
+            session_id=record.session_id,
+            container_name=record.container_name,
+            workspace=str(record.workspace),
+            workspace_mount=record.workspace_mount,
+            image=record.image,
+            network_enabled=record.network_enabled,
+        )
+
+    @router.delete("/sessions/{session_id}", status_code=204)
+    def delete_session(session_id: str) -> None:
+        ok = manager.delete(session_id)
+        if not ok:
+            raise HTTPException(status_code=404, detail="session not found")
+        return None
+
+    return router

--- a/tako_vm/session.py
+++ b/tako_vm/session.py
@@ -1,0 +1,400 @@
+"""Long-lived sandbox sessions for roaming agents.
+
+A *session* is a container that stays up across many ``exec`` calls
+against a shared workspace. Two backends are provided:
+
+- :class:`LocalTakoSession` — talks directly to the local Docker daemon
+  via ``docker run -d`` / ``docker exec``. Useful for offline dev or
+  machines that don't have a tako-vm server running.
+- :class:`RemoteTakoSession` — talks to a tako-vm server over HTTP
+  (``POST /sessions`` / ``POST /sessions/{id}/exec`` /
+  ``DELETE /sessions/{id}``). This is the default; it matches the
+  production architecture where the server owns the sandbox plane.
+
+``TakoSession`` is an alias for :class:`RemoteTakoSession`. Instantiate
+that directly if you want the HTTP backend explicitly, or use
+:class:`LocalTakoSession` if you want the local-docker fallback.
+
+Example (remote)::
+
+    from pathlib import Path
+    from tako_vm import TakoSession
+
+    with TakoSession(workspace=Path("/tmp/tako-vm-workspace/agent-abc")) as s:
+        print(s.exec("ls /workspace").stdout)
+
+Example (local)::
+
+    from tako_vm import LocalTakoSession
+
+    with LocalTakoSession(workspace=Path("/tmp/agent-ws")) as s:
+        print(s.exec("echo hi").stdout)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from tako_vm.constants import DEFAULT_IMAGE
+from tako_vm.execution.docker import generate_container_name, kill_container
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WORKSPACE_MOUNT = "/workspace"
+DEFAULT_SESSION_TIMEOUT = 60
+DEFAULT_SERVER_URL = os.environ.get("TAKO_SERVER_URL", "http://localhost:8000")
+
+
+@dataclass
+class SessionExecResult:
+    """Result of a single ``exec`` call against a session."""
+
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+    duration_ms: int = 0
+    timed_out: bool = False
+
+
+def build_session_docker_command(
+    container_name: str,
+    workspace: Path,
+    image: str,
+    memory_limit: str,
+    cpu_limit: float,
+    network_enabled: bool,
+    workspace_mount: str,
+    enable_cap_restrictions: bool,
+) -> List[str]:
+    """Assemble the ``docker run -d`` command for a session container.
+
+    Shared by the local backend and the server-side session manager so
+    both end up with identical sandbox semantics.
+    """
+    cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        f"--name={container_name}",
+        "--init",
+        "--read-only",
+        "--user=1000:1000",
+        "--entrypoint=/bin/sleep",
+    ]
+    if enable_cap_restrictions:
+        cmd.append("--cap-drop=ALL")
+    cmd.append("--network=bridge" if network_enabled else "--network=none")
+    cmd.extend(
+        [
+            f"--memory={memory_limit}",
+            f"--memory-swap={memory_limit}",
+            f"--cpus={cpu_limit}",
+            "--pids-limit=200",
+            "--tmpfs=/tmp:rw,exec,nosuid,size=300m",
+            f"--mount=type=bind,source={workspace},target={workspace_mount}",
+            image,
+            "infinity",
+        ]
+    )
+    return cmd
+
+
+def run_docker_exec(
+    container_name: str,
+    command: str,
+    cwd: str,
+    timeout: int,
+    env: Optional[Dict[str, str]] = None,
+) -> SessionExecResult:
+    """Run ``docker exec ... bash -c "command"`` and return the result."""
+    exec_cmd: List[str] = ["docker", "exec", "-w", cwd]
+    if env:
+        for k, v in env.items():
+            exec_cmd.extend(["-e", f"{k}={v}"])
+    exec_cmd.extend([container_name, "bash", "-c", command])
+
+    start = time.time()
+    try:
+        proc = subprocess.run(
+            exec_cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+        duration_ms = int((time.time() - start) * 1000)
+        return SessionExecResult(
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            exit_code=proc.returncode,
+            duration_ms=duration_ms,
+            timed_out=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        duration_ms = int((time.time() - start) * 1000)
+        return SessionExecResult(
+            stdout=e.stdout.decode("utf-8", "replace") if e.stdout else "",
+            stderr=e.stderr.decode("utf-8", "replace") if e.stderr else "",
+            exit_code=-1,
+            duration_ms=duration_ms,
+            timed_out=True,
+        )
+
+
+def ensure_workspace_writable(workspace: Path) -> None:
+    """Make the workspace writable by the sandbox user (uid 1000).
+
+    The image runs as uid 1000. For local dev we chmod 0o777; production
+    should set up UID remapping or match host/container UIDs.
+    """
+    if not workspace.exists():
+        workspace.mkdir(parents=True)
+    if not workspace.is_dir():
+        raise ValueError(f"Workspace is not a directory: {workspace}")
+    try:
+        os.chmod(workspace, 0o777)
+    except PermissionError:
+        logger.warning(
+            "Could not chmod workspace %s to 0777; writes from the "
+            "sandbox user may fail.",
+            workspace,
+        )
+
+
+class LocalTakoSession:
+    """Session backed by the local Docker daemon.
+
+    Use when you don't have a tako-vm server running (tests, CLI tools,
+    offline dev).
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        image: str = DEFAULT_IMAGE,
+        memory_limit: str = "512m",
+        cpu_limit: float = 1.0,
+        network_enabled: bool = False,
+        workspace_mount: str = DEFAULT_WORKSPACE_MOUNT,
+        enable_cap_restrictions: bool = True,
+    ) -> None:
+        self.workspace = workspace.resolve()
+        self.image = image
+        self.memory_limit = memory_limit
+        self.cpu_limit = cpu_limit
+        self.network_enabled = network_enabled
+        self.workspace_mount = workspace_mount
+        self.enable_cap_restrictions = enable_cap_restrictions
+        self.container_name: Optional[str] = None
+        self._started = False
+
+    def __enter__(self) -> "LocalTakoSession":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+
+    def start(self) -> None:
+        if self._started:
+            return
+        ensure_workspace_writable(self.workspace)
+        self.container_name = generate_container_name("tako-session")
+        cmd = build_session_docker_command(
+            container_name=self.container_name,
+            workspace=self.workspace,
+            image=self.image,
+            memory_limit=self.memory_limit,
+            cpu_limit=self.cpu_limit,
+            network_enabled=self.network_enabled,
+            workspace_mount=self.workspace_mount,
+            enable_cap_restrictions=self.enable_cap_restrictions,
+        )
+        logger.debug("Starting session container: %s", " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to start session container: {result.stderr.strip()}"
+            )
+        self._started = True
+
+    def exec(
+        self,
+        command: str,
+        cwd: Optional[str] = None,
+        timeout: int = DEFAULT_SESSION_TIMEOUT,
+        env: Optional[Dict[str, str]] = None,
+    ) -> SessionExecResult:
+        if not self._started or self.container_name is None:
+            raise RuntimeError("Session is not started; call start() first")
+        working_dir = cwd if cwd is not None else self.workspace_mount
+        return run_docker_exec(
+            self.container_name, command, working_dir, timeout, env
+        )
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+        if self.container_name is not None:
+            kill_container(self.container_name)
+        self._started = False
+        self.container_name = None
+
+    def info(self) -> Dict[str, Any]:
+        return {
+            "backend": "local",
+            "container_name": self.container_name,
+            "started": self._started,
+            "workspace": str(self.workspace),
+            "workspace_mount": self.workspace_mount,
+            "image": self.image,
+        }
+
+
+class RemoteTakoSession:
+    """Session backed by a tako-vm server over HTTP.
+
+    The server owns the sandbox container and does all Docker operations.
+    The client passes a workspace path that must be reachable by the
+    server at the same absolute path (this is the
+    ``/tmp/tako-vm-workspace/...`` shared-bind-mount convention from
+    ``docker-compose.yml``).
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        server_url: str = DEFAULT_SERVER_URL,
+        image: Optional[str] = None,
+        memory_limit: Optional[str] = None,
+        cpu_limit: Optional[float] = None,
+        network_enabled: Optional[bool] = None,
+        workspace_mount: str = DEFAULT_WORKSPACE_MOUNT,
+        enable_cap_restrictions: Optional[bool] = None,
+        request_timeout: float = 30.0,
+    ) -> None:
+        self.workspace = workspace.resolve()
+        self.server_url = server_url.rstrip("/")
+        self.image = image
+        self.memory_limit = memory_limit
+        self.cpu_limit = cpu_limit
+        self.network_enabled = network_enabled
+        self.workspace_mount = workspace_mount
+        self.enable_cap_restrictions = enable_cap_restrictions
+        self.request_timeout = request_timeout
+        self.session_id: Optional[str] = None
+        self.container_name: Optional[str] = None
+        self._client: Optional[httpx.Client] = None
+
+    def __enter__(self) -> "RemoteTakoSession":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+
+    def _http(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self.server_url, timeout=self.request_timeout
+            )
+        return self._client
+
+    def start(self) -> None:
+        if self.session_id is not None:
+            return
+        # Ensure the workspace is writable by the sandbox user. The server
+        # sees the same path via the shared bind mount, so we prep it here
+        # on the client side.
+        ensure_workspace_writable(self.workspace)
+
+        payload: Dict[str, Any] = {
+            "workspace": str(self.workspace),
+            "workspace_mount": self.workspace_mount,
+        }
+        if self.image is not None:
+            payload["image"] = self.image
+        if self.memory_limit is not None:
+            payload["memory_limit"] = self.memory_limit
+        if self.cpu_limit is not None:
+            payload["cpu_limit"] = self.cpu_limit
+        if self.network_enabled is not None:
+            payload["network_enabled"] = self.network_enabled
+        if self.enable_cap_restrictions is not None:
+            payload["enable_cap_restrictions"] = self.enable_cap_restrictions
+
+        resp = self._http().post("/sessions", json=payload)
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Failed to create session ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json()
+        self.session_id = data["session_id"]
+        self.container_name = data.get("container_name")
+
+    def exec(
+        self,
+        command: str,
+        cwd: Optional[str] = None,
+        timeout: int = DEFAULT_SESSION_TIMEOUT,
+        env: Optional[Dict[str, str]] = None,
+    ) -> SessionExecResult:
+        if self.session_id is None:
+            raise RuntimeError("Session is not started; call start() first")
+        payload: Dict[str, Any] = {"command": command, "timeout": timeout}
+        if cwd is not None:
+            payload["cwd"] = cwd
+        if env:
+            payload["env"] = env
+        resp = self._http().post(
+            f"/sessions/{self.session_id}/exec",
+            json=payload,
+            timeout=timeout + self.request_timeout,
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"exec failed ({resp.status_code}): {resp.text}"
+            )
+        data = resp.json()
+        return SessionExecResult(
+            stdout=data.get("stdout", ""),
+            stderr=data.get("stderr", ""),
+            exit_code=data.get("exit_code", 0),
+            duration_ms=data.get("duration_ms", 0),
+            timed_out=data.get("timed_out", False),
+        )
+
+    def stop(self) -> None:
+        if self.session_id is None:
+            return
+        try:
+            self._http().delete(f"/sessions/{self.session_id}")
+        except Exception as e:
+            logger.warning("Failed to stop session %s: %s", self.session_id, e)
+        finally:
+            self.session_id = None
+            self.container_name = None
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+
+    def info(self) -> Dict[str, Any]:
+        return {
+            "backend": "remote",
+            "server_url": self.server_url,
+            "session_id": self.session_id,
+            "container_name": self.container_name,
+            "workspace": str(self.workspace),
+            "workspace_mount": self.workspace_mount,
+        }
+
+
+# ``TakoSession`` is the default client class. The HTTP backend is the
+# production path; use ``LocalTakoSession`` explicitly when you want the
+# offline fallback.
+TakoSession = RemoteTakoSession


### PR DESCRIPTION
Roaming-agent support (see outerport-backend
internal-docs/design/roaming-agents/ for the broader design). A session is a container that stays up across many exec calls against a shared workspace — the primitive an agent's Bash tool hangs off of.

- tako_vm/session.py: client-facing session classes. RemoteTakoSession talks to this server over HTTP (default), and LocalTakoSession talks directly to the local Docker daemon as an offline fallback. Shared helpers (build_session_docker_command, run_docker_exec, ensure_workspace_writable) are reused by the server-side manager so both paths have identical sandbox semantics.

- tako_vm/server/sessions.py: SessionManager + FastAPI router. Endpoints: POST /sessions, POST /sessions/{id}/exec, GET /sessions/{id}, DELETE /sessions/{id}. State is in-memory; the startup-cleanup routine already reaps orphaned tako-session-* containers on boot.

- Workspace paths are validated against a prefix allowlist (/tmp/tako-vm-workspace by default) so the host and the tako-server container resolve the same absolute path when docker-compose mounts are in place.

Session containers run "sleep infinity" as entrypoint (bypassing the existing image entrypoint that installs deps and runs code). Each exec is an independent docker exec — filesystem state under /workspace persists, shell state (cwd/env/bg procs) does not. This is a deliberate simplification, documented in the design doc; persistent shells can be added later if agent workflows need them.