### PR TITLE
Harden execution ID and workflow validation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -39,6 +39,7 @@ from tako_vm.security import (
     validate_docker_image,
     validate_env_key,
     validate_env_value,
+    validate_execution_id,
     validate_pip_requirement,
 )
 
@@ -46,6 +47,15 @@ logger = logging.getLogger(__name__)
 
 # Cache for runtime availability check
 _gvisor_available: Optional[bool] = None
+
+
+def _require_safe_execution_id(execution_id: str) -> str:
+    """Reject execution IDs that are unsafe for filesystem-backed storage."""
+    if not validate_execution_id(execution_id):
+        raise ValueError(
+            "Execution ID must be 1-64 chars of letters, numbers, '.', '_' or '-'"
+        )
+    return execution_id
 
 
 def check_gvisor_available() -> bool:
@@ -311,7 +321,7 @@ class CodeExecutor:
                 - error: Error message (if failed)
                 - job_type: Name of job type used
         """
-        job_id = job.get("id", str(int(time.time() * 1000)))
+        job_id = _require_safe_execution_id(job.get("id", str(int(time.time() * 1000))))
 
         # Get job type configuration
         job_type = self._get_job_type(job.get("job_type"))
@@ -396,6 +406,8 @@ class CodeExecutor:
         Returns:
             ExecutionRecord with complete audit trail
         """
+        job_id = _require_safe_execution_id(job_id)
+
         # Create initial record
         code = job.get("code", "")
         input_data = job.get("input_data", {})
@@ -640,6 +652,7 @@ class CodeExecutor:
         """
         artifacts = []
         total_size = 0
+        job_id = _require_safe_execution_id(job_id)
 
         if not output_dir.exists():
             return artifacts
@@ -709,6 +722,7 @@ class CodeExecutor:
             List of InputArtifact objects for the stored files
         """
         replay_artifacts = []
+        execution_id = _require_safe_execution_id(execution_id)
         runs_dir = self.config.data_dir / "runs" / execution_id
 
         try:

--- a/tako_vm/security.py
+++ b/tako_vm/security.py
@@ -472,14 +472,40 @@ def validate_python_version(version: str) -> bool:
     return bool(_PYTHON_VERSION_PATTERN.match(version))
 
 
-# Pattern for pip package specifier (simplified PEP 508)
-# Allows: package-name, package_name, package[extra], package>=1.0, etc.
-_PIP_PACKAGE_PATTERN = re.compile(
-    r"^[a-zA-Z0-9][-a-zA-Z0-9._]*"  # Package name
-    r"(?:\[[a-zA-Z0-9][-a-zA-Z0-9,._]*\])?"  # Optional extras
-    r"(?:[<>=!~]+[a-zA-Z0-9.*+!-]+(?:,[<>=!~]+[a-zA-Z0-9.*+!-]+)*)?"  # Optional version
-    r"$"
+_SAFE_EXECUTION_ID_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
 )
+_SAFE_PIP_NAME_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._"
+)
+_SAFE_PIP_VERSION_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.*+!-"
+)
+_SAFE_PIP_OPERATOR_CHARS = frozenset("<>=!~")
+
+
+def validate_execution_id(value: str) -> bool:
+    """
+    Validate an execution/job ID before using it in filesystem paths.
+
+    The same identifier is also reused in Docker container names, so the
+    character set stays intentionally conservative.
+    """
+    if not value or len(value) > 64:
+        return False
+    if value in (".", "..") or value.startswith("."):
+        return False
+    if "/" in value or "\\" in value:
+        return False
+    return all(char in _SAFE_EXECUTION_ID_CHARS for char in value)
+
+
+def _consume_token(value: str, start: int, allowed_chars: frozenset[str]) -> int:
+    """Consume a non-empty token made of allowed characters."""
+    index = start
+    while index < len(value) and value[index] in allowed_chars:
+        index += 1
+    return index
 
 
 def validate_pip_requirement(requirement: str) -> bool:
@@ -515,4 +541,48 @@ def validate_pip_requirement(requirement: str) -> bool:
         if pattern in requirement:
             return False
 
-    return bool(_PIP_PACKAGE_PATTERN.match(requirement))
+    # Parse a conservative subset of PEP 508 in linear time:
+    # package-name
+    # package-name[extra,extra2]
+    # package-name>=1.0,!=2.0
+    index = _consume_token(requirement, 0, _SAFE_PIP_NAME_CHARS)
+    if index == 0:
+        return False
+
+    # Optional extras block: [extra,extra2]
+    if index < len(requirement) and requirement[index] == "[":
+        index += 1
+        while True:
+            extra_end = _consume_token(requirement, index, _SAFE_PIP_NAME_CHARS)
+            if extra_end == index:
+                return False
+            index = extra_end
+
+            if index >= len(requirement):
+                return False
+            if requirement[index] == "]":
+                index += 1
+                break
+            if requirement[index] != ",":
+                return False
+            index += 1
+
+    # Optional version clauses: >=1.0,!=2.0
+    while index < len(requirement):
+        op_end = _consume_token(requirement, index, _SAFE_PIP_OPERATOR_CHARS)
+        if op_end == index:
+            return False
+        index = op_end
+
+        version_end = _consume_token(requirement, index, _SAFE_PIP_VERSION_CHARS)
+        if version_end == index:
+            return False
+        index = version_end
+
+        if index == len(requirement):
+            return True
+        if requirement[index] != ",":
+            return False
+        index += 1
+
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,17 @@ def pytest_collection_modifyitems(config, items):
             if not DOCKER_AVAILABLE:
                 item.add_marker(pytest.mark.skip(reason="Docker not available"))
 
+        # Auto-skip proc exposure tests if Docker/executor image not available
+        if "test_proc_exposure" in item.nodeid:
+            if not DOCKER_AVAILABLE:
+                item.add_marker(pytest.mark.skip(reason="Docker not available"))
+            elif not EXECUTOR_IMAGE_AVAILABLE:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="Executor image not built. Run: docker build -t code-executor:latest -f docker/Dockerfile.executor ."
+                    )
+                )
+
         # Skip tests that require host mounts when running in a VM
         if item.get_closest_marker("requires_host_mounts"):
             if RUNNING_IN_VM:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,86 @@
+"""Tests for security validation helpers."""
+
+import pytest
+
+import tako_vm.execution.worker as worker_module
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution import CodeExecutor
+from tako_vm.security import validate_execution_id, validate_pip_requirement
+
+
+class TestValidateExecutionId:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "550e8400-e29b-41d4-a716-446655440000",
+            "api-1700000000000",
+            "job_v1.2",
+            "abc123-def456",
+            "record-01",
+            "idem-test",
+            "failed-job-123",
+        ],
+    )
+    def test_accepts_existing_repo_id_formats(self, value):
+        assert validate_execution_id(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", ".", "..", "../escape", "nested/path", r"windows\\path", ".hidden", "a" * 65],
+    )
+    def test_rejects_unsafe_ids(self, value):
+        assert validate_execution_id(value) is False
+
+
+class TestValidatePipRequirement:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "numpy",
+            "pandas>=2.0",
+            "numpy>=1.20",
+            "requests[security]",
+            "flask[async]",
+            "pkg[one,two]!=1.0,>=0.9",
+        ],
+    )
+    def test_accepts_supported_requirement_forms(self, value):
+        assert validate_pip_requirement(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "git+https://example.com/pkg",
+            "pkg @ https://example.com/pkg.whl",
+            "pkg; python_version>'3.10'",
+            "pkg[",
+            "pkg[]",
+            "pkg>=,1.0",
+        ],
+    )
+    def test_rejects_unsafe_or_malformed_forms(self, value):
+        assert validate_pip_requirement(value) is False
+
+
+class TestExecutorRejectsUnsafeIds:
+    @pytest.fixture(autouse=True)
+    def mock_gvisor_available(self, monkeypatch):
+        monkeypatch.setattr(worker_module, "_gvisor_available", True)
+
+    def test_execute_job_rejects_path_traversal_ids(self):
+        executor = CodeExecutor(config=TakoVMConfig(container_runtime="runsc", security_mode="strict"))
+
+        with pytest.raises(ValueError, match="Execution ID must be"):
+            executor.execute_job({"id": "../escape", "code": "print('hi')", "input_data": {}})
+
+    def test_execute_job_with_record_accepts_existing_repo_id_formats(self):
+        executor = CodeExecutor(config=TakoVMConfig(container_runtime="runsc", security_mode="strict"))
+
+        record = executor.execute_job_with_record(
+            "550e8400-e29b-41d4-a716-446655440000",
+            {"code": "print('hi')", "input_data": {}},
+        )
+
+        assert record.execution_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert record.status in {"queued", "failed", "running", "succeeded"}


### PR DESCRIPTION
## Summary
- validate execution IDs before using them in filesystem-backed worker paths
- replace the pip requirement regex with linear validation logic
- add explicit GitHub Actions permissions and regression coverage

## Verification
- ruff check on edited Python files
- full test suite: 260 passed, 70 skipped
- Docker-backed proc exposure tests: 5 passed, 1 skipped
