### PR TITLE
Fix ruff formatting on main

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -52,9 +52,7 @@ _gvisor_available: Optional[bool] = None
 def _require_safe_execution_id(execution_id: str) -> str:
     """Reject execution IDs that are unsafe for filesystem-backed storage."""
     if not validate_execution_id(execution_id):
-        raise ValueError(
-            "Execution ID must be 1-64 chars of letters, numbers, '.', '_' or '-'"
-        )
+        raise ValueError("Execution ID must be 1-64 chars of letters, numbers, '.', '_' or '-'")
     return execution_id
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -69,13 +69,17 @@ class TestExecutorRejectsUnsafeIds:
         monkeypatch.setattr(worker_module, "_gvisor_available", True)
 
     def test_execute_job_rejects_path_traversal_ids(self):
-        executor = CodeExecutor(config=TakoVMConfig(container_runtime="runsc", security_mode="strict"))
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
 
         with pytest.raises(ValueError, match="Execution ID must be"):
             executor.execute_job({"id": "../escape", "code": "print('hi')", "input_data": {}})
 
     def test_execute_job_with_record_accepts_existing_repo_id_formats(self):
-        executor = CodeExecutor(config=TakoVMConfig(container_runtime="runsc", security_mode="strict"))
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
 
         record = executor.execute_job_with_record(
             "550e8400-e29b-41d4-a716-446655440000",


### PR DESCRIPTION
## Summary
- apply ruff formatting to files introduced by the security hardening change

## Verification
- ruff check .
- ruff format --check .
- .venv/bin/pytest tests/test_security.py tests/test_docker_utils.py tests/test_storage.py -q
