### PR TITLE
Fix runtime review findings

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,11 @@ get_time_ms() {
     echo $(($(date +%s%N) / 1000000))
 }
 
+write_total_time() {
+    END_TOTAL=$(get_time_ms)
+    echo "total_ms=$((END_TOTAL - START_TOTAL))" >> "$PHASE_FILE"
+}
+
 # Initialize phase tracking
 START_TOTAL=$(get_time_ms)
 echo "container_start_ms=$START_TOTAL" > "$PHASE_FILE"
@@ -35,7 +40,12 @@ if [ -n "$TAKO_REQUIREMENTS" ]; then
 
     # Capture install result (don't exit on error yet so we can record timing)
     set +e
-    uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE" 2>&1
+    if [ -n "$TAKO_STARTUP_TIMEOUT" ]; then
+        timeout --signal=TERM "${TAKO_STARTUP_TIMEOUT}s" \
+            uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE" 2>&1
+    else
+        uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE" 2>&1
+    fi
     DEP_EXIT_CODE=$?
     set -e
 
@@ -52,8 +62,10 @@ if [ -n "$TAKO_REQUIREMENTS" ]; then
 
     # Exit if dep install failed
     if [ $DEP_EXIT_CODE -ne 0 ]; then
+        echo "startup_ms=$((END_DEP - START_STARTUP))" >> "$PHASE_FILE"
         echo "phase=failed" >> "$PHASE_FILE"
         echo "failed_phase=startup" >> "$PHASE_FILE"
+        write_total_time
         exit $DEP_EXIT_CODE
     fi
 else
@@ -73,8 +85,14 @@ echo "execution_start_ms=$START_EXEC" >> "$PHASE_FILE"
 
 # Drop privileges and run user code as sandbox user
 # Using exec replaces this process, so we need a wrapper to capture timing
-gosu sandbox python -u /code/main.py
+set +e
+if [ -n "$TAKO_EXECUTION_TIMEOUT" ]; then
+    timeout --signal=TERM "${TAKO_EXECUTION_TIMEOUT}s" gosu sandbox python -u /code/main.py
+else
+    gosu sandbox python -u /code/main.py
+fi
 EXEC_EXIT_CODE=$?
+set -e
 
 # Record execution completion
 END_EXEC=$(get_time_ms)
@@ -90,7 +108,6 @@ else
 fi
 
 # Total time
-END_TOTAL=$(get_time_ms)
-echo "total_ms=$((END_TOTAL - START_TOTAL))" >> "$PHASE_FILE"
+write_total_time
 
 exit $EXEC_EXIT_CODE

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -45,7 +45,7 @@ def generate_container_name(prefix: str, job_id: Optional[str] = None) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:12]}"
 
 
-def kill_container(container_name: str) -> None:
+def kill_container(container_name: str) -> bool:
     """
     Kill and remove a container by name.
 
@@ -58,15 +58,23 @@ def kill_container(container_name: str) -> None:
 
     Args:
         container_name: Name of the container to kill
+
+    Returns:
+        True if Docker reported the container was killed, False otherwise
     """
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["docker", "kill", container_name],
             capture_output=True,
             timeout=10,
             check=False,
         )
-        logger.debug("Killed container %s", container_name)
+        if result.returncode == 0:
+            logger.debug("Killed container %s", container_name)
+            return True
+        logger.debug("Container %s was not running", container_name)
+        return False
     except Exception as e:
         # Ignore errors - container may not exist or already be stopped
         logger.debug("Failed to kill container %s: %s", container_name, e)
+        return False

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -331,13 +332,14 @@ class CodeExecutor:
                 - error: Error message (if failed)
                 - job_type: Name of job type used
         """
-        job_id = _require_safe_execution_id(job.get("id", str(int(time.time() * 1000))))
+        job_id = _require_safe_execution_id(job.get("id", uuid.uuid4().hex))
 
         # Get job type configuration
         job_type = self._get_job_type(job.get("job_type"))
 
         # Use job-specific timeout, or job type default
         timeout = job.get("timeout", job_type.timeout)
+        startup_timeout = job.get("startup_timeout", job_type.startup_timeout)
 
         # Create temporary workspace
         workspace = Path(tempfile.mkdtemp(prefix="job-", dir=WORKSPACE_DIR))
@@ -369,6 +371,7 @@ class CodeExecutor:
                 input_dir=input_dir,
                 output_dir=output_dir,
                 timeout=timeout,
+                startup_timeout=startup_timeout,
                 job_type=job_type,
                 extra_requirements=job.get("requirements"),
                 job_id=job_id,
@@ -456,6 +459,7 @@ class CodeExecutor:
             return record
 
         timeout = job.get("timeout", job_type.timeout)
+        startup_timeout = job.get("startup_timeout", job_type.startup_timeout)
 
         # Create temporary workspace
         workspace = Path(tempfile.mkdtemp(prefix="job-", dir=WORKSPACE_DIR))
@@ -509,6 +513,7 @@ class CodeExecutor:
                         input_dir=input_dir,
                         output_dir=output_dir,
                         timeout=timeout,
+                        startup_timeout=startup_timeout,
                         job_type=job_type,
                         extra_requirements=job.get("requirements"),
                         job_id=job_id,
@@ -580,17 +585,20 @@ class CodeExecutor:
             record.timing = timing
 
             # Determine which phase timed out (if applicable)
-            timeout_phase = determine_timeout_phase(timing, timed_out)
+            internal_timeout = result.get("exit_code") == 124 and determine_timeout_phase(
+                timing, True
+            )
+            timeout_phase = determine_timeout_phase(timing, timed_out) or internal_timeout
 
             # Determine final status with phase-aware timeout handling
-            if timed_out:
+            if timed_out or internal_timeout:
                 record.status = "timeout"
                 if timeout_phase == "startup":
                     startup_time = timing.startup_ms if timing else None
                     time_info = f" (startup took {startup_time}ms)" if startup_time else ""
                     record.error = ExecutionError(
                         type="startup_timeout",
-                        message=f"Startup phase exceeded time limit ({timeout}s){time_info}",
+                        message=f"Startup phase exceeded time limit ({startup_timeout}s){time_info}",
                         phase="startup",
                     )
                 elif timeout_phase == "execution":
@@ -782,6 +790,7 @@ class CodeExecutor:
         input_dir: Path,
         output_dir: Path,
         timeout: int,
+        startup_timeout: int,
         job_type: JobType,
         extra_requirements: Optional[List[str]] = None,
         job_id: Optional[str] = None,
@@ -793,7 +802,8 @@ class CodeExecutor:
             code_dir: Path to directory containing code (will be mounted read-only)
             input_dir: Path to directory containing input data (will be mounted read-only)
             output_dir: Path to directory for output (will be mounted read-write)
-            timeout: Timeout in seconds
+            timeout: Execution timeout in seconds
+            startup_timeout: Startup timeout in seconds
             job_type: Job type configuration for container settings
             extra_requirements: Additional requirements to install (merged with job_type)
 
@@ -960,12 +970,16 @@ class CodeExecutor:
                 reqs_str = ",".join(validated_reqs)
                 cmd.append(f"--env=TAKO_REQUIREMENTS={reqs_str}")
 
+        cmd.append(f"--env=TAKO_STARTUP_TIMEOUT={startup_timeout}")
+        cmd.append(f"--env=TAKO_EXECUTION_TIMEOUT={timeout}")
+
         # Add image name
         cmd.append(image_name)
 
         try:
+            container_timeout = startup_timeout + timeout + 5
             result = subprocess.run(
-                cmd, timeout=timeout, capture_output=True, text=True, check=False
+                cmd, timeout=container_timeout, capture_output=True, text=True, check=False
             )
 
             # Record success with circuit breaker

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -17,6 +17,7 @@ except ImportError:
 import asyncio
 import logging
 import time
+import uuid
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Literal, Optional
 
@@ -62,7 +63,12 @@ def _configure_log_level(log_level: str) -> None:
 
 
 def compute_idempotency_fingerprint(
-    code: str, input_data: dict, job_type: Optional[str], timeout: Optional[int]
+    code: str,
+    input_data: dict,
+    job_type: Optional[str],
+    timeout: Optional[int],
+    startup_timeout: Optional[int],
+    requirements: Optional[List[str]],
 ) -> str:
     """
     Compute fingerprint of request parameters for idempotency validation.
@@ -76,8 +82,15 @@ def compute_idempotency_fingerprint(
             "input_hash": sha256_json(input_data),
             "job_type": job_type or "default",
             "timeout": timeout,
+            "startup_timeout": startup_timeout,
+            "requirements": requirements or [],
         }
     )
+
+
+def _generate_sync_job_id() -> str:
+    """Generate a collision-resistant ID for the legacy sync endpoint."""
+    return f"api-{uuid.uuid4()}"
 
 
 # Keyed lock for idempotency (prevents race conditions under concurrent requests)
@@ -750,7 +763,7 @@ async def execute_code(request: ExecuteRequest):
     Returns:
         Execution results including output, stdout, stderr
     """
-    job_id = f"api-{int(time.time() * 1000)}"
+    job_id = _generate_sync_job_id()
 
     logger.info(f"Executing job {job_id}")
     start_time = time.time()
@@ -765,6 +778,9 @@ async def execute_code(request: ExecuteRequest):
 
         if request.timeout is not None:
             job["timeout"] = request.timeout
+
+        if request.startup_timeout is not None:
+            job["startup_timeout"] = request.startup_timeout
 
         if request.requirements is not None:
             job["requirements"] = request.requirements
@@ -839,7 +855,12 @@ async def _submit_async_job(request: ExecuteRequest, http_request: Request) -> A
         if existing:
             # Verify fingerprint matches (detect key reuse with different payload)
             expected_fingerprint = compute_idempotency_fingerprint(
-                request.code, request.input_data, request.job_type, request.timeout
+                request.code,
+                request.input_data,
+                request.job_type,
+                request.timeout,
+                request.startup_timeout,
+                request.requirements,
             )
 
             if (
@@ -861,7 +882,12 @@ async def _submit_async_job(request: ExecuteRequest, http_request: Request) -> A
     idempotency_fingerprint = None
     if request.idempotency_key:
         idempotency_fingerprint = compute_idempotency_fingerprint(
-            request.code, request.input_data, request.job_type, request.timeout
+            request.code,
+            request.input_data,
+            request.job_type,
+            request.timeout,
+            request.startup_timeout,
+            request.requirements,
         )
 
     job_data = {

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from tako_vm.execution.docker import generate_container_name, kill_container
 from tako_vm.models import (
     DeadLetterEntry,
     ExecutionError,
@@ -49,6 +50,9 @@ class QueuedJob:
 
     cancelled: bool = False
     """Whether this job has been cancelled."""
+
+    cancel_signal_sent: bool = False
+    """Whether a kill signal was successfully sent to a running container."""
 
 
 class WorkerPool:
@@ -311,24 +315,58 @@ class WorkerPool:
         Returns:
             True if job was found and cancelled
         """
+        running_job: Optional[QueuedJob] = None
         async with self._jobs_lock:
             # Check pending jobs
             job = self._active_jobs.get(job_id)
             if job and job.future and not job.future.done():
                 job.cancelled = True
-                job.future.cancel()
                 logger.info(f"Job {job_id} cancelled (was pending)")
                 return True
 
-            # Check running jobs - can't cancel Docker execution directly
-            # but we can mark it for cleanup
+            # Check running jobs - send a kill to the tracked container.
             job = self._running_jobs.get(job_id)
             if job:
                 job.cancelled = True
-                logger.info(f"Job {job_id} marked for cancellation (was running)")
-                return True
+                running_job = job
 
-        return False
+        if not running_job:
+            return False
+
+        container_name = generate_container_name("tako", job_id)
+        signal_sent = await asyncio.to_thread(kill_container, container_name)
+
+        async with self._jobs_lock:
+            current = self._running_jobs.get(job_id)
+            if current is running_job:
+                current.cancel_signal_sent = signal_sent
+
+        if signal_sent:
+            logger.info(f"Job {job_id} cancellation signal sent to container {container_name}")
+        else:
+            logger.info(f"Job {job_id} cancellation requested, but container was not running")
+
+        return True
+
+    def _build_cancelled_record(self, job: QueuedJob) -> ExecutionRecord:
+        """Create a final cancelled record for a job."""
+        job_type_name = job.job_data.get("job_type") or "default"
+        return ExecutionRecord(
+            execution_id=job.job_id,
+            status="cancelled",
+            job_type=job_type_name,
+            job_ref=f"{job_type_name}@latest",
+            created_at=job.created_at,
+            queued_at=job.created_at,
+            code_hash=sha256_content(job.job_data.get("code", "")),
+            input_hash=sha256_json(job.job_data.get("input_data", {})),
+            client_ip=job.client_ip,
+            error=ExecutionError(type="cancelled", message="Execution was cancelled by user"),
+            idempotency_key=job.job_data.get("idempotency_key"),
+            idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
+            parent_execution_id=job.job_data.get("parent_execution_id"),
+            relationship=job.job_data.get("relationship"),
+        )
 
     def _estimate_queue_position_unlocked(self, job_id: str) -> int:
         """Estimate position in queue (rough estimate). Must be called with _jobs_lock held."""
@@ -397,6 +435,12 @@ class WorkerPool:
 
                 # Skip if already cancelled
                 if job.cancelled or (job.future and job.future.cancelled()):
+                    await self.storage.save_record(self._build_cancelled_record(job))
+                    if job.future and not job.future.done():
+                        try:
+                            job.future.set_result(self._build_cancelled_record(job))
+                        except asyncio.InvalidStateError:
+                            logger.debug(f"Future already done for cancelled job {job.job_id}")
                     async with self._jobs_lock:
                         self._active_jobs.pop(job.job_id, None)
                     continue
@@ -416,6 +460,17 @@ class WorkerPool:
                     # Run execution in thread pool
                     record = await self._execute_job(job)
 
+                    if job.cancelled and (
+                        job.cancel_signal_sent or record.exit_code in {124, 137, 143}
+                    ):
+                        phase = record.timing.phase_at_exit if record.timing else None
+                        record.status = "cancelled"
+                        record.error = ExecutionError(
+                            type="cancelled",
+                            message="Execution was cancelled by user",
+                            phase=phase,
+                        )
+
                     # Save to storage
                     await self.storage.save_record(record)
 
@@ -428,23 +483,7 @@ class WorkerPool:
 
                 except asyncio.CancelledError:
                     # Job was cancelled
-                    job_type_name = job.job_data.get("job_type") or "default"
-                    record = ExecutionRecord(
-                        execution_id=job.job_id,
-                        status="cancelled",
-                        job_type=job_type_name,
-                        job_ref=f"{job_type_name}@latest",
-                        created_at=job.created_at,
-                        queued_at=job.created_at,
-                        code_hash=sha256_content(job.job_data.get("code", "")),
-                        input_hash=sha256_json(job.job_data.get("input_data", {})),
-                        client_ip=job.client_ip,
-                        # Propagate idempotency and lineage fields
-                        idempotency_key=job.job_data.get("idempotency_key"),
-                        idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
-                        parent_execution_id=job.job_data.get("parent_execution_id"),
-                        relationship=job.job_data.get("relationship"),
-                    )
+                    record = self._build_cancelled_record(job)
                     await self.storage.save_record(record)
 
                     if job.future:
@@ -563,9 +602,10 @@ class WorkerPool:
         """
         loop = asyncio.get_running_loop()
 
-        # Get job timeout with buffer for Docker startup overhead
+        # Include both startup and execution budgets, plus buffer for Docker orchestration.
         job_timeout = job.job_data.get("timeout", 30)
-        executor_timeout = job_timeout + 60  # 60s buffer for container setup
+        startup_timeout = job.job_data.get("startup_timeout", 120)
+        executor_timeout = startup_timeout + job_timeout + 60
 
         # Run synchronous execution in thread pool with timeout protection
         record = await asyncio.wait_for(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,15 @@ class TestHealthEndpoint:
 class TestSyncExecution:
     """Tests for synchronous /execute endpoint."""
 
+    def test_generate_sync_job_id_is_unique(self):
+        """Legacy sync endpoint IDs are UUID-based to avoid collisions."""
+        from tako_vm.server.app import _generate_sync_job_id
+
+        job_ids = {_generate_sync_job_id() for _ in range(20)}
+
+        assert len(job_ids) == 20
+        assert all(job_id.startswith("api-") for job_id in job_ids)
+
     def test_execute_simple_code(self, client):
         """Execute simple code that writes output."""
         code = """
@@ -443,6 +452,11 @@ for i in range(60):
         assert cancel_data["status"] == "cancelled"
         assert cancel_data["job_id"] == job_id
 
+        result_response = client.get(f"/jobs/{job_id}/result", params={"wait": True, "timeout": 60})
+        assert result_response.status_code == 200
+        result_data = result_response.json()
+        assert result_data["status"] == "cancelled"
+
     def test_cancel_nonexistent_job(self, client):
         """Cancel of non-existent job returns 404."""
         response = client.post("/jobs/nonexistent-id/cancel")
@@ -588,6 +602,54 @@ class TestIdempotency:
         second_response = client.post(
             "/execute/async",
             json={"code": "print('different')", "idempotency_key": idempotency_key},
+        )
+        assert second_response.status_code == 409
+
+    def test_idempotency_key_reuse_with_different_requirements_fails(self, client):
+        """Requirements changes must be treated as a different idempotent payload."""
+        idempotency_key = "test-conflict-reqs-12345"
+
+        first_response = client.post(
+            "/execute/async",
+            json={
+                "code": "print('deps')",
+                "requirements": ["requests"],
+                "idempotency_key": idempotency_key,
+            },
+        )
+        assert first_response.status_code == 200
+
+        second_response = client.post(
+            "/execute/async",
+            json={
+                "code": "print('deps')",
+                "requirements": ["httpx"],
+                "idempotency_key": idempotency_key,
+            },
+        )
+        assert second_response.status_code == 409
+
+    def test_idempotency_key_reuse_with_different_startup_timeout_fails(self, client):
+        """Startup timeout changes must be treated as a different idempotent payload."""
+        idempotency_key = "test-conflict-startup-12345"
+
+        first_response = client.post(
+            "/execute/async",
+            json={
+                "code": "print('startup')",
+                "startup_timeout": 30,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        assert first_response.status_code == 200
+
+        second_response = client.post(
+            "/execute/async",
+            json={
+                "code": "print('startup')",
+                "startup_timeout": 60,
+                "idempotency_key": idempotency_key,
+            },
         )
         assert second_response.status_code == 409
 

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -70,7 +70,7 @@ class TestKillContainer:
         """kill_container calls docker kill command."""
         mock_run.return_value = MagicMock(returncode=0)
 
-        kill_container("tako-test-123")
+        assert kill_container("tako-test-123") is True
 
         mock_run.assert_called_once_with(
             ["docker", "kill", "tako-test-123"],
@@ -84,24 +84,21 @@ class TestKillContainer:
         """kill_container silently ignores errors."""
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
 
-        # Should not raise
-        kill_container("nonexistent-container")
+        assert kill_container("nonexistent-container") is False
 
     @patch("subprocess.run")
     def test_kill_container_ignores_docker_errors(self, mock_run):
         """kill_container ignores docker command failures."""
         mock_run.return_value = MagicMock(returncode=1)  # Container not found
 
-        # Should not raise
-        kill_container("already-stopped-container")
+        assert kill_container("already-stopped-container") is False
 
     @patch("subprocess.run")
     def test_kill_container_handles_exception(self, mock_run):
         """kill_container handles unexpected exceptions."""
         mock_run.side_effect = Exception("Unexpected error")
 
-        # Should not raise
-        kill_container("error-container")
+        assert kill_container("error-container") is False
 
 
 class TestContainerNameValidation:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,71 @@
+"""Tests for worker-pool cancellation and timeout bookkeeping."""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from tako_vm.models import ExecutionRecord
+from tako_vm.server.queue import QueuedJob, WorkerPool
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_job_leaves_future_resolvable():
+    """Pending-job cancellation should not poison the waiter future."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-123",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+
+    async with pool._jobs_lock:
+        pool._active_jobs[job.job_id] = job
+
+    cancelled = await pool.cancel(job.job_id)
+
+    assert cancelled is True
+    assert job.cancelled is True
+    assert job.future is not None
+    assert job.future.cancelled() is False
+
+
+@pytest.mark.asyncio
+async def test_execute_job_timeout_includes_startup_timeout(monkeypatch):
+    """Thread-pool timeout must cover startup and execution budgets."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    pool._thread_pool = MagicMock()
+    job = QueuedJob(
+        job_id="job-123",
+        job_data={"timeout": 30, "startup_timeout": 90},
+        client_ip=None,
+    )
+
+    captured = {}
+
+    class DummyLoop:
+        def run_in_executor(self, executor, fn, arg):
+            record = ExecutionRecord(
+                execution_id="job-123",
+                status="queued",
+                created_at=datetime.now(timezone.utc),
+                queued_at=datetime.now(timezone.utc),
+                code_hash="a" * 64,
+                input_hash="b" * 64,
+            )
+            return asyncio.sleep(0, result=record)
+
+    async def fake_wait_for(awaitable, timeout):
+        captured["timeout"] = timeout
+        return await awaitable
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: DummyLoop())
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+
+    record = await pool._execute_job(job)
+
+    assert record.execution_id == "job-123"
+    assert captured["timeout"] == 180

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,10 +1,13 @@
 """Tests for security validation helpers."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
 from tako_vm.execution import CodeExecutor
+from tako_vm.job_types import JobType
 from tako_vm.security import validate_execution_id, validate_pip_requirement
 
 
@@ -88,3 +91,38 @@ class TestExecutorRejectsUnsafeIds:
 
         assert record.execution_id == "550e8400-e29b-41d4-a716-446655440000"
         assert record.status in {"queued", "failed", "running", "succeeded"}
+
+    def test_run_container_receives_startup_and_execution_timeouts(self, monkeypatch, tmp_path):
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        captured = {}
+
+        def fake_run(cmd, timeout, capture_output, text, check):
+            captured["cmd"] = cmd
+            captured["timeout"] = timeout
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+
+        result = executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            job_id="job-123",
+        )
+
+        assert result["success"] is True
+        assert captured["timeout"] == 80
+        assert "--env=TAKO_STARTUP_TIMEOUT=45" in captured["cmd"]
+        assert "--env=TAKO_EXECUTION_TIMEOUT=30" in captured["cmd"]


### PR DESCRIPTION
## Summary
- make cancellation semantics consistent for pending and running jobs
- include startup timeout and requirements in idempotency fingerprints
- enforce separate startup and execution timeout budgets in the executor/entrypoint path
- replace timestamp-based sync job IDs with UUID-based IDs

## Verification
- ruff check on touched files
- .venv/bin/pytest tests/test_api.py tests/test_docker_utils.py tests/test_security.py tests/test_queue.py -q
- .venv/bin/pytest tests/test_storage.py tests/test_runtime.py tests/test_proc_exposure.py -q
- .venv/bin/pytest -q
