### PR TITLE
Harden docker command validation

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -37,6 +37,7 @@ from tako_vm.security import (
     compute_file_hash,
     is_safe_filename,
     sanitize_error,
+    validate_docker_run_args,
     validate_docker_image,
     validate_env_key,
     validate_env_value,
@@ -836,6 +837,14 @@ class CodeExecutor:
             image_name = job_type.base_image
         else:
             image_name = self.docker_image
+            if not validate_docker_image(image_name):
+                return {
+                    "success": False,
+                    "error": "Invalid docker_image configuration",
+                    "stdout": "",
+                    "stderr": f"docker_image '{image_name}' failed validation",
+                    "exit_code": -1,
+                }
 
         # Merge job_type requirements with extra_requirements
         all_requirements = list(job_type.requirements) if job_type.requirements else []
@@ -978,6 +987,14 @@ class CodeExecutor:
 
         try:
             container_timeout = startup_timeout + timeout + 5
+            if not validate_docker_run_args(cmd):
+                return {
+                    "success": False,
+                    "error": "Unsafe Docker command rejected",
+                    "stdout": "",
+                    "stderr": "Docker command arguments failed validation",
+                    "exit_code": -1,
+                }
             result = subprocess.run(
                 cmd, timeout=container_timeout, capture_output=True, text=True, check=False
             )

--- a/tako_vm/security.py
+++ b/tako_vm/security.py
@@ -7,6 +7,7 @@ Provides output capping, error sanitization, and artifact validation.
 import hashlib
 import logging
 import re
+from typing import Sequence
 from pathlib import Path
 from typing import List, Tuple
 
@@ -482,6 +483,10 @@ _SAFE_PIP_VERSION_CHARS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.*+!-"
 )
 _SAFE_PIP_OPERATOR_CHARS = frozenset("<>=!~")
+_SAFE_DOCKER_ARG_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    "._:/=,+-[]{}@%"
+)
 
 
 def validate_execution_id(value: str) -> bool:
@@ -584,5 +589,32 @@ def validate_pip_requirement(requirement: str) -> bool:
         if requirement[index] != ",":
             return False
         index += 1
+
+    return True
+
+
+def validate_docker_run_args(args: Sequence[str]) -> bool:
+    """
+    Validate a Docker CLI argv list before execution.
+
+    This is a defense-in-depth check for commands built from validated user and
+    config inputs. It assumes list-style subprocess execution (no shell).
+
+    Args:
+        args: Complete argv list passed to subprocess.run()
+
+    Returns:
+        True if every argument is safe for direct Docker CLI execution
+    """
+    if not args or args[0] != "docker":
+        return False
+
+    for arg in args:
+        if not isinstance(arg, str) or not arg:
+            return False
+        if len(arg) > 4096:
+            return False
+        if any(char not in _SAFE_DOCKER_ARG_CHARS for char in arg):
+            return False
 
     return True

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -8,7 +8,11 @@ import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
 from tako_vm.execution import CodeExecutor
 from tako_vm.job_types import JobType
-from tako_vm.security import validate_execution_id, validate_pip_requirement
+from tako_vm.security import (
+    validate_docker_run_args,
+    validate_execution_id,
+    validate_pip_requirement,
+)
 
 
 class TestValidateExecutionId:
@@ -64,6 +68,40 @@ class TestValidatePipRequirement:
     )
     def test_rejects_unsafe_or_malformed_forms(self, value):
         assert validate_pip_requirement(value) is False
+
+
+class TestValidateDockerRunArgs:
+    def test_accepts_safe_docker_run_argv(self, tmp_path):
+        code_dir = tmp_path / "code"
+        code_dir.mkdir()
+
+        assert (
+            validate_docker_run_args(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--name=tako-job-123",
+                    "--network=none",
+                    f"--mount=type=bind,source={code_dir.resolve()},target=/code,readonly",
+                    "--env=TAKO_EXECUTION_TIMEOUT=30",
+                    "code-executor:latest",
+                ]
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["podman", "run", "code-executor:latest"],
+            ["docker", "run", "bad\narg", "code-executor:latest"],
+            ["docker", "run", "--env=NAME=value with spaces", "code-executor:latest"],
+            ["docker", "run", "", "code-executor:latest"],
+        ],
+    )
+    def test_rejects_unsafe_docker_run_argv(self, args):
+        assert validate_docker_run_args(args) is False
 
 
 class TestExecutorRejectsUnsafeIds:


### PR DESCRIPTION
## Summary
- validate the default configured Docker image before use in the worker
- add a final argv validator before invoking docker run
- add regression tests for safe and unsafe Docker argv values

## Testing
- uv run pytest tests/test_security.py