### PR TITLE
Pass runtime requirements via input file

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,13 +25,10 @@ echo "container_start_ms=$START_TOTAL" > "$PHASE_FILE"
 echo "phase=startup" >> "$PHASE_FILE"
 START_STARTUP=$(get_time_ms)
 
-if [ -n "$TAKO_REQUIREMENTS" ]; then
-    echo "dep_install_started=true" >> "$PHASE_FILE"
+REQS_FILE="/input/_requirements.txt"
 
-    # Write requirements to a temporary file for safer handling
-    # This avoids shell word splitting issues with package specifiers
-    REQS_FILE=$(mktemp)
-    echo "$TAKO_REQUIREMENTS" | tr ',' '\n' > "$REQS_FILE"
+if [ -s "$REQS_FILE" ]; then
+    echo "dep_install_started=true" >> "$PHASE_FILE"
 
     # Install with uv to a writable target directory (avoids read-only filesystem issues)
     # Using --target instead of --system to install to /tmp/site-packages
@@ -51,9 +48,6 @@ if [ -n "$TAKO_REQUIREMENTS" ]; then
 
     # Set PYTHONPATH so Python can find the installed packages
     export PYTHONPATH="$TARGET_DIR:$PYTHONPATH"
-
-    # Cleanup
-    rm -f "$REQS_FILE"
 
     # Record dep install completion
     END_DEP=$(get_time_ms)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@
         ▼                       ▼                       ▼
 ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
 │ entrypoint.sh    │    │ uv pip install   │    │ gosu sandbox     │
-│ starts           │    │ $TAKO_REQUIREMENTS│   │ python main.py   │
+│ starts           │    │ _requirements.txt │   │ python main.py   │
 └──────────────────┘    └──────────────────┘    └──────────────────┘
                                │
                                ▼

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -3,8 +3,8 @@
 ## Dependency Flow
 
 1. Job submitted with `job_type: "data-processing"` (has `requirements: [pandas, numpy]`)
-2. Worker passes requirements via `TAKO_REQUIREMENTS` env var
-3. Container starts, `entrypoint.sh` runs `uv pip install pandas numpy`
+2. Worker writes validated requirements to `/input/_requirements.txt`
+3. Container starts, `entrypoint.sh` runs `uv pip install -r /input/_requirements.txt`
 4. Code runs as `sandbox` user (uid 1000) via `gosu`
 
 For network-isolated jobs with deps, use pre-built images via the REST API:

--- a/docs/security/env-var-mitigation.md
+++ b/docs/security/env-var-mitigation.md
@@ -12,7 +12,7 @@ with open('/proc/self/environ', 'rb') as f:
 
 Instead of passing secrets via `--env` flags, write them to read-only files in `/input/`.
 
-### Implementation Plan
+### Current Implementation
 
 #### Step 1: Update worker.py
 
@@ -37,7 +37,7 @@ def _prepare_config_file(self, job_type: JobType, input_dir: Path) -> None:
 
 def _prepare_requirements_file(self, requirements: List[str], input_dir: Path) -> None:
     """
-    Write requirements to file instead of TAKO_REQUIREMENTS env var.
+    Write requirements to file instead of an environment variable.
     """
     if requirements:
         reqs_file = input_dir / "_requirements.txt"
@@ -54,8 +54,7 @@ for key, value in job_type.environment.items():
     cmd.append(f"--env={key}={value}")
 
 if validated_reqs:
-    reqs_str = ",".join(validated_reqs)
-    cmd.append(f"--env=TAKO_REQUIREMENTS={reqs_str}")
+    cmd.append("--env=DEPENDENCIES=<comma-separated requirements>")
 ```
 
 With this:
@@ -73,8 +72,8 @@ Replace the env var reading:
 
 ```bash
 # OLD: Read from env var
-if [ -n "$TAKO_REQUIREMENTS" ]; then
-    echo "$TAKO_REQUIREMENTS" | tr ',' '\n' > /tmp/requirements.txt
+if [ -n "$DEPENDENCIES" ]; then
+    echo "$DEPENDENCIES" | tr ',' '\n' > /tmp/requirements.txt
     uv pip install -r /tmp/requirements.txt
 fi
 ```

--- a/docs/security/mitigations.md
+++ b/docs/security/mitigations.md
@@ -72,7 +72,7 @@ These are tracked as future work:
 | `/proc` path masking | Use Docker `--security-opt=mask=` to hide sensitive `/proc` paths | Planned |
 | AppArmor profile | Deny access to `/proc/*/environ` and `/proc/*/fd/` | Planned |
 | Config file migration | Move job type environment vars from env to read-only files | Planned |
-| Requirements via file | Pass `TAKO_REQUIREMENTS` via file instead of env var | Planned |
+| Requirements via file | Pass validated requirements via `/input/_requirements.txt` instead of env var | Active |
 
 ## References
 

--- a/docs/security/proc-exposure-vulnerability.md
+++ b/docs/security/proc-exposure-vulnerability.md
@@ -36,7 +36,7 @@ print("Environment extracted successfully")
 ```
 
 **Information Exposed:**
-- `TAKO_REQUIREMENTS` - reveals dependency list
+- Job type environment variables - avoid using these for secrets
 - Custom `job_type.environment` variables - may contain API keys, secrets
 - System environment (PATH, HOME, etc.)
 

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -37,8 +37,8 @@ from tako_vm.security import (
     compute_file_hash,
     is_safe_filename,
     sanitize_error,
-    validate_docker_run_args,
     validate_docker_image,
+    validate_docker_run_args,
     validate_env_key,
     validate_env_value,
     validate_execution_id,
@@ -822,9 +822,40 @@ class CodeExecutor:
                 "exit_code": -1,
             }
 
+        # Validate runtime requirements before deciding network and tmpfs policy.
+        all_requirements = list(job_type.requirements) if job_type.requirements else []
+        if extra_requirements:
+            all_requirements.extend(extra_requirements)
+
+        if len(all_requirements) > MAX_REQUIREMENTS:
+            logger.error(
+                "Job has %s requirements (max %s). Use pre-built images for large dependency sets.",
+                len(all_requirements),
+                MAX_REQUIREMENTS,
+            )
+            return {
+                "success": False,
+                "error": f"Too many requirements ({len(all_requirements)} > {MAX_REQUIREMENTS})",
+                "stdout": "",
+                "stderr": "Use pre-built images for jobs with many dependencies",
+                "exit_code": -1,
+            }
+
+        validated_reqs = []
+        for req in all_requirements:
+            if validate_pip_requirement(req):
+                validated_reqs.append(req)
+            else:
+                logger.warning("Skipping invalid pip requirement: %s", req)
+
+        requirements_file = input_dir / "_requirements.txt"
+        if validated_reqs:
+            requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
+            requirements_file.chmod(0o444)
+
         # Determine which image to use
         # Use custom base_image if specified, otherwise use default executor
-        # Dependencies are installed at runtime via TAKO_REQUIREMENTS env var
+        # Dependencies are installed at runtime from /input/_requirements.txt.
         if job_type.base_image:
             if not validate_docker_image(job_type.base_image):
                 return {
@@ -846,13 +877,8 @@ class CodeExecutor:
                     "exit_code": -1,
                 }
 
-        # Merge job_type requirements with extra_requirements
-        all_requirements = list(job_type.requirements) if job_type.requirements else []
-        if extra_requirements:
-            all_requirements.extend(extra_requirements)
-
         # Check if runtime deps require network access
-        has_runtime_deps = bool(all_requirements)
+        has_runtime_deps = bool(validated_reqs)
         needs_network_for_deps = has_runtime_deps and not job_type.network_enabled
 
         if needs_network_for_deps:
@@ -952,32 +978,6 @@ class CodeExecutor:
                 logger.warning(f"Skipping environment variable with unsafe value: {key}")
                 continue
             cmd.append(f"--env={key}={value}")
-
-        # Pass requirements for runtime installation via uv
-        if all_requirements:
-            # Check requirements limit to prevent env var overflow
-            if len(all_requirements) > MAX_REQUIREMENTS:
-                logger.error(
-                    f"Job has {len(all_requirements)} requirements "
-                    f"(max {MAX_REQUIREMENTS}). Use pre-built images for large dependency sets."
-                )
-                return {
-                    "success": False,
-                    "error": f"Too many requirements ({len(all_requirements)} > {MAX_REQUIREMENTS})",
-                    "stdout": "",
-                    "stderr": "Use pre-built images for jobs with many dependencies",
-                    "exit_code": -1,
-                }
-
-            validated_reqs = []
-            for req in all_requirements:
-                if validate_pip_requirement(req):
-                    validated_reqs.append(req)
-                else:
-                    logger.warning(f"Skipping invalid pip requirement: {req}")
-            if validated_reqs:
-                reqs_str = ",".join(validated_reqs)
-                cmd.append(f"--env=TAKO_REQUIREMENTS={reqs_str}")
 
         cmd.append(f"--env=TAKO_STARTUP_TIMEOUT={startup_timeout}")
         cmd.append(f"--env=TAKO_EXECUTION_TIMEOUT={timeout}")

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -23,8 +23,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from tako_vm.constants import DEFAULT_IMAGE, UV_CACHE_VOLUME, WORKSPACE_DIR
+from tako_vm.constants import DEFAULT_IMAGE, MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
 from tako_vm.execution.docker import generate_container_name, kill_container
+from tako_vm.security import validate_pip_requirement
 
 logger = logging.getLogger(__name__)
 
@@ -391,6 +392,23 @@ class Sandbox:
         Returns:
             Tuple of (command, container_name) for cleanup on timeout.
         """
+        validated_reqs = []
+        if requirements:
+            if len(requirements) > MAX_REQUIREMENTS:
+                raise ValueError(
+                    f"Too many requirements ({len(requirements)} > {MAX_REQUIREMENTS})"
+                )
+            for req in requirements:
+                if validate_pip_requirement(req):
+                    validated_reqs.append(req)
+                else:
+                    logger.warning("Skipping invalid pip requirement: %s", req)
+
+        if validated_reqs:
+            requirements_file = input_dir / "_requirements.txt"
+            requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
+            requirements_file.chmod(0o444)
+
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako-sandbox")
 
@@ -419,7 +437,7 @@ class Sandbox:
             # no capability to regain root. The container also has all other caps dropped.
 
         # Network isolation
-        has_requirements = bool(requirements)
+        has_requirements = bool(validated_reqs)
         if self.config.network_enabled or has_requirements:
             cmd.append("--network=bridge")
         else:
@@ -466,11 +484,6 @@ class Sandbox:
         if pythonpath_parts:
             pythonpath = ":".join(pythonpath_parts)
             cmd.append(f"--env=PYTHONPATH={pythonpath}")
-
-        # Pass requirements
-        if requirements:
-            reqs_str = ",".join(requirements)
-            cmd.append(f"--env=TAKO_REQUIREMENTS={reqs_str}")
 
         # Image
         cmd.append(self.config.image)

--- a/tako_vm/security.py
+++ b/tako_vm/security.py
@@ -7,9 +7,8 @@ Provides output capping, error sanitization, and artifact validation.
 import hashlib
 import logging
 import re
-from typing import Sequence
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 
 from .models import ErrorType
 
@@ -484,8 +483,7 @@ _SAFE_PIP_VERSION_CHARS = frozenset(
 )
 _SAFE_PIP_OPERATOR_CHARS = frozenset("<>=!~")
 _SAFE_DOCKER_ARG_CHARS = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    "._:/=,+-[]{}@%"
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/=,+-[]{}@%"
 )
 
 

--- a/tests/test_proc_exposure.py
+++ b/tests/test_proc_exposure.py
@@ -26,7 +26,7 @@ class TestProcExposure:
         Demonstrate that user code can read /proc/self/environ.
 
         VULNERABILITY: User code can access all environment variables including:
-        - TAKO_REQUIREMENTS (dependency list)
+        - dependency specifications if they are passed through environment variables
         - Custom job_type.environment variables
         """
         code = """
@@ -63,12 +63,12 @@ with open('/output/result.json', 'w') as f:
             "id": "test-proc-environ",
             "code": code,
             "input_data": {},
-            "requirements": ["requests"],  # This will appear in TAKO_REQUIREMENTS
+            "requirements": ["requests"],
         }
 
         result = executor.execute_job(job)
 
-        # This test PASSES, demonstrating the vulnerability
+        # /proc environment access remains possible, but dependency specs should not leak.
         assert result["success"], (
             f"Execution failed: stderr={result.get('stderr')}, error={result.get('error')}"
         )
@@ -79,14 +79,13 @@ with open('/output/result.json', 'w') as f:
         assert output["has_path"] is True
         assert output["has_home"] is True
 
-        # SECURITY ISSUE: Tako-specific variables are exposed
-        assert "TAKO_REQUIREMENTS" in output["tako_vars"]
-        assert "requests" in output["tako_vars"]["TAKO_REQUIREMENTS"]
+        # Dependency requirements are passed via /input/_requirements.txt, not env.
+        assert "TAKO_REQUIREMENTS" not in output["tako_vars"]
 
-        print("\n⚠️  VULNERABILITY CONFIRMED:")
+        print("\n/proc environment exposure observed:")
         print(f"   - Total environment variables exposed: {output['total_vars']}")
         print(f"   - Tako variables exposed: {list(output['tako_vars'].keys())}")
-        print(f"   - Requirements leaked: {output['tako_vars'].get('TAKO_REQUIREMENTS', 'N/A')}")
+        print("   - Requirements leaked: no")
 
     def test_binary_extraction_via_proc_exe(self, executor):
         """

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -164,3 +164,38 @@ class TestExecutorRejectsUnsafeIds:
         assert captured["timeout"] == 80
         assert "--env=TAKO_STARTUP_TIMEOUT=45" in captured["cmd"]
         assert "--env=TAKO_EXECUTION_TIMEOUT=30" in captured["cmd"]
+
+    def test_run_container_writes_requirements_file_not_env(self, monkeypatch, tmp_path):
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        captured = {}
+
+        def fake_run(cmd, timeout, capture_output, text, check):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+
+        result = executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            extra_requirements=["requests>=2.31"],
+            job_id="job-123",
+        )
+
+        assert result["success"] is True
+        assert not any(arg.startswith("--env=TAKO_REQUIREMENTS=") for arg in captured["cmd"])
+        assert "--network=bridge" in captured["cmd"]
+        assert (input_dir / "_requirements.txt").read_text(encoding="utf-8") == "requests>=2.31\n"


### PR DESCRIPTION
## Summary
- write validated runtime requirements to /input/_requirements.txt instead of a Docker --env argument
- update the executor entrypoint and direct Sandbox path to install from that file
- update proc-exposure regression coverage and docs for the new behavior

## Verification
- .venv/bin/ruff check tako_vm/execution/worker.py tako_vm/sandbox.py tests/test_security.py tests/test_proc_exposure.py
- .venv/bin/ruff format --check tako_vm/execution/worker.py tako_vm/sandbox.py tests/test_security.py tests/test_proc_exposure.py
- .venv/bin/pytest tests/test_security.py tests/test_sandbox.py tests/test_proc_exposure.py -q
- docker build via DOCKER_BUILDKIT=0 -t code-executor:latest -f docker/Dockerfile.executor .
- .venv/bin/pytest -q  # 270 passed, 72 skipped, 1 warning