### PR TITLE
Disable runtime dependency installs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ cython_debug/
 # Ruff stuff:
 .ruff_cache/
 
+# Local dependency caches
+.pip-cache/
+
 # PyPI configuration file
 .pypirc
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,17 +34,29 @@ if [ -s "$REQS_FILE" ]; then
     # Using --target instead of --system to install to /tmp/site-packages
     TARGET_DIR="/tmp/site-packages"
     mkdir -p "$TARGET_DIR"
+    UV_INSTALL_CMD=(uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE")
+
+    if [ -n "$TAKO_DEPENDENCY_PROXY_URL" ]; then
+        UV_INSTALL_CMD=(
+            env
+            "HTTP_PROXY=$TAKO_DEPENDENCY_PROXY_URL"
+            "HTTPS_PROXY=$TAKO_DEPENDENCY_PROXY_URL"
+            "ALL_PROXY=$TAKO_DEPENDENCY_PROXY_URL"
+            "${UV_INSTALL_CMD[@]}"
+        )
+    fi
 
     # Capture install result (don't exit on error yet so we can record timing)
     set +e
     if [ -n "$TAKO_STARTUP_TIMEOUT" ]; then
-        timeout --signal=TERM "${TAKO_STARTUP_TIMEOUT}s" \
-            uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE" 2>&1
+        timeout --signal=TERM "${TAKO_STARTUP_TIMEOUT}s" "${UV_INSTALL_CMD[@]}" 2>&1
     else
-        uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE" 2>&1
+        "${UV_INSTALL_CMD[@]}" 2>&1
     fi
     DEP_EXIT_CODE=$?
     set -e
+
+    unset TAKO_DEPENDENCY_PROXY_URL
 
     # Set PYTHONPATH so Python can find the installed packages
     export PYTHONPATH="$TARGET_DIR:$PYTHONPATH"
@@ -66,6 +78,8 @@ else
     echo "dep_install_started=false" >> "$PHASE_FILE"
     echo "dep_install_ms=0" >> "$PHASE_FILE"
 fi
+
+unset TAKO_DEPENDENCY_PROXY_URL
 
 END_STARTUP=$(get_time_ms)
 echo "startup_ms=$((END_STARTUP - START_STARTUP))" >> "$PHASE_FILE"

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -58,7 +58,7 @@ POST /execute
 | `timeout` | integer | No | Code execution timeout in seconds (default: 30). Does not include container startup or dependency installation time. |
 | `startup_timeout` | integer | No | Container startup timeout in seconds (10-600, default: 60). Includes container creation and dependency installation. |
 | `job_type` | string | No | Environment name (default: "default") |
-| `requirements` | array | No | Python packages to install at runtime (e.g., `["pandas", "numpy>=1.20"]`) |
+| `requirements` | array | No | Python packages to install at runtime when `allow_runtime_requirements` is enabled (e.g., `["pandas", "numpy>=1.20"]`). Prefer pre-built images in production. |
 
 ### Example Request
 
@@ -85,7 +85,7 @@ curl -X POST http://localhost:8000/execute \
   }'
 ```
 
-This example sets a 5-minute startup timeout (for installing TensorFlow) and a 1-minute code execution timeout.
+This example requires `allow_runtime_requirements: true`. It sets a 5-minute startup timeout (for installing TensorFlow) and a 1-minute code execution timeout.
 
 ### Example with Input/Output
 
@@ -137,7 +137,7 @@ POST /execute/async
 | `timeout` | integer | No | Code execution timeout in seconds (default: 30). Does not include container startup or dependency installation time. |
 | `startup_timeout` | integer | No | Container startup timeout in seconds (10-600, default: 60). Includes container creation and dependency installation. |
 | `job_type` | string | No | Environment name (default: "default") |
-| `requirements` | array | No | Python packages to install at runtime (e.g., `["pandas", "numpy>=1.20"]`) |
+| `requirements` | array | No | Python packages to install at runtime when `allow_runtime_requirements` is enabled (e.g., `["pandas", "numpy>=1.20"]`). Prefer pre-built images in production. |
 | `idempotency_key` | string | No | Unique key for idempotent submission |
 
 ### Idempotency

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -51,6 +51,8 @@ job_types:
 
 When `network_enabled: true`, containers can access any external host. For strict egress control, use external firewalls or Kubernetes NetworkPolicy.
 
+Runtime dependency installation is disabled by default. This prevents untrusted jobs from fetching packages and running package setup code during execution. Prefer pre-built images; if a trusted deployment needs runtime installs, set `allow_runtime_requirements: true` and route installs through `dependency_proxy_url`.
+
 ### Read-Only Filesystem
 
 ```bash

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -46,6 +46,9 @@ api_rate_limit_window_seconds: 60    # Rate limit window in seconds
 default_timeout: 30       # seconds
 max_timeout: 300          # maximum allowed
 
+allow_runtime_requirements: false      # install request/job requirements at runtime
+dependency_proxy_url: null             # optional proxy for runtime dependency installs
+
 max_code_bytes: 102400    # 100KB
 max_input_bytes: 1048576  # 1MB
 max_stdout_bytes: 65536   # 64KB
@@ -107,6 +110,9 @@ max_artifact_bytes: 10485760
 max_total_artifacts_bytes: 52428800
 execution_record_ttl_days: 30
 ```
+
+!!! warning "Runtime dependencies are opt-in"
+    `requirements` are intended for pre-built job images. Runtime installation is disabled by default because it allows outbound package downloads and package setup code execution. Set `allow_runtime_requirements: true` only for trusted deployments, preferably with `dependency_proxy_url` configured.
 
 ## Config File Search Order
 

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -105,6 +105,13 @@ job_types:
 
 When `network_enabled: true`, containers can access any external host. For strict egress control in production, use external firewalls or Kubernetes NetworkPolicy.
 
+Runtime dependency installation from `requirements` is disabled by default. Use pre-built job images for production. For trusted development environments, enable:
+
+```yaml
+allow_runtime_requirements: true
+dependency_proxy_url: "https://proxy.example:8443"  # optional
+```
+
 ## List Job Types
 
 ```python
@@ -159,6 +166,7 @@ In production mode (`production_mode: true`):
 - Auto-build is disabled
 - All job types must be pre-built
 - Requests for missing job types fail with an error
+- Runtime dependency installation should remain disabled
 
 ```yaml
 production_mode: true

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -22,6 +22,10 @@ CONFIG_SEARCH_PATHS = [
     Path("/etc/tako_vm/config.yaml"),  # System-wide
 ]
 
+_SAFE_PROXY_URL_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/=,+-[]{}@%"
+)
+
 
 def get_default_data_dir() -> Path:
     """Get default data directory."""
@@ -322,6 +326,16 @@ class TakoVMConfig(BaseModel):
     max_startup_timeout: int = Field(default=600, ge=30, le=1800)
     """Maximum allowed timeout for startup phase (up to 30 minutes for large deps)."""
 
+    # Runtime dependency installation
+    allow_runtime_requirements: bool = Field(
+        default=False,
+        description="Allow jobs to install Python packages at runtime",
+    )
+    dependency_proxy_url: Optional[str] = Field(
+        default=None,
+        description="Optional HTTP(S)/SOCKS proxy URL used only during runtime dependency installs",
+    )
+
     # Retention
     execution_record_ttl_days: int = Field(default=30, ge=1, le=3650)
 
@@ -373,6 +387,28 @@ class TakoVMConfig(BaseModel):
 
     # Job types (new - can be defined in main config)
     job_types: List[JobTypeConfig] = Field(default_factory=list)
+
+    @field_validator("dependency_proxy_url")
+    @classmethod
+    def validate_dependency_proxy_url(cls, v: Optional[str]) -> Optional[str]:
+        """Validate optional dependency egress proxy URL."""
+        if v is None:
+            return None
+        normalized = v.strip()
+        if not normalized:
+            return None
+        if any(char in normalized for char in ("\n", "\r", "\x00")):
+            raise ValueError("dependency_proxy_url cannot contain control characters")
+        parsed = urlsplit(normalized)
+        if parsed.scheme not in {"http", "https", "socks5"}:
+            raise ValueError("dependency_proxy_url must use http://, https://, or socks5://")
+        if not parsed.hostname:
+            raise ValueError("dependency_proxy_url must include a hostname")
+        if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+            raise ValueError("dependency_proxy_url cannot include a path, query, or fragment")
+        if any(char not in _SAFE_PROXY_URL_CHARS for char in normalized):
+            raise ValueError("dependency_proxy_url contains unsupported characters")
+        return normalized
 
     # Internal: resolved paths (set after validation)
     _resolved_data_dir: Optional[Path] = None
@@ -541,6 +577,16 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         config_dict["api_rate_limit_window_seconds"] = parse_env_int(
             "TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS"
         )
+    if "TAKO_VM_ALLOW_RUNTIME_REQUIREMENTS" in os.environ:
+        config_dict["allow_runtime_requirements"] = os.environ[
+            "TAKO_VM_ALLOW_RUNTIME_REQUIREMENTS"
+        ].lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+    if "TAKO_VM_DEPENDENCY_PROXY_URL" in os.environ:
+        config_dict["dependency_proxy_url"] = os.environ["TAKO_VM_DEPENDENCY_PROXY_URL"]
     # Validate and create config
     try:
         config = TakoVMConfig(**config_dict)

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -850,6 +850,17 @@ class CodeExecutor:
 
         requirements_file = input_dir / "_requirements.txt"
         if validated_reqs:
+            if not self.config.allow_runtime_requirements:
+                return {
+                    "success": False,
+                    "error": "Runtime dependency installation is disabled",
+                    "stdout": "",
+                    "stderr": (
+                        "Runtime dependency installation is disabled. "
+                        "Use pre-built images or set allow_runtime_requirements=true."
+                    ),
+                    "exit_code": -1,
+                }
             requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
             requirements_file.chmod(0o444)
 
@@ -978,6 +989,9 @@ class CodeExecutor:
                 logger.warning(f"Skipping environment variable with unsafe value: {key}")
                 continue
             cmd.append(f"--env={key}={value}")
+
+        if has_runtime_deps and self.config.dependency_proxy_url:
+            cmd.append(f"--env=TAKO_DEPENDENCY_PROXY_URL={self.config.dependency_proxy_url}")
 
         cmd.append(f"--env=TAKO_STARTUP_TIMEOUT={startup_timeout}")
         cmd.append(f"--env=TAKO_EXECUTION_TIMEOUT={timeout}")

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -22,12 +22,17 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
 
 from tako_vm.constants import DEFAULT_IMAGE, MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
 from tako_vm.execution.docker import generate_container_name, kill_container
 from tako_vm.security import validate_pip_requirement
 
 logger = logging.getLogger(__name__)
+
+_SAFE_PROXY_URL_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/=,+-[]{}@%"
+)
 
 
 @dataclass
@@ -62,6 +67,27 @@ def _default_enable_cap_restrictions() -> bool:
     return env_val in ("true", "1", "yes")
 
 
+def _validate_dependency_proxy_url(value: Optional[str]) -> Optional[str]:
+    """Validate optional dependency proxy URL for Docker env usage."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if any(char in normalized for char in ("\n", "\r", "\x00")):
+        raise ValueError("dependency_proxy_url cannot contain control characters")
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https", "socks5"}:
+        raise ValueError("dependency_proxy_url must use http://, https://, or socks5://")
+    if not parsed.hostname:
+        raise ValueError("dependency_proxy_url must include a hostname")
+    if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+        raise ValueError("dependency_proxy_url cannot include a path, query, or fragment")
+    if any(char not in _SAFE_PROXY_URL_CHARS for char in normalized):
+        raise ValueError("dependency_proxy_url contains unsupported characters")
+    return normalized
+
+
 @dataclass
 class SandboxConfig:
     """Configuration for the sandbox."""
@@ -80,6 +106,12 @@ class SandboxConfig:
 
     network_enabled: bool = False
     """Whether to allow network access."""
+
+    allow_runtime_requirements: bool = False
+    """Whether to allow installing requirements at runtime."""
+
+    dependency_proxy_url: Optional[str] = None
+    """Optional proxy URL used only during runtime dependency installs."""
 
     package_dirs: List[str] = field(default_factory=list)
     """Local directories to mount as packages (added to PYTHONPATH)."""
@@ -107,7 +139,7 @@ class Sandbox:
             print(result.stdout)  # "2"
 
         # With dependencies
-        with Sandbox() as sb:
+        with Sandbox(allow_runtime_requirements=True) as sb:
             result = sb.run(
                 "import pandas; print(pandas.__version__)",
                 requirements=["pandas"]
@@ -125,6 +157,8 @@ class Sandbox:
         memory_limit: str = "512m",
         cpu_limit: float = 1.0,
         network_enabled: bool = False,
+        allow_runtime_requirements: bool = False,
+        dependency_proxy_url: Optional[str] = None,
         package_dirs: Optional[List[str]] = None,
         auto_build: bool = True,
     ):
@@ -137,6 +171,8 @@ class Sandbox:
             memory_limit: Memory limit (e.g., "512m", "1g")
             cpu_limit: CPU limit (e.g., 1.0 = one CPU)
             network_enabled: Whether to allow network access
+            allow_runtime_requirements: Whether requirements may be installed at runtime
+            dependency_proxy_url: Optional proxy URL for runtime dependency installs
             package_dirs: Local directories to mount as Python packages
             auto_build: Whether to auto-build image if missing
         """
@@ -146,6 +182,8 @@ class Sandbox:
             memory_limit=memory_limit,
             cpu_limit=cpu_limit,
             network_enabled=network_enabled,
+            allow_runtime_requirements=allow_runtime_requirements,
+            dependency_proxy_url=_validate_dependency_proxy_url(dependency_proxy_url),
             package_dirs=package_dirs or [],
         )
         self.auto_build = auto_build
@@ -321,13 +359,16 @@ class Sandbox:
             input_file.chmod(0o444)
 
             # Build docker command
-            cmd, container_name = self._build_docker_command(
-                code_dir=code_dir,
-                input_dir=input_dir,
-                output_dir=output_dir,
-                timeout=timeout,
-                requirements=requirements,
-            )
+            try:
+                cmd, container_name = self._build_docker_command(
+                    code_dir=code_dir,
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    timeout=timeout,
+                    requirements=requirements,
+                )
+            except ValueError as e:
+                return SandboxResult(success=False, exit_code=-1, error=str(e))
 
             # Execute
             start_time = time.time()
@@ -405,6 +446,11 @@ class Sandbox:
                     logger.warning("Skipping invalid pip requirement: %s", req)
 
         if validated_reqs:
+            if not self.config.allow_runtime_requirements:
+                raise ValueError(
+                    "Runtime dependency installation is disabled. "
+                    "Use pre-built images or set allow_runtime_requirements=True."
+                )
             requirements_file = input_dir / "_requirements.txt"
             requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
             requirements_file.chmod(0o444)
@@ -484,6 +530,9 @@ class Sandbox:
         if pythonpath_parts:
             pythonpath = ":".join(pythonpath_parts)
             cmd.append(f"--env=PYTHONPATH={pythonpath}")
+
+        if has_requirements and self.config.dependency_proxy_url:
+            cmd.append(f"--env=TAKO_DEPENDENCY_PROXY_URL={self.config.dependency_proxy_url}")
 
         # Image
         cmd.append(self.config.image)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,6 +254,8 @@ class TestTakoVMConfig:
         assert config.api_rate_limit_enabled is True
         assert config.api_rate_limit_requests == 120
         assert config.api_rate_limit_window_seconds == 60
+        assert config.allow_runtime_requirements is False
+        assert config.dependency_proxy_url is None
 
     def test_tako_vm_config_path_resolution(self):
         """TakoVMConfig resolves data_dir while keeping database URL."""
@@ -325,6 +327,20 @@ class TestTakoVMConfig:
         assert len(config.job_types) == 2
         assert config.job_types[0].name == "job-a"
 
+    def test_tako_vm_config_dependency_proxy_url_validation(self):
+        """Dependency proxy URL accepts proxy schemes and rejects unsafe values."""
+        config = TakoVMConfig(dependency_proxy_url=" https://proxy.example:8443 ")
+        assert config.dependency_proxy_url == "https://proxy.example:8443"
+
+        with pytest.raises(ValueError, match="dependency_proxy_url"):
+            TakoVMConfig(dependency_proxy_url="file:///tmp/proxy")
+
+        with pytest.raises(ValueError, match="control characters"):
+            TakoVMConfig(dependency_proxy_url="https://proxy.example\nbad")
+
+        with pytest.raises(ValueError, match="path, query, or fragment"):
+            TakoVMConfig(dependency_proxy_url="https://proxy.example:8443/proxy")
+
     def test_tako_vm_config_get_method(self):
         """TakoVMConfig.get() provides dict-like access."""
         config = TakoVMConfig(max_workers=8)
@@ -388,6 +404,8 @@ security_mode: permissive
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_ENABLED", "false")
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_REQUESTS", "42")
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS", "15")
+        monkeypatch.setenv("TAKO_VM_ALLOW_RUNTIME_REQUIREMENTS", "true")
+        monkeypatch.setenv("TAKO_VM_DEPENDENCY_PROXY_URL", "https://proxy.example:8443")
 
         config = load_config()
 
@@ -395,6 +413,8 @@ security_mode: permissive
         assert config.api_rate_limit_enabled is False
         assert config.api_rate_limit_requests == 42
         assert config.api_rate_limit_window_seconds == 15
+        assert config.allow_runtime_requirements is True
+        assert config.dependency_proxy_url == "https://proxy.example:8443"
 
     @pytest.mark.parametrize(
         "var_name",

--- a/tests/test_proc_exposure.py
+++ b/tests/test_proc_exposure.py
@@ -9,13 +9,14 @@ WARNING: These are intentionally vulnerable scenarios to document the risk.
 
 import pytest
 
+from tako_vm.config import TakoVMConfig
 from tako_vm.execution.worker import CodeExecutor
 
 
 @pytest.fixture
 def executor():
     """Create a CodeExecutor for testing."""
-    return CodeExecutor()
+    return CodeExecutor(config=TakoVMConfig(allow_runtime_requirements=True))
 
 
 class TestProcExposure:

--- a/tests/test_proc_exposure.py
+++ b/tests/test_proc_exposure.py
@@ -16,7 +16,14 @@ from tako_vm.execution.worker import CodeExecutor
 @pytest.fixture
 def executor():
     """Create a CodeExecutor for testing."""
-    return CodeExecutor(config=TakoVMConfig(allow_runtime_requirements=True))
+    return CodeExecutor(
+        config=TakoVMConfig(
+            allow_runtime_requirements=True,
+            security_mode="permissive",
+            enable_cap_restrictions=False,
+            enable_seccomp=False,
+        )
+    )
 
 
 class TestProcExposure:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -239,7 +239,7 @@ class TestSandboxRequirements:
 import requests
 print(f"requests version: {requests.__version__}")
 """
-        with Sandbox() as sb:
+        with Sandbox(allow_runtime_requirements=True) as sb:
             result = sb.run(code, requirements=["requests"])
 
         assert result.success is True
@@ -253,7 +253,7 @@ import httpx
 print(f"requests: {requests.__version__}")
 print(f"httpx: {httpx.__version__}")
 """
-        with Sandbox() as sb:
+        with Sandbox(allow_runtime_requirements=True) as sb:
             result = sb.run(code, requirements=["requests", "httpx"])
 
         assert result.success is True
@@ -266,11 +266,66 @@ print(f"httpx: {httpx.__version__}")
 import requests
 print(f"version: {requests.__version__}")
 """
-        with Sandbox() as sb:
+        with Sandbox(allow_runtime_requirements=True) as sb:
             result = sb.run(code, requirements=["requests>=2.20.0"])
 
         assert result.success is True
         assert "version:" in result.stdout
+
+    def test_sandbox_rejects_requirements_by_default(self):
+        """Runtime dependency installation is opt-in."""
+        with Sandbox() as sb:
+            result = sb.run("print('hi')", requirements=["requests"])
+
+        assert result.success is False
+        assert result.exit_code == -1
+        assert result.error is not None
+        assert "Runtime dependency installation is disabled" in result.error
+
+    def test_sandbox_dependency_proxy_url_validation(self):
+        """Sandbox validates dependency proxy URL."""
+        with Sandbox(dependency_proxy_url=" https://proxy.example:8443 ") as sb:
+            assert sb.config.dependency_proxy_url == "https://proxy.example:8443"
+
+        with pytest.raises(ValueError, match="dependency_proxy_url"):
+            Sandbox(dependency_proxy_url="file:///tmp/proxy")
+
+        with pytest.raises(ValueError, match="path, query, or fragment"):
+            Sandbox(dependency_proxy_url="https://proxy.example:8443/proxy")
+
+    def test_sandbox_dependency_proxy_is_scoped_to_runtime_requirements(self, tmp_path):
+        """Sandbox passes proxy only when runtime requirements are present."""
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        sb = Sandbox(
+            allow_runtime_requirements=True,
+            dependency_proxy_url="https://proxy.example:8443",
+        )
+        cmd, _ = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            requirements=["requests"],
+        )
+
+        assert "--env=TAKO_DEPENDENCY_PROXY_URL=https://proxy.example:8443" in cmd
+        assert not any(arg.startswith("--env=HTTP_PROXY=") for arg in cmd)
+
+        (input_dir / "_requirements.txt").unlink()
+        cmd, _ = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+        )
+
+        assert not any(arg.startswith("--env=TAKO_DEPENDENCY_PROXY_URL=") for arg in cmd)
 
 
 @pytest.mark.requires_host_mounts

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -167,7 +167,11 @@ class TestExecutorRejectsUnsafeIds:
 
     def test_run_container_writes_requirements_file_not_env(self, monkeypatch, tmp_path):
         executor = CodeExecutor(
-            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+            config=TakoVMConfig(
+                container_runtime="runsc",
+                security_mode="strict",
+                allow_runtime_requirements=True,
+            )
         )
         code_dir = tmp_path / "code"
         input_dir = tmp_path / "input"
@@ -199,3 +203,91 @@ class TestExecutorRejectsUnsafeIds:
         assert not any(arg.startswith("--env=TAKO_REQUIREMENTS=") for arg in captured["cmd"])
         assert "--network=bridge" in captured["cmd"]
         assert (input_dir / "_requirements.txt").read_text(encoding="utf-8") == "requests>=2.31\n"
+
+    def test_run_container_rejects_requirements_when_policy_disabled(self, monkeypatch, tmp_path):
+        executor = CodeExecutor(
+            config=TakoVMConfig(container_runtime="runsc", security_mode="strict")
+        )
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        fake_run = MagicMock()
+        monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+
+        result = executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            extra_requirements=["requests>=2.31"],
+            job_id="job-123",
+        )
+
+        assert result["success"] is False
+        assert "Runtime dependency installation is disabled" in result["error"]
+        assert not (input_dir / "_requirements.txt").exists()
+        fake_run.assert_not_called()
+
+    def test_run_container_adds_dependency_proxy_only_for_runtime_deps(self, monkeypatch, tmp_path):
+        executor = CodeExecutor(
+            config=TakoVMConfig(
+                container_runtime="runsc",
+                security_mode="strict",
+                allow_runtime_requirements=True,
+                dependency_proxy_url="https://proxy.example:8443",
+            )
+        )
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        captured = {}
+
+        def fake_run(cmd, timeout, capture_output, text, check):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+
+        result = executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            extra_requirements=["requests>=2.31"],
+            job_id="job-123",
+        )
+
+        assert result["success"] is True
+        assert "--env=TAKO_DEPENDENCY_PROXY_URL=https://proxy.example:8443" in captured["cmd"]
+        assert not any(arg.startswith("--env=HTTP_PROXY=") for arg in captured["cmd"])
+        assert not any(arg.startswith("--env=HTTPS_PROXY=") for arg in captured["cmd"])
+        assert not any(arg.startswith("--env=ALL_PROXY=") for arg in captured["cmd"])
+
+        captured.clear()
+        (input_dir / "_requirements.txt").unlink()
+        result = executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            job_id="job-123",
+        )
+
+        assert result["success"] is True
+        assert not any(
+            arg.startswith("--env=TAKO_DEPENDENCY_PROXY_URL=") for arg in captured["cmd"]
+        )


### PR DESCRIPTION
## Summary
- make runtime dependency installation opt-in via allow_runtime_requirements
- add validated dependency_proxy_url support scoped to dependency installation
- keep proxy variables out of user-code ambient HTTP_PROXY/HTTPS_PROXY/ALL_PROXY
- update docs and tests for the new default-deny policy

## Verification
- bash -n docker/entrypoint.sh
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/pytest tests/test_config.py tests/test_security.py tests/test_sandbox.py tests/test_proc_exposure.py -q
- .venv/bin/pytest -q