### PR TITLE
Route compose Docker access through socket proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,28 @@
 #   docker-compose logs -f tako-vm
 
 services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: tako-vm-docker-socket-proxy
+    environment:
+      # Docker CLI health/startup checks
+      - INFO=1
+      # Required for docker run lifecycle: create/start/wait/logs/remove.
+      - CONTAINERS=1
+      # Required for image inspection during container creation.
+      - IMAGES=1
+      # Required because executor containers use a named uv cache volume.
+      - VOLUMES=1
+      # Required for container create/start/stop API calls.
+      - POST=1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    networks:
+      - docker-internal
+    security_opt:
+      - no-new-privileges:true
+
   tako-vm:
     build:
       context: .
@@ -19,8 +41,6 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      # Docker socket for spawning executor containers
-      - /var/run/docker.sock:/var/run/docker.sock
       # Shared workspace for job files (must match host path for Docker mounts)
       - /tmp/tako-vm-jobs:/tmp/tako-vm-jobs
       # Config with scaled worker settings (16 workers, 500 queue)
@@ -32,9 +52,15 @@ services:
       # Use shared workspace path for job files
       - TAKO_VM_WORKSPACE=/tmp/tako-vm-jobs
       - TAKO_VM_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/tako_vm
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     depends_on:
+      docker-socket-proxy:
+        condition: service_started
       postgres:
         condition: service_healthy
+    networks:
+      - default
+      - docker-internal
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
@@ -73,3 +99,7 @@ services:
 # Optional: persist data
 volumes:
   tako-vm-postgres-data:
+
+networks:
+  docker-internal:
+    internal: true

--- a/docs/deployment/how-to-deploy.md
+++ b/docs/deployment/how-to-deploy.md
@@ -124,13 +124,27 @@ docker-compose logs -f tako-vm
 
 1. **tako-vm-server** - The API server (from `docker/Dockerfile.server`)
 2. **code-executor** - The sandbox container for running code (from `docker/Dockerfile.executor`)
+3. **docker-socket-proxy** - Internal Docker API proxy used by the server to start executor containers
 
 ### docker-compose.yaml
 
-The included `docker-compose.yaml` handles everything:
+The included `docker-compose.yaml` handles everything. The public `tako-vm` service does not mount `/var/run/docker.sock` directly; it reaches Docker through an internal socket proxy on `DOCKER_HOST=tcp://docker-socket-proxy:2375`.
 
 ```yaml
 services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - INFO=1
+      - POST=1
+      - VOLUMES=1
+    networks:
+      - docker-internal
+
   tako-vm:
     build:
       context: .
@@ -139,10 +153,12 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      # Docker socket for spawning executor containers
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Shared workspace for job files
+      - /tmp/tako-vm-jobs:/tmp/tako-vm-jobs
       # Optional: mount custom config
       # - ./tako_vm.yaml:/app/tako_vm.yaml:ro
+    environment:
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
@@ -175,7 +191,7 @@ docker-compose down && docker-compose up -d
 ```
 
 !!! warning "Security Note"
-    Mounting `/var/run/docker.sock` gives Tako VM full Docker access. The executor containers are still isolated, but Tako VM itself has elevated privileges.
+    The socket proxy is an interim hardening layer: it removes the raw Docker socket from the public API container and limits Docker API sections, but it is not the same as a dedicated policy-enforcing executor service. Treat the compose deployment as trusted infrastructure and keep it behind authentication and network controls.
 
 ### Container-in-Container: Workspace Volume
 
@@ -195,12 +211,12 @@ services:
   tako-vm:
     # ... other config ...
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       # Shared workspace - same path inside container AND on host
       - /tmp/tako-workspace:/tmp/tako-workspace
     environment:
       # Tell Tako VM to use this directory for job files
       - TAKO_VM_WORKSPACE=/tmp/tako-workspace
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
 ```
 
 This mounts the **same host directory** at the **same path** inside Tako VM, so when Docker mounts `/tmp/tako-workspace/job-123`, it finds the files.

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -94,18 +94,21 @@ docker-compose logs -f tako-vm
 docker-compose down
 ```
 
+The compose deployment routes Docker access through an internal `docker-socket-proxy` service. The public `tako-vm` container does not mount `/var/run/docker.sock` directly.
+
 To customize, mount your config file:
 
 ```yaml
 services:
   tako-vm:
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - ./tako_vm.yaml:/app/tako_vm.yaml:ro  # Add this line
+    environment:
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
 ```
 
 !!! warning
-    Mounting the Docker socket gives Tako VM access to the Docker daemon. In high-security environments, consider using Docker-in-Docker or a separate Docker host.
+    The socket proxy is an interim mitigation, not a complete privilege boundary. In high-security environments, prefer Docker-in-Docker, a separate Docker host, or the planned dedicated executor service with policy enforcement.
 
 ## Reverse Proxy (Nginx)
 

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -455,7 +455,7 @@ docker run --runtime=runsc ...
 
 ### Does Containerizing the API Server Add Security?
 
-**Short answer: No.** The API server needs Docker socket access to spawn executor containers. Docker socket access effectively grants root privileges on the host, so containerizing the server doesn't create a meaningful security boundary.
+**Short answer: only partially.** The Docker Compose deployment avoids mounting `/var/run/docker.sock` into the public API container directly; instead it uses an internal `docker-socket-proxy` service and sets `DOCKER_HOST=tcp://docker-socket-proxy:2375`. This reduces accidental exposure of the raw socket and limits Docker API sections, but it does not create the same privilege boundary as a separate policy-enforcing executor service.
 
 ```
 Current Model (adequate for most cases):

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,0 +1,37 @@
+"""Tests for docker-compose deployment hardening."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _compose_config() -> dict:
+    return yaml.safe_load((ROOT / "docker-compose.yaml").read_text(encoding="utf-8"))
+
+
+def test_api_service_uses_socket_proxy_instead_of_socket_mount():
+    """The public API service should not mount the host Docker socket directly."""
+    config = _compose_config()
+    tako_vm = config["services"]["tako-vm"]
+    volumes = tako_vm.get("volumes", [])
+    environment = tako_vm.get("environment", [])
+
+    assert not any("/var/run/docker.sock" in volume for volume in volumes)
+    assert "DOCKER_HOST=tcp://docker-socket-proxy:2375" in environment
+    assert "docker-socket-proxy" in tako_vm["depends_on"]
+    assert "docker-internal" in tako_vm["networks"]
+
+
+def test_socket_proxy_is_internal_and_owns_socket_mount():
+    """Only the internal proxy service should receive the Docker socket mount."""
+    config = _compose_config()
+    proxy = config["services"]["docker-socket-proxy"]
+    volumes = proxy.get("volumes", [])
+    environment = set(proxy.get("environment", []))
+
+    assert "/var/run/docker.sock:/var/run/docker.sock:ro" in volumes
+    assert "docker-internal" in proxy["networks"]
+    assert config["networks"]["docker-internal"]["internal"] is True
+    assert {"CONTAINERS=1", "IMAGES=1", "INFO=1", "POST=1", "VOLUMES=1"} <= environment


### PR DESCRIPTION
## Summary
- add an internal docker-socket-proxy service to docker-compose.yaml
- remove the direct /var/run/docker.sock mount from the public tako-vm service
- set DOCKER_HOST=tcp://docker-socket-proxy:2375 for Docker CLI access
- document the proxy as an interim mitigation, not a complete executor-service boundary
- add compose regression tests for socket ownership and internal networking

## Notes
This reduces direct socket exposure for compose deployments but does not fully close #7. The dedicated policy-enforcing executor service is still the long-term fix.

## Verification
- docker compose config
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/pytest tests/test_docker_compose.py tests/test_config.py tests/test_security.py -q
- .venv/bin/pytest -q