### PR TITLE
Make runtime dependency cache opt in

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,9 +102,9 @@
                                │
                                ▼
                         ┌──────────────────┐
-                        │ Cached in        │
-                        │ tako-uv-cache    │
-                        │ volume           │
+                        │ Optional shared  │
+                        │ cache volume     │
+                        │ if enabled       │
                         └──────────────────┘
 
 Security Layers:
@@ -123,7 +123,7 @@ Security Layers:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                     Runtime Dependencies (Default)                          │
+│                     Runtime Dependencies (Opt-in)                           │
 └─────────────────────────────────────────────────────────────────────────────┘
 
   Job Config                    Container                    Result
@@ -134,15 +134,15 @@ Security Layers:
       │                             │                           │
       ▼                             ▼                           ▼
 ┌──────────────┐          ┌─────────────────┐         ┌──────────────┐
-│ TAKO_        │─────────▶│ uv pip install  │────────▶│ Code runs    │
-│ REQUIREMENTS │          │ pandas numpy    │         │ with deps    │
-│ env var      │          │ (~1-2 seconds)  │         │ available    │
+│ /input/      │─────────▶│ uv pip install  │────────▶│ Code runs    │
+│ _requirements│          │ pandas numpy    │         │ with deps    │
+│ .txt file    │          │                 │         │ available    │
 └──────────────┘          └─────────────────┘         └──────────────┘
                                   │
                                   ▼
                           ┌─────────────────┐
-                          │ tako-uv-cache   │  Cached for
-                          │ Docker volume   │  future runs
+                          │ Optional shared │  Enabled only with
+                          │ Docker volume   │  dependency cache
                           └─────────────────┘
 
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -86,7 +86,7 @@ Comparison of secure code execution platforms (as of January 2026)
 **Tako VM:**
 - **Runtime installation** via `uv` (10x faster than pip)
 - Single base image for all job types
-- Dependencies cached in Docker volume (`tako-uv-cache`)
+- Runtime dependency cache is opt-in (`enable_runtime_dependency_cache`)
 - Optional: Pre-built images for production
 - Install time: ~1-2 seconds for common packages
 

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -51,7 +51,7 @@ job_types:
 
 When `network_enabled: true`, containers can access any external host. For strict egress control, use external firewalls or Kubernetes NetworkPolicy.
 
-Runtime dependency installation is disabled by default. This prevents untrusted jobs from fetching packages and running package setup code during execution. Prefer pre-built images; if a trusted deployment needs runtime installs, set `allow_runtime_requirements: true` and route installs through `dependency_proxy_url`.
+Runtime dependency installation is disabled by default. This prevents untrusted jobs from fetching packages and running package setup code during execution. Prefer pre-built images; if a trusted deployment needs runtime installs, set `allow_runtime_requirements: true` and route installs through `dependency_proxy_url`. The shared uv cache volume is also disabled by default; enable `enable_runtime_dependency_cache` only when you accept shared writable dependency-cache state across jobs.
 
 ### Read-Only Filesystem
 

--- a/docs/design/dind-support.md
+++ b/docs/design/dind-support.md
@@ -151,7 +151,7 @@ Tako VM connects to the sidecar's Docker daemon via `DOCKER_HOST=tcp://localhost
 
 1. **Executor image exists**: Tako VM assumes `code-executor:latest` is available. With dind, the nested daemon starts empty.
 
-2. **UV cache volume exists**: Tako VM mounts `tako-uv-cache` volume for fast dependency installs. This volume doesn't exist in a fresh dind daemon.
+2. **UV cache volume exists when enabled**: If `enable_runtime_dependency_cache` is true, Tako VM mounts the `tako-uv-cache` volume for faster dependency installs. This volume doesn't exist in a fresh dind daemon.
 
 ### Required Changes
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -48,6 +48,7 @@ max_timeout: 300          # maximum allowed
 
 allow_runtime_requirements: false      # install request/job requirements at runtime
 dependency_proxy_url: null             # optional proxy for runtime dependency installs
+enable_runtime_dependency_cache: false # shared uv cache for runtime installs
 
 max_code_bytes: 102400    # 100KB
 max_input_bytes: 1048576  # 1MB
@@ -113,6 +114,8 @@ execution_record_ttl_days: 30
 
 !!! warning "Runtime dependencies are opt-in"
     `requirements` are intended for pre-built job images. Runtime installation is disabled by default because it allows outbound package downloads and package setup code execution. Set `allow_runtime_requirements: true` only for trusted deployments, preferably with `dependency_proxy_url` configured.
+
+    The shared uv dependency cache is also disabled by default to avoid writable state shared across jobs. Set `enable_runtime_dependency_cache: true` only when the performance benefit is worth the cross-job cache tradeoff.
 
 ## Config File Search Order
 

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -110,6 +110,7 @@ Runtime dependency installation from `requirements` is disabled by default. Use 
 ```yaml
 allow_runtime_requirements: true
 dependency_proxy_url: "https://proxy.example:8443"  # optional
+enable_runtime_dependency_cache: false              # default: no shared writable cache
 ```
 
 ## List Job Types
@@ -167,6 +168,7 @@ In production mode (`production_mode: true`):
 - All job types must be pre-built
 - Requests for missing job types fail with an error
 - Runtime dependency installation should remain disabled
+- Shared runtime dependency cache should remain disabled unless explicitly needed
 
 ```yaml
 production_mode: true

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -335,6 +335,10 @@ class TakoVMConfig(BaseModel):
         default=None,
         description="Optional HTTP(S)/SOCKS proxy URL used only during runtime dependency installs",
     )
+    enable_runtime_dependency_cache: bool = Field(
+        default=False,
+        description="Mount a shared uv cache volume for runtime dependency installs",
+    )
 
     # Retention
     execution_record_ttl_days: int = Field(default=30, ge=1, le=3650)
@@ -587,6 +591,14 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         )
     if "TAKO_VM_DEPENDENCY_PROXY_URL" in os.environ:
         config_dict["dependency_proxy_url"] = os.environ["TAKO_VM_DEPENDENCY_PROXY_URL"]
+    if "TAKO_VM_ENABLE_RUNTIME_DEPENDENCY_CACHE" in os.environ:
+        config_dict["enable_runtime_dependency_cache"] = os.environ[
+            "TAKO_VM_ENABLE_RUNTIME_DEPENDENCY_CACHE"
+        ].lower() in (
+            "true",
+            "1",
+            "yes",
+        )
     # Validate and create config
     try:
         config = TakoVMConfig(**config_dict)

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -934,7 +934,11 @@ class CodeExecutor:
 
         # Mount uv cache volume for faster repeated installs
         if has_runtime_deps:
-            cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target=/root/.cache/uv")
+            uv_cache_dir = "/tmp/uv-cache"
+            if self.config.enable_runtime_dependency_cache:
+                uv_cache_dir = "/root/.cache/uv"
+                cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
+            cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 
         # Network isolation (default: no network for security)
         if job_type.network_enabled:

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -113,6 +113,9 @@ class SandboxConfig:
     dependency_proxy_url: Optional[str] = None
     """Optional proxy URL used only during runtime dependency installs."""
 
+    enable_runtime_dependency_cache: bool = False
+    """Whether to mount a shared uv cache volume for runtime dependency installs."""
+
     package_dirs: List[str] = field(default_factory=list)
     """Local directories to mount as packages (added to PYTHONPATH)."""
 
@@ -159,6 +162,7 @@ class Sandbox:
         network_enabled: bool = False,
         allow_runtime_requirements: bool = False,
         dependency_proxy_url: Optional[str] = None,
+        enable_runtime_dependency_cache: bool = False,
         package_dirs: Optional[List[str]] = None,
         auto_build: bool = True,
     ):
@@ -173,6 +177,7 @@ class Sandbox:
             network_enabled: Whether to allow network access
             allow_runtime_requirements: Whether requirements may be installed at runtime
             dependency_proxy_url: Optional proxy URL for runtime dependency installs
+            enable_runtime_dependency_cache: Whether to use a shared uv cache volume
             package_dirs: Local directories to mount as Python packages
             auto_build: Whether to auto-build image if missing
         """
@@ -184,6 +189,7 @@ class Sandbox:
             network_enabled=network_enabled,
             allow_runtime_requirements=allow_runtime_requirements,
             dependency_proxy_url=_validate_dependency_proxy_url(dependency_proxy_url),
+            enable_runtime_dependency_cache=enable_runtime_dependency_cache,
             package_dirs=package_dirs or [],
         )
         self.auto_build = auto_build
@@ -491,7 +497,11 @@ class Sandbox:
 
         # Mount uv cache for faster installs
         if has_requirements:
-            cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target=/root/.cache/uv")
+            uv_cache_dir = "/tmp/uv-cache"
+            if self.config.enable_runtime_dependency_cache:
+                uv_cache_dir = "/root/.cache/uv"
+                cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
+            cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 
         # Resource limits
         cmd.extend(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,6 +256,7 @@ class TestTakoVMConfig:
         assert config.api_rate_limit_window_seconds == 60
         assert config.allow_runtime_requirements is False
         assert config.dependency_proxy_url is None
+        assert config.enable_runtime_dependency_cache is False
 
     def test_tako_vm_config_path_resolution(self):
         """TakoVMConfig resolves data_dir while keeping database URL."""
@@ -406,6 +407,7 @@ security_mode: permissive
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS", "15")
         monkeypatch.setenv("TAKO_VM_ALLOW_RUNTIME_REQUIREMENTS", "true")
         monkeypatch.setenv("TAKO_VM_DEPENDENCY_PROXY_URL", "https://proxy.example:8443")
+        monkeypatch.setenv("TAKO_VM_ENABLE_RUNTIME_DEPENDENCY_CACHE", "true")
 
         config = load_config()
 
@@ -415,6 +417,7 @@ security_mode: permissive
         assert config.api_rate_limit_window_seconds == 15
         assert config.allow_runtime_requirements is True
         assert config.dependency_proxy_url == "https://proxy.example:8443"
+        assert config.enable_runtime_dependency_cache is True
 
     @pytest.mark.parametrize(
         "var_name",

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from tako_vm.constants import UV_CACHE_VOLUME
 from tako_vm.sandbox import Sandbox, SandboxResult
 from tako_vm.sandbox import run as sandbox_run
 
@@ -326,6 +327,36 @@ print(f"version: {requests.__version__}")
         )
 
         assert not any(arg.startswith("--env=TAKO_DEPENDENCY_PROXY_URL=") for arg in cmd)
+
+    @pytest.mark.parametrize(
+        ("cache_enabled", "expect_cache_mount"),
+        [(False, False), (True, True)],
+    )
+    def test_sandbox_dependency_cache_is_opt_in(self, tmp_path, cache_enabled, expect_cache_mount):
+        """Sandbox mounts the shared uv cache only when explicitly enabled."""
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        sb = Sandbox(
+            allow_runtime_requirements=True,
+            enable_runtime_dependency_cache=cache_enabled,
+        )
+        cmd, _ = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            requirements=["requests"],
+        )
+
+        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target=/root/.cache/uv"
+        expected_cache_dir = "/root/.cache/uv" if cache_enabled else "/tmp/uv-cache"
+        assert (cache_mount in cmd) is expect_cache_mount
+        assert f"--env=UV_CACHE_DIR={expected_cache_dir}" in cmd
 
 
 @pytest.mark.requires_host_mounts

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -6,6 +6,7 @@ import pytest
 
 import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
+from tako_vm.constants import UV_CACHE_VOLUME
 from tako_vm.execution import CodeExecutor
 from tako_vm.job_types import JobType
 from tako_vm.security import (
@@ -291,3 +292,50 @@ class TestExecutorRejectsUnsafeIds:
         assert not any(
             arg.startswith("--env=TAKO_DEPENDENCY_PROXY_URL=") for arg in captured["cmd"]
         )
+
+    @pytest.mark.parametrize(
+        ("cache_enabled", "expect_cache_mount"),
+        [(False, False), (True, True)],
+    )
+    def test_run_container_dependency_cache_is_opt_in(
+        self, monkeypatch, tmp_path, cache_enabled, expect_cache_mount
+    ):
+        executor = CodeExecutor(
+            config=TakoVMConfig(
+                container_runtime="runsc",
+                security_mode="strict",
+                allow_runtime_requirements=True,
+                enable_runtime_dependency_cache=cache_enabled,
+            )
+        )
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        code_dir.mkdir()
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        captured = {}
+
+        def fake_run(cmd, timeout, capture_output, text, check):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+
+        result = executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            extra_requirements=["requests>=2.31"],
+            job_id="job-123",
+        )
+
+        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target=/root/.cache/uv"
+        expected_cache_dir = "/root/.cache/uv" if cache_enabled else "/tmp/uv-cache"
+        assert result["success"] is True
+        assert (cache_mount in captured["cmd"]) is expect_cache_mount
+        assert f"--env=UV_CACHE_DIR={expected_cache_dir}" in captured["cmd"]


### PR DESCRIPTION
## Summary
- make the shared uv runtime dependency cache opt-in via enable_runtime_dependency_cache=false by default
- use per-container /tmp/uv-cache when the shared cache is disabled so installs still work on read-only root filesystems
- add worker and Sandbox coverage for cache mount behavior and UV_CACHE_DIR
- update docs that previously described the shared cache as unconditional

## Verification
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/pytest tests/test_config.py tests/test_security.py tests/test_sandbox.py -q
- .venv/bin/pytest -q