### PR TITLE
Add opt-in API key authentication

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -112,6 +112,16 @@ services:
 
 ## Reverse Proxy (Nginx)
 
+Enable API key authentication before exposing Tako VM beyond a trusted local network:
+
+```yaml
+api_auth_enabled: true
+api_keys:
+  - "replace-with-a-long-random-key"
+```
+
+Clients should send `X-API-Key: <key>` or `Authorization: Bearer <key>`. Keep reverse-proxy authentication or network controls in front as defense in depth.
+
 ```nginx
 # /etc/nginx/sites-available/tako-vm
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -36,6 +36,9 @@ database_url: "postgresql://postgres:postgres@localhost:5432/tako_vm"
 # API PROTECTION
 # ==============================================================================
 api_max_payload_bytes: 2097152       # 2MB max HTTP request body
+api_auth_enabled: false              # Require API key auth for protected routes
+api_keys: []                         # Accepted API keys when auth is enabled
+api_auth_header: X-API-Key           # Header for API key auth
 api_rate_limit_enabled: true         # Enable per-client-IP rate limiting
 api_rate_limit_requests: 120         # Requests allowed per window
 api_rate_limit_window_seconds: 60    # Rate limit window in seconds
@@ -116,6 +119,27 @@ execution_record_ttl_days: 30
     `requirements` are intended for pre-built job images. Runtime installation is disabled by default because it allows outbound package downloads and package setup code execution. Set `allow_runtime_requirements: true` only for trusted deployments, preferably with `dependency_proxy_url` configured.
 
     The shared uv dependency cache is also disabled by default to avoid writable state shared across jobs. Set `enable_runtime_dependency_cache: true` only when the performance benefit is worth the cross-job cache tradeoff.
+
+## API Authentication
+
+API authentication is disabled by default for local compatibility. For exposed deployments, enable API keys:
+
+```yaml
+api_auth_enabled: true
+api_keys:
+  - "replace-with-a-long-random-key"
+api_auth_header: X-API-Key
+```
+
+Clients can send either `X-API-Key: <key>` or `Authorization: Bearer <key>`. Health, docs, and OpenAPI routes remain unauthenticated for operations. When auth is enabled, rate limits are tracked per API key instead of only by client IP.
+
+Environment variables:
+
+```bash
+TAKO_VM_API_AUTH_ENABLED=true
+TAKO_VM_API_KEYS=key-one-at-least-16,key-two-at-least-16
+TAKO_VM_API_AUTH_HEADER=X-API-Key
+```
 
 ## Config File Search Order
 
@@ -307,6 +331,9 @@ limactl shell tako-gvisor
 | `server_host` | Server bind host | `0.0.0.0` |
 | `server_port` | Server bind port | `8000` |
 | `api_max_payload_bytes` | Max HTTP request body size (bytes) | `2097152` |
+| `api_auth_enabled` | Require API key auth for protected routes | `false` |
+| `api_keys` | Accepted API keys when auth is enabled | `[]` |
+| `api_auth_header` | Header used for API key auth | `X-API-Key` |
 | `api_rate_limit_enabled` | Enable API rate limiting | `true` |
 | `api_rate_limit_requests` | Requests allowed per rate-limit window | `120` |
 | `api_rate_limit_window_seconds` | Rate-limit window duration (seconds) | `60` |

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -239,6 +239,15 @@ class TakoVMConfig(BaseModel):
     api_max_payload_bytes: int = Field(
         default=2097152, ge=1024, le=104857600, description="Maximum HTTP request payload size"
     )
+    api_auth_enabled: bool = Field(default=False, description="Require API key authentication")
+    api_keys: List[str] = Field(
+        default_factory=list,
+        description="Accepted API keys when api_auth_enabled is true",
+    )
+    api_auth_header: str = Field(
+        default="X-API-Key",
+        description="Header used for API key authentication",
+    )
     api_rate_limit_enabled: bool = Field(default=True, description="Enable API rate limiting")
     api_rate_limit_requests: int = Field(
         default=120, ge=1, le=100000, description="Requests allowed per rate limit window"
@@ -271,6 +280,45 @@ class TakoVMConfig(BaseModel):
         if v.upper() not in valid_levels:
             raise ValueError(f"log_level must be one of: {', '.join(sorted(valid_levels))}")
         return v.upper()
+
+    @field_validator("api_auth_header")
+    @classmethod
+    def validate_api_auth_header(cls, v: str) -> str:
+        """Validate API auth header name."""
+        normalized = v.strip()
+        if not normalized:
+            raise ValueError("api_auth_header cannot be empty")
+        allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        if any(char not in allowed for char in normalized):
+            raise ValueError("api_auth_header must be a valid HTTP header name")
+        return normalized
+
+    @field_validator("api_keys")
+    @classmethod
+    def validate_api_keys(cls, values: List[str]) -> List[str]:
+        """Normalize and validate configured API keys."""
+        normalized: List[str] = []
+        seen: set[str] = set()
+        for value in values:
+            key = value.strip()
+            if not key:
+                raise ValueError("api_keys cannot contain empty values")
+            if any(char in key for char in ("\n", "\r", "\x00")):
+                raise ValueError("api_keys cannot contain control characters")
+            if len(key) < 16:
+                raise ValueError("api_keys entries must be at least 16 characters")
+            if key in seen:
+                raise ValueError("api_keys cannot contain duplicate values")
+            seen.add(key)
+            normalized.append(key)
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_api_auth_config(self) -> "TakoVMConfig":
+        """Require at least one API key when auth is enabled."""
+        if self.api_auth_enabled and not self.api_keys:
+            raise ValueError("api_keys must contain at least one key when api_auth_enabled=true")
+        return self
 
     database_url: str = Field(
         default="postgresql://postgres:postgres@localhost:5432/tako_vm",
@@ -567,6 +615,18 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         )
     if "TAKO_VM_API_MAX_PAYLOAD_BYTES" in os.environ:
         config_dict["api_max_payload_bytes"] = parse_env_int("TAKO_VM_API_MAX_PAYLOAD_BYTES")
+    if "TAKO_VM_API_AUTH_ENABLED" in os.environ:
+        config_dict["api_auth_enabled"] = os.environ["TAKO_VM_API_AUTH_ENABLED"].lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+    if "TAKO_VM_API_KEYS" in os.environ:
+        config_dict["api_keys"] = [
+            key.strip() for key in os.environ["TAKO_VM_API_KEYS"].split(",") if key.strip()
+        ]
+    if "TAKO_VM_API_AUTH_HEADER" in os.environ:
+        config_dict["api_auth_header"] = os.environ["TAKO_VM_API_AUTH_HEADER"]
     if "TAKO_VM_API_RATE_LIMIT_ENABLED" in os.environ:
         config_dict["api_rate_limit_enabled"] = os.environ[
             "TAKO_VM_API_RATE_LIMIT_ENABLED"

--- a/tako_vm/server/limits.py
+++ b/tako_vm/server/limits.py
@@ -8,6 +8,8 @@ This middleware provides lightweight API-layer protections:
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import math
 import time
 from threading import Lock
@@ -26,6 +28,7 @@ from tako_vm.server.correlation import (
 
 _CORRELATION_ID_HEADER_BYTES = CORRELATION_ID_HEADER.lower().encode("ascii")
 _RATE_LIMIT_EXEMPT_PATHS = {
+    "/health",
     "/openapi.json",
     "/docs/oauth2-redirect",
 }
@@ -87,7 +90,8 @@ class ApiProtectionMiddleware:
     """
     Enforce API request protections.
 
-    - Rate limits requests by client IP (excluding docs/schema routes)
+    - Optionally requires API key auth (excluding health/docs/schema routes)
+    - Rate limits requests by client IP or authenticated API key
     - Rejects oversized payloads with HTTP 413
     """
 
@@ -104,10 +108,24 @@ class ApiProtectionMiddleware:
 
         config = self._config_getter()
         path = scope.get("path", "")
+        authenticated_key = None
+
+        if config.api_auth_enabled and not self._is_auth_exempt(path):
+            authenticated_key = self._authenticate_request(scope, config)
+            if authenticated_key is None:
+                await self._send_error_response(
+                    scope,
+                    receive,
+                    send,
+                    status_code=401,
+                    detail="Missing or invalid API key.",
+                    extra_headers={"WWW-Authenticate": "Bearer"},
+                )
+                return
 
         if config.api_rate_limit_enabled and not self._is_rate_limit_exempt(path):
             limiter = self._get_rate_limiter(config)
-            client_id = self._get_client_identifier(scope)
+            client_id = self._get_client_identifier(scope, authenticated_key)
             allowed, retry_after = limiter.allow(client_id)
 
             if not allowed:
@@ -201,9 +219,46 @@ class ApiProtectionMiddleware:
 
         return self._rate_limiter
 
+    def _authenticate_request(self, scope: Scope, config: TakoVMConfig) -> Optional[str]:
+        """Return the matched API key if the request is authenticated."""
+        provided_key = self._extract_api_key(scope, config.api_auth_header)
+        if provided_key is None:
+            return None
+
+        for configured_key in config.api_keys:
+            if hmac.compare_digest(provided_key, configured_key):
+                return configured_key
+        return None
+
     @staticmethod
-    def _get_client_identifier(scope: Scope) -> str:
-        """Use client host as rate-limiting identifier."""
+    def _extract_api_key(scope: Scope, api_auth_header: str) -> Optional[str]:
+        """Extract API key from configured header or Authorization bearer token."""
+        configured_header = api_auth_header.lower().encode("ascii")
+        for header_name, header_value in scope.get("headers", []):
+            header_name_lower = header_name.lower()
+            if header_name_lower == configured_header:
+                try:
+                    value = header_value.decode("utf-8").strip()
+                except UnicodeDecodeError:
+                    return None
+                return value or None
+            if header_name_lower == b"authorization":
+                try:
+                    value = header_value.decode("utf-8").strip()
+                except UnicodeDecodeError:
+                    return None
+                prefix = "bearer "
+                if value.lower().startswith(prefix):
+                    token = value[len(prefix) :].strip()
+                    return token or None
+        return None
+
+    @staticmethod
+    def _get_client_identifier(scope: Scope, authenticated_key: Optional[str] = None) -> str:
+        """Use API key identity when present, otherwise client host."""
+        if authenticated_key:
+            key_hash = hashlib.sha256(authenticated_key.encode("utf-8")).hexdigest()[:16]
+            return f"api_key:{key_hash}"
         client = scope.get("client")
         if client and client[0]:
             return str(client[0])
@@ -219,6 +274,11 @@ class ApiProtectionMiddleware:
             path == prefix or path.startswith(f"{prefix}/")
             for prefix in _RATE_LIMIT_EXEMPT_PREFIXES
         )
+
+    @classmethod
+    def _is_auth_exempt(cls, path: str) -> bool:
+        """Allow health/docs/schema endpoints to bypass API key auth."""
+        return cls._is_rate_limit_exempt(path)
 
     @staticmethod
     def _get_content_length(scope: Scope) -> Optional[int]:

--- a/tako_vm/server/limits.py
+++ b/tako_vm/server/limits.py
@@ -8,7 +8,6 @@ This middleware provides lightweight API-layer protections:
 
 from __future__ import annotations
 
-import hashlib
 import hmac
 import math
 import time
@@ -108,11 +107,11 @@ class ApiProtectionMiddleware:
 
         config = self._config_getter()
         path = scope.get("path", "")
-        authenticated_key = None
+        authenticated_identity = None
 
         if config.api_auth_enabled and not self._is_auth_exempt(path):
-            authenticated_key = self._authenticate_request(scope, config)
-            if authenticated_key is None:
+            authenticated_identity = self._authenticate_request(scope, config)
+            if authenticated_identity is None:
                 await self._send_error_response(
                     scope,
                     receive,
@@ -125,7 +124,7 @@ class ApiProtectionMiddleware:
 
         if config.api_rate_limit_enabled and not self._is_rate_limit_exempt(path):
             limiter = self._get_rate_limiter(config)
-            client_id = self._get_client_identifier(scope, authenticated_key)
+            client_id = self._get_client_identifier(scope, authenticated_identity)
             allowed, retry_after = limiter.allow(client_id)
 
             if not allowed:
@@ -220,14 +219,14 @@ class ApiProtectionMiddleware:
         return self._rate_limiter
 
     def _authenticate_request(self, scope: Scope, config: TakoVMConfig) -> Optional[str]:
-        """Return the matched API key if the request is authenticated."""
+        """Return a non-secret API key identity if the request is authenticated."""
         provided_key = self._extract_api_key(scope, config.api_auth_header)
         if provided_key is None:
             return None
 
-        for configured_key in config.api_keys:
+        for index, configured_key in enumerate(config.api_keys):
             if hmac.compare_digest(provided_key, configured_key):
-                return configured_key
+                return f"api_key:{index}"
         return None
 
     @staticmethod
@@ -254,11 +253,10 @@ class ApiProtectionMiddleware:
         return None
 
     @staticmethod
-    def _get_client_identifier(scope: Scope, authenticated_key: Optional[str] = None) -> str:
+    def _get_client_identifier(scope: Scope, authenticated_identity: Optional[str] = None) -> str:
         """Use API key identity when present, otherwise client host."""
-        if authenticated_key:
-            key_hash = hashlib.sha256(authenticated_key.encode("utf-8")).hexdigest()[:16]
-            return f"api_key:{key_hash}"
+        if authenticated_identity:
+            return authenticated_identity
         client = scope.get("client")
         if client and client[0]:
             return str(client[0])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,6 +254,9 @@ class TestTakoVMConfig:
         assert config.api_rate_limit_enabled is True
         assert config.api_rate_limit_requests == 120
         assert config.api_rate_limit_window_seconds == 60
+        assert config.api_auth_enabled is False
+        assert config.api_keys == []
+        assert config.api_auth_header == "X-API-Key"
         assert config.allow_runtime_requirements is False
         assert config.dependency_proxy_url is None
         assert config.enable_runtime_dependency_cache is False
@@ -342,6 +345,20 @@ class TestTakoVMConfig:
         with pytest.raises(ValueError, match="path, query, or fragment"):
             TakoVMConfig(dependency_proxy_url="https://proxy.example:8443/proxy")
 
+    def test_tako_vm_config_api_auth_validation(self):
+        """API auth requires usable keys when enabled."""
+        config = TakoVMConfig(api_auth_enabled=True, api_keys=[" aaaaaaaaaaaaaaaa "])
+        assert config.api_keys == ["aaaaaaaaaaaaaaaa"]
+
+        with pytest.raises(ValueError, match="api_keys"):
+            TakoVMConfig(api_auth_enabled=True)
+
+        with pytest.raises(ValueError, match="at least 16"):
+            TakoVMConfig(api_auth_enabled=True, api_keys=["short"])
+
+        with pytest.raises(ValueError, match="api_auth_header"):
+            TakoVMConfig(api_auth_header="Bad Header")
+
     def test_tako_vm_config_get_method(self):
         """TakoVMConfig.get() provides dict-like access."""
         config = TakoVMConfig(max_workers=8)
@@ -405,6 +422,9 @@ security_mode: permissive
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_ENABLED", "false")
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_REQUESTS", "42")
         monkeypatch.setenv("TAKO_VM_API_RATE_LIMIT_WINDOW_SECONDS", "15")
+        monkeypatch.setenv("TAKO_VM_API_AUTH_ENABLED", "true")
+        monkeypatch.setenv("TAKO_VM_API_KEYS", "aaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb")
+        monkeypatch.setenv("TAKO_VM_API_AUTH_HEADER", "X-Tako-Key")
         monkeypatch.setenv("TAKO_VM_ALLOW_RUNTIME_REQUIREMENTS", "true")
         monkeypatch.setenv("TAKO_VM_DEPENDENCY_PROXY_URL", "https://proxy.example:8443")
         monkeypatch.setenv("TAKO_VM_ENABLE_RUNTIME_DEPENDENCY_CACHE", "true")
@@ -415,6 +435,9 @@ security_mode: permissive
         assert config.api_rate_limit_enabled is False
         assert config.api_rate_limit_requests == 42
         assert config.api_rate_limit_window_seconds == 15
+        assert config.api_auth_enabled is True
+        assert config.api_keys == ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]
+        assert config.api_auth_header == "X-Tako-Key"
         assert config.allow_runtime_requirements is True
         assert config.dependency_proxy_url == "https://proxy.example:8443"
         assert config.enable_runtime_dependency_cache is True

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -12,6 +12,9 @@ from tako_vm.server.limits import ApiProtectionMiddleware
 def create_client(
     *,
     api_max_payload_bytes: int = 1024,
+    api_auth_enabled: bool = False,
+    api_keys: list[str] | None = None,
+    api_auth_header: str = "X-API-Key",
     api_rate_limit_enabled: bool = True,
     api_rate_limit_requests: int = 2,
     api_rate_limit_window_seconds: int = 60,
@@ -19,6 +22,9 @@ def create_client(
     """Create a minimal app client with API protection middleware."""
     config = TakoVMConfig(
         api_max_payload_bytes=api_max_payload_bytes,
+        api_auth_enabled=api_auth_enabled,
+        api_keys=api_keys or [],
+        api_auth_header=api_auth_header,
         api_rate_limit_enabled=api_rate_limit_enabled,
         api_rate_limit_requests=api_rate_limit_requests,
         api_rate_limit_window_seconds=api_rate_limit_window_seconds,
@@ -99,6 +105,66 @@ class TestApiRateLimiting:
         with create_client(api_rate_limit_enabled=False, api_rate_limit_requests=1) as client:
             for _ in range(5):
                 assert client.get("/limited").status_code == 200
+
+    def test_rate_limit_uses_api_key_identity_when_authenticated(self):
+        """Authenticated clients have independent rate-limit buckets per API key."""
+        keys = ["a" * 16, "b" * 16]
+        with create_client(
+            api_auth_enabled=True,
+            api_keys=keys,
+            api_rate_limit_requests=1,
+            api_rate_limit_window_seconds=60,
+        ) as client:
+            assert client.get("/limited", headers={"X-API-Key": keys[0]}).status_code == 200
+            assert client.get("/limited", headers={"X-API-Key": keys[0]}).status_code == 429
+            assert client.get("/limited", headers={"X-API-Key": keys[1]}).status_code == 200
+
+
+class TestApiAuthentication:
+    """API key authentication behavior."""
+
+    def test_auth_disabled_by_default(self):
+        """Existing deployments remain unauthenticated unless auth is enabled."""
+        with create_client(api_auth_enabled=False) as client:
+            assert client.get("/limited").status_code == 200
+
+    def test_missing_api_key_rejected_when_auth_enabled(self):
+        """Protected routes reject unauthenticated requests."""
+        with create_client(api_auth_enabled=True, api_keys=["a" * 16]) as client:
+            response = client.get("/limited")
+
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+        payload = response.json()
+        assert "api key" in payload["detail"].lower()
+        assert payload["correlation_id"]
+
+    def test_invalid_api_key_rejected(self):
+        """Protected routes reject invalid API keys."""
+        with create_client(api_auth_enabled=True, api_keys=["a" * 16]) as client:
+            response = client.get("/limited", headers={"X-API-Key": "b" * 16})
+
+        assert response.status_code == 401
+
+    def test_configured_header_api_key_allowed(self):
+        """The configured API key header authenticates requests."""
+        with create_client(api_auth_enabled=True, api_keys=["a" * 16]) as client:
+            response = client.get("/limited", headers={"X-API-Key": "a" * 16})
+
+        assert response.status_code == 200
+
+    def test_authorization_bearer_api_key_allowed(self):
+        """Bearer tokens are accepted for clients that prefer Authorization."""
+        with create_client(api_auth_enabled=True, api_keys=["a" * 16]) as client:
+            response = client.get("/limited", headers={"Authorization": f"Bearer {'a' * 16}"})
+
+        assert response.status_code == 200
+
+    def test_docs_and_health_are_auth_exempt(self):
+        """Operational/docs endpoints remain available without API keys."""
+        with create_client(api_auth_enabled=True, api_keys=["a" * 16]) as client:
+            assert client.get("/docs").status_code == 200
+            assert client.get("/openapi.json").status_code == 200
 
 
 class TestApiPayloadLimit:


### PR DESCRIPTION
## Summary
- add opt-in API key auth via api_auth_enabled, api_keys, and api_auth_header
- accept keys via configured header or Authorization: Bearer
- keep health/docs/OpenAPI unauthenticated for operations
- rate-limit authenticated requests by API key identity instead of only client IP
- document YAML/env configuration

## Notes
This partially addresses #16 by adding authentication and per-key rate-limit identity. Full per-tenant CPU/memory/concurrency quotas remain future work.

## Verification
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/pytest tests/test_config.py tests/test_limits.py -q
- .venv/bin/pytest -q