### PR TITLE
feat(builder): add opt-in skip_existing to build_all

### DIFF
--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -227,7 +227,11 @@ CMD ["python", "-u", "/code/main.py"]
                 raise BuildError(f"Failed to build {job_type.name}: {error_msg}") from e
 
     def build_all(
-        self, registry: JobTypeRegistry, no_cache: bool = False, quiet: bool = False
+        self,
+        registry: JobTypeRegistry,
+        no_cache: bool = False,
+        quiet: bool = False,
+        skip_existing: bool = False,
     ) -> dict[str, bool]:
         """
         Build images for all registered job types.
@@ -236,12 +240,20 @@ CMD ["python", "-u", "/code/main.py"]
             registry: Job type registry
             no_cache: If True, build without Docker cache
             quiet: If True, suppress build output
+            skip_existing: If True, skip job types whose image already exists
+                on the Docker daemon instead of rebuilding it. Useful for
+                long-running callers that pre-build images at startup and only
+                want to build what is missing.
 
         Returns:
             Dict mapping job type name to build success
         """
         results = {}
         for job_type in registry.list():
+            if skip_existing and self.image_exists(job_type):
+                logger.info(f"Image for {job_type.name} already exists; skipping build")
+                results[job_type.name] = True
+                continue
             try:
                 self.build(job_type, no_cache=no_cache, quiet=quiet)
                 results[job_type.name] = True

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,67 @@
+"""
+Tests for ContainerBuilder.build_all image build orchestration.
+
+Covers the opt-in ``skip_existing`` behavior: ``build_all`` skips job types
+whose image is already present instead of rebuilding it, while the default
+still builds every registered job type.
+"""
+
+from pathlib import Path
+
+from tako_vm.execution.builder import ContainerBuilder
+from tako_vm.job_types import JobType, JobTypeRegistry
+
+
+def _empty_registry(tmp_path: Path, *names: str) -> JobTypeRegistry:
+    # A non-existent config path yields an empty registry (the package
+    # job_types.json is not loaded); persist=False keeps the test off disk.
+    registry = JobTypeRegistry(config_path=tmp_path / "job_types.json")
+    for name in names:
+        registry.register(JobType(name=name), persist=False)
+    return registry
+
+
+class TestBuildAllSkipExisting:
+    def test_skips_present_images_when_enabled(self, tmp_path, monkeypatch):
+        """skip_existing=True does not rebuild images that already exist."""
+        builder = ContainerBuilder()
+        built: list[str] = []
+        monkeypatch.setattr(builder, "image_exists", lambda job_type: True)
+        monkeypatch.setattr(
+            builder, "build", lambda job_type, **kwargs: built.append(job_type.name) or True
+        )
+
+        results = builder.build_all(_empty_registry(tmp_path, "alpha", "beta"), skip_existing=True)
+
+        assert built == []
+        assert results == {"alpha": True, "beta": True}
+
+    def test_builds_only_missing_images_when_enabled(self, tmp_path, monkeypatch):
+        """skip_existing=True still builds images that are absent."""
+        builder = ContainerBuilder()
+        built: list[str] = []
+        monkeypatch.setattr(builder, "image_exists", lambda job_type: job_type.name == "present")
+        monkeypatch.setattr(
+            builder, "build", lambda job_type, **kwargs: built.append(job_type.name) or True
+        )
+
+        results = builder.build_all(
+            _empty_registry(tmp_path, "present", "absent"), skip_existing=True
+        )
+
+        assert built == ["absent"]
+        assert results == {"present": True, "absent": True}
+
+    def test_builds_every_job_type_by_default(self, tmp_path, monkeypatch):
+        """Default (skip_existing=False) builds every job type, ignoring existence."""
+        builder = ContainerBuilder()
+        built: list[str] = []
+        monkeypatch.setattr(builder, "image_exists", lambda job_type: True)
+        monkeypatch.setattr(
+            builder, "build", lambda job_type, **kwargs: built.append(job_type.name) or True
+        )
+
+        results = builder.build_all(_empty_registry(tmp_path, "alpha", "beta"))
+
+        assert built == ["alpha", "beta"]
+        assert results == {"alpha": True, "beta": True}


### PR DESCRIPTION
## What

`build_all()` runs `docker build` for every registered job type on each call, even when the image already exists on the daemon — paying a build-context send and Dockerfile parse every time. Callers that pre-build images once at startup only want to build what is missing.

This adds an opt-in `skip_existing` flag (default `False`, fully backwards-compatible). When enabled, `build_all` skips any job type whose image is already present — using the existing `image_exists()` check — and records it as a success.

## Tests

Adds `tests/test_builder.py` (`ContainerBuilder` previously had no coverage):
- `skip_existing=True` does not rebuild present images and reports them as success
- `skip_existing=True` still builds absent images
- default (`skip_existing=False`) builds every job type, ignoring existence

All Docker-free (mocked at the `build` / `image_exists` boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
