### PR TITLE
fix(sandbox): enforce gVisor on the library Sandbox path via shared resolver

### DIFF
--- a/tako_vm/execution/__init__.py
+++ b/tako_vm/execution/__init__.py
@@ -15,6 +15,7 @@ from tako_vm.execution.worker import (
     RuntimeUnavailableError,
     check_gvisor_available,
     reset_gvisor_check,
+    resolve_runtime,
 )
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "RuntimeUnavailableError",
     "check_gvisor_available",
     "reset_gvisor_check",
+    "resolve_runtime",
     # Builder
     "ContainerBuilder",
     # Docker utilities

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -204,6 +204,58 @@ def determine_timeout_phase(timing: Optional[ExecutionTiming], timed_out: bool) 
     return None
 
 
+def resolve_runtime(config: TakoVMConfig) -> str:
+    """Resolve the container runtime ('runsc' or 'runc') from config.
+
+    Single source of truth shared by every execution path — the server
+    ``CodeExecutor`` and the library ``Sandbox`` — so they apply gVisor
+    identically and can't drift. In strict mode (the default) gVisor must be
+    available or this fails closed; in permissive mode a missing gVisor falls
+    back to runc with a loud warning. An explicit ``container_runtime='runc'``
+    is honored only outside strict mode.
+
+    Raises:
+        RuntimeUnavailableError: strict mode and gVisor unavailable, or runc
+            explicitly requested under strict mode.
+    """
+    requested_runtime = config.container_runtime
+    security_mode = config.security_mode
+
+    # If runc is explicitly requested, allow it (user knows what they're doing)
+    if requested_runtime == "runc":
+        if security_mode == "strict":
+            raise RuntimeUnavailableError(
+                "Cannot use 'runc' runtime in strict security mode. "
+                "Use container_runtime='runsc' or set security_mode='permissive'."
+            )
+        logger.warning(
+            "Using 'runc' runtime. This provides weaker isolation than gVisor. "
+            "DO NOT USE FOR UNTRUSTED CODE."
+        )
+        return "runc"
+
+    # gVisor requested (default) - check availability
+    if check_gvisor_available():
+        logger.info("Using gVisor (runsc) runtime for strong isolation")
+        return "runsc"
+
+    # gVisor not available
+    if security_mode == "strict":
+        raise RuntimeUnavailableError(
+            "gVisor (runsc) runtime is not available but required in strict mode. "
+            "Install gVisor: https://gvisor.dev/docs/user_guide/install/ "
+            "Or set security_mode='permissive' to allow fallback to runc (NOT RECOMMENDED)."
+        )
+
+    # Permissive mode - fall back to runc with loud warning
+    logger.warning("=" * 60)
+    logger.warning("WARNING: gVisor not available, falling back to runc")
+    logger.warning("WARNING: This provides WEAKER ISOLATION")
+    logger.warning("WARNING: DO NOT USE FOR UNTRUSTED CODE")
+    logger.warning("=" * 60)
+    return "runc"
+
+
 class CodeExecutor:
     """Execute Python code in isolated Docker containers."""
 
@@ -235,54 +287,8 @@ class CodeExecutor:
         self._runtime = self._resolve_runtime()
 
     def _resolve_runtime(self) -> str:
-        """
-        Resolve the container runtime to use.
-
-        In strict mode (default), gVisor must be available or we fail.
-        In permissive mode, we fall back to runc with a warning.
-
-        Returns:
-            The runtime to use ('runsc' or 'runc')
-
-        Raises:
-            RuntimeUnavailableError: If strict mode and gVisor unavailable
-        """
-        requested_runtime = self.config.container_runtime
-        security_mode = self.config.security_mode
-
-        # If runc is explicitly requested, allow it (user knows what they're doing)
-        if requested_runtime == "runc":
-            if security_mode == "strict":
-                raise RuntimeUnavailableError(
-                    "Cannot use 'runc' runtime in strict security mode. "
-                    "Use container_runtime='runsc' or set security_mode='permissive'."
-                )
-            logger.warning(
-                "Using 'runc' runtime. This provides weaker isolation than gVisor. "
-                "DO NOT USE FOR UNTRUSTED CODE."
-            )
-            return "runc"
-
-        # gVisor requested (default) - check availability
-        if check_gvisor_available():
-            logger.info("Using gVisor (runsc) runtime for strong isolation")
-            return "runsc"
-
-        # gVisor not available
-        if security_mode == "strict":
-            raise RuntimeUnavailableError(
-                "gVisor (runsc) runtime is not available but required in strict mode. "
-                "Install gVisor: https://gvisor.dev/docs/user_guide/install/ "
-                "Or set security_mode='permissive' to allow fallback to runc (NOT RECOMMENDED)."
-            )
-
-        # Permissive mode - fall back to runc with loud warning
-        logger.warning("=" * 60)
-        logger.warning("WARNING: gVisor not available, falling back to runc")
-        logger.warning("WARNING: This provides WEAKER ISOLATION")
-        logger.warning("WARNING: DO NOT USE FOR UNTRUSTED CODE")
-        logger.warning("=" * 60)
-        return "runc"
+        """Resolve the runtime via the shared module-level ``resolve_runtime``."""
+        return resolve_runtime(self.config)
 
     def _get_job_type(self, job_type_name: Optional[str]) -> JobType:
         """

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -24,7 +24,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit
 
+from tako_vm.config import get_config
 from tako_vm.constants import DEFAULT_IMAGE, MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
+from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import generate_container_name, kill_container
 from tako_vm.security import validate_pip_requirement
 
@@ -472,6 +474,14 @@ class Sandbox:
             "--init",  # Faster signal handling with tini
             "--read-only",
         ]
+
+        # Apply the resolved container runtime via the shared resolver, so the
+        # library path enforces gVisor identically to CodeExecutor. runc is
+        # docker's default (and some daemons reject `--runtime=runc`), so only
+        # pass the flag for gVisor; strict mode fails closed when gVisor is
+        # unavailable.
+        if resolve_runtime(get_config()) == "runsc":
+            cmd.append("--runtime=runsc")
 
         # Capability restrictions (can be disabled in CI environments where Docker
         # can't modify capability bounding sets)

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -1,0 +1,68 @@
+"""
+Runtime (gVisor) enforcement tests for the library Sandbox path.
+
+The ``Sandbox`` / ``sandbox.run`` convenience entry point must apply the same
+container runtime policy as the server execution path: pass ``--runtime=runsc``
+when gVisor is selected, and fail closed in strict mode when gVisor is absent.
+These are pure command-construction tests — no Docker required.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import tako_vm.execution.worker as worker_module
+import tako_vm.sandbox as sandbox_module
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution import RuntimeUnavailableError, reset_gvisor_check
+from tako_vm.sandbox import Sandbox
+
+
+@pytest.fixture(autouse=True)
+def reset_gvisor_cache():
+    reset_gvisor_check()
+    yield
+    reset_gvisor_check()
+
+
+def _use_config(monkeypatch, *, container_runtime="runsc", security_mode="strict"):
+    config = TakoVMConfig(container_runtime=container_runtime, security_mode=security_mode)
+    monkeypatch.setattr(sandbox_module, "get_config", lambda: config)
+
+
+def _set_gvisor(monkeypatch, available: bool):
+    monkeypatch.setattr(worker_module, "_gvisor_available", available)
+
+
+def _runtime_flags(tmp_path: Path) -> list[str]:
+    """Build a sandbox docker command and return the --runtime=* args it carries."""
+    sb = Sandbox(auto_build=False)
+    cmd, _ = sb._build_docker_command(
+        code_dir=tmp_path, input_dir=tmp_path, output_dir=tmp_path, timeout=10
+    )
+    return [arg for arg in cmd if arg.startswith("--runtime")]
+
+
+class TestSandboxRuntimeEnforcement:
+    def test_uses_gvisor_when_available(self, monkeypatch, tmp_path):
+        _use_config(monkeypatch, container_runtime="runsc", security_mode="strict")
+        _set_gvisor(monkeypatch, True)
+        assert _runtime_flags(tmp_path) == ["--runtime=runsc"]
+
+    def test_strict_fails_closed_without_gvisor(self, monkeypatch, tmp_path):
+        _use_config(monkeypatch, container_runtime="runsc", security_mode="strict")
+        _set_gvisor(monkeypatch, False)
+        with pytest.raises(RuntimeUnavailableError):
+            _runtime_flags(tmp_path)
+
+    def test_permissive_falls_back_to_runc_without_gvisor(self, monkeypatch, tmp_path):
+        _use_config(monkeypatch, container_runtime="runsc", security_mode="permissive")
+        _set_gvisor(monkeypatch, False)
+        # runc is docker's default, so no --runtime flag is added.
+        assert _runtime_flags(tmp_path) == []
+
+    def test_explicit_runc_in_strict_fails_closed(self, monkeypatch, tmp_path):
+        _use_config(monkeypatch, container_runtime="runc", security_mode="strict")
+        _set_gvisor(monkeypatch, True)
+        with pytest.raises(RuntimeUnavailableError):
+            _runtime_flags(tmp_path)


### PR DESCRIPTION
## What

The library `Sandbox` / `sandbox.run()` path built its `docker run` command without ever passing `--runtime`, so it ran containers under docker's default runtime (runc / host kernel) **even when `container_runtime=runsc` and `security_mode=strict` were configured**. `CodeExecutor` already resolves the runtime and appends `--runtime=runsc`; the convenience path did not — so untrusted code run through `sandbox.run` could execute without gVisor isolation.

## Root cause & fix

Each execution path assembles its own `docker run` command, and the runtime decision lived only inside `CodeExecutor._resolve_runtime`. This extracts that decision into a module-level `resolve_runtime(config)` — a single source of truth — and applies it on the `Sandbox` path:

- `CodeExecutor._resolve_runtime` now delegates to `resolve_runtime(self.config)` (behavior unchanged).
- `Sandbox._build_docker_command` calls `resolve_runtime(get_config())` and appends `--runtime=runsc` when gVisor is selected.

Resolution policy (now shared by both paths):
- strict + gVisor available → `runsc`
- strict + gVisor unavailable → fail closed (`RuntimeUnavailableError`)
- permissive + gVisor unavailable → fall back to `runc` with a warning
- explicit `runc` in strict → fail closed

`runc` stays implicit (no `--runtime` flag) since it is docker's default and some daemons reject `--runtime=runc`.

## Compatibility

No behavior change for existing callers — `CodeExecutor` delegates to the same logic it had inline. Only the library `Sandbox` path changes: it now enforces the configured runtime instead of always using docker's default.

## Tests

- `resolve_runtime` stays covered end-to-end by the existing `tests/test_runtime.py` (via `CodeExecutor`).
- Adds `tests/test_sandbox_runtime.py` (Docker-free, pure command-construction):
  - uses `--runtime=runsc` when gVisor is available
  - fails closed in strict mode without gVisor
  - falls back to runc (no `--runtime` flag) in permissive mode
  - explicit runc in strict fails closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
