### PR TITLE
refactor(execution): share one isolation base across CodeExecutor and Sandbox

### DIFF
--- a/tako_vm/execution/__init__.py
+++ b/tako_vm/execution/__init__.py
@@ -6,6 +6,7 @@ Provides code execution in isolated containers with gVisor isolation by default.
 
 from tako_vm.execution.builder import ContainerBuilder
 from tako_vm.execution.docker import (
+    base_isolation_args,
     generate_container_name,
     is_native_linux,
     kill_container,
@@ -31,4 +32,5 @@ __all__ = [
     "generate_container_name",
     "kill_container",
     "is_native_linux",
+    "base_isolation_args",
 ]

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -78,3 +78,65 @@ def kill_container(container_name: str) -> bool:
         # Ignore errors - container may not exist or already be stopped
         logger.debug("Failed to kill container %s: %s", container_name, e)
         return False
+
+
+def base_isolation_args(
+    container_name: str,
+    *,
+    runtime: str,
+    enable_cap_restrictions: bool = True,
+) -> list[str]:
+    """Leading ``docker run`` args shared by every isolated-execution path.
+
+    Centralizes the always-on isolation posture — ``--rm``, ``--init``,
+    ``--read-only``, the capability drop/add set, and the gVisor ``--runtime``
+    flag — so it is assembled in exactly one place. The execution paths that
+    each build their own command (``CodeExecutor`` and the library ``Sandbox``)
+    start from this, which keeps the isolation flags from drifting between them
+    (e.g. a hardening flag added to one builder and silently missed on
+    another). Path-specific args (network, mounts, resource limits, env,
+    seccomp) are appended by the caller.
+
+    Args:
+        container_name: Container name (``--name``).
+        runtime: Resolved container runtime ('runsc' or 'runc'). Only gVisor
+            ('runsc') is passed explicitly: runc is docker's default and some
+            daemons reject ``--runtime=runc``.
+        enable_cap_restrictions: Drop all capabilities and re-add only SETUID/
+            SETGID (needed by gosu to drop to the unprivileged sandbox user).
+            Can be disabled in CI where Docker can't modify capability sets.
+
+    Returns:
+        The leading argument list, ready to have path-specific flags and the
+        image name appended before execution.
+    """
+    args = [
+        "docker",
+        "run",
+        "--rm",
+        f"--name={container_name}",
+        "--init",  # Faster signal handling with tini
+        "--read-only",
+    ]
+
+    # Capability restrictions (can be disabled in CI environments where Docker
+    # can't modify capability bounding sets)
+    if enable_cap_restrictions:
+        args.extend(
+            [
+                "--cap-drop=ALL",
+                "--cap-add=SETUID",  # Required for gosu to switch user
+                "--cap-add=SETGID",  # Required for gosu to switch user
+            ]
+        )
+        # Security note: We don't use --security-opt=no-new-privileges because gosu requires
+        # setuid to drop from root to sandbox user (uid 1000). This is a one-way privilege drop:
+        # after gosu exec's the user code, the process runs as unprivileged sandbox user with
+        # no capability to regain root. The container also has all other caps dropped.
+
+    # Only specify runtime explicitly for gVisor (runsc). runc is docker's
+    # default, and some daemons reject ``--runtime=runc``.
+    if runtime == "runsc":
+        args.append(f"--runtime={runtime}")
+
+    return args

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -17,7 +17,12 @@ from typing import Any, Dict, List, Optional
 
 from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.constants import MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
-from tako_vm.execution.docker import generate_container_name, is_native_linux, kill_container
+from tako_vm.execution.docker import (
+    base_isolation_args,
+    generate_container_name,
+    is_native_linux,
+    kill_container,
+)
 from tako_vm.execution.health import get_circuit_breaker
 from tako_vm.execution.retry import RetryConfig, RetryContext, is_transient_error
 from tako_vm.job_types import JobType, JobTypeRegistry
@@ -908,35 +913,11 @@ class CodeExecutor:
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako", job_id)
 
-        cmd = [
-            "docker",
-            "run",
-            "--rm",
-            f"--name={container_name}",
-            "--init",  # Faster signal handling with tini
-            "--read-only",
-        ]
-
-        # Capability restrictions (can be disabled in CI environments where Docker
-        # can't modify capability bounding sets)
-        if self.config.enable_cap_restrictions:
-            cmd.extend(
-                [
-                    "--cap-drop=ALL",
-                    "--cap-add=SETUID",  # Required for gosu to switch user
-                    "--cap-add=SETGID",  # Required for gosu to switch user
-                ]
-            )
-            # Security note: We don't use --security-opt=no-new-privileges because gosu requires
-            # setuid to drop from root to sandbox user (uid 1000). This is a one-way privilege drop:
-            # after gosu exec's the user code, the process runs as unprivileged sandbox user with
-            # no capability to regain root. The container also has all other caps dropped.
-
-        # Only specify runtime explicitly for gVisor (runsc)
-        # runc is the default Docker runtime, so we don't need to specify it explicitly
-        # (and some Docker configurations may not accept --runtime=runc)
-        if self._runtime == "runsc":
-            cmd.append(f"--runtime={self._runtime}")
+        cmd = base_isolation_args(
+            container_name,
+            runtime=self._runtime,
+            enable_cap_restrictions=self.config.enable_cap_restrictions,
+        )
 
         # Mount uv cache volume for faster repeated installs
         if has_runtime_deps:

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -27,7 +27,11 @@ from urllib.parse import urlsplit
 from tako_vm.config import get_config
 from tako_vm.constants import DEFAULT_IMAGE, MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
 from tako_vm.execution import resolve_runtime
-from tako_vm.execution.docker import generate_container_name, kill_container
+from tako_vm.execution.docker import (
+    base_isolation_args,
+    generate_container_name,
+    kill_container,
+)
 from tako_vm.security import validate_pip_requirement
 
 logger = logging.getLogger(__name__)
@@ -466,37 +470,15 @@ class Sandbox:
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako-sandbox")
 
-        cmd = [
-            "docker",
-            "run",
-            "--rm",
-            f"--name={container_name}",
-            "--init",  # Faster signal handling with tini
-            "--read-only",
-        ]
-
-        # Apply the resolved container runtime via the shared resolver, so the
-        # library path enforces gVisor identically to CodeExecutor. runc is
-        # docker's default (and some daemons reject `--runtime=runc`), so only
-        # pass the flag for gVisor; strict mode fails closed when gVisor is
-        # unavailable.
-        if resolve_runtime(get_config()) == "runsc":
-            cmd.append("--runtime=runsc")
-
-        # Capability restrictions (can be disabled in CI environments where Docker
-        # can't modify capability bounding sets)
-        if self.config.enable_cap_restrictions:
-            cmd.extend(
-                [
-                    "--cap-drop=ALL",
-                    "--cap-add=SETUID",  # Required for gosu to switch user
-                    "--cap-add=SETGID",  # Required for gosu to switch user
-                ]
-            )
-            # Security note: We don't use --security-opt=no-new-privileges because gosu requires
-            # setuid to drop from root to sandbox user (uid 1000). This is a one-way privilege drop:
-            # after gosu exec's the user code, the process runs as unprivileged sandbox user with
-            # no capability to regain root. The container also has all other caps dropped.
+        # Shared isolation base: --rm/--init/--read-only, capability drops, and
+        # the gVisor --runtime flag, resolved via the shared resolver so the
+        # library path enforces the same posture as CodeExecutor (and fails
+        # closed in strict mode when gVisor is unavailable).
+        cmd = base_isolation_args(
+            container_name,
+            runtime=resolve_runtime(get_config()),
+            enable_cap_restrictions=self.config.enable_cap_restrictions,
+        )
 
         # Network isolation
         has_requirements = bool(validated_reqs)

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -8,6 +8,7 @@ import subprocess
 from unittest.mock import MagicMock, patch
 
 from tako_vm.execution.docker import (
+    base_isolation_args,
     generate_container_name,
     is_native_linux,
     kill_container,
@@ -128,3 +129,39 @@ class TestContainerNameValidation:
         # Docker has a max container name length, but we don't enforce it
         # Just verify it's not empty
         assert len(name) > 0
+
+
+class TestBaseIsolationArgs:
+    """Tests for the shared isolation-base argument builder."""
+
+    def test_always_on_flags_present(self):
+        """The fixed isolation flags are always emitted, in order."""
+        args = base_isolation_args("c1", runtime="runc")
+        assert args[:6] == [
+            "docker",
+            "run",
+            "--rm",
+            "--name=c1",
+            "--init",
+            "--read-only",
+        ]
+
+    def test_caps_dropped_by_default(self):
+        """Capabilities are dropped and only SETUID/SETGID re-added by default."""
+        args = base_isolation_args("c1", runtime="runc")
+        assert "--cap-drop=ALL" in args
+        assert "--cap-add=SETUID" in args
+        assert "--cap-add=SETGID" in args
+
+    def test_caps_can_be_disabled(self):
+        """Disabling cap restrictions omits the cap-drop/add flags."""
+        args = base_isolation_args("c1", runtime="runc", enable_cap_restrictions=False)
+        assert not any(a.startswith("--cap-") for a in args)
+
+    def test_runsc_adds_runtime_flag(self):
+        """gVisor is passed explicitly via --runtime=runsc."""
+        assert "--runtime=runsc" in base_isolation_args("c1", runtime="runsc")
+
+    def test_runc_is_implicit(self):
+        """runc is docker's default and is not passed explicitly."""
+        assert not any(a.startswith("--runtime") for a in base_isolation_args("c1", runtime="runc"))


### PR DESCRIPTION
## What

`CodeExecutor` and the library `Sandbox` each assemble their own `docker run` command, duplicating the always-on isolation flags — `--rm`, `--init`, `--read-only`, the capability drop/add set, and the gVisor `--runtime` flag. That duplication is exactly how `--runtime` drifted (enforced in `CodeExecutor`, missing from `Sandbox` until #57).

This extracts the shared prefix into **`base_isolation_args()`** (`execution/docker.py`) and has both paths start from it, appending only their path-specific flags (network, mounts, resource limits, env, seccomp). The isolation posture is now assembled in **one place**, so a future hardening flag can't land on one builder and silently miss the other.

## Behavior

Behavior-preserving:
- **`CodeExecutor`** — emitted command is **byte-identical** (same flags, same order).
- **`Sandbox`** — only change is `--runtime` now follows the cap flags instead of preceding them; flag order before the image is a docker no-op.

## Scope

Covers the always-on isolation *base*. Path-specific flags (network mode, tmpfs, seccomp, resource limits, mounts) stay in each builder since they are parameterized differently — folding those in is a possible follow-up. This addresses the core of #58: the always-on security flags are no longer duplicated.

## Tests

- Adds direct `base_isolation_args` tests (`tests/test_docker_utils.py`): always-on flags present and ordered, caps droppable, runsc adds `--runtime`, runc stays implicit.
- Existing `tests/test_runtime.py` (CodeExecutor) and `tests/test_sandbox_runtime.py` unchanged and passing — confirming no behavior change.

Refs #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
