### PR TITLE
fix(security): reject symlinks in artifact collection and contain replay reads

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -141,6 +141,10 @@ def parse_phase_file(output_dir: Path) -> Optional[ExecutionTiming]:
         ExecutionTiming with parsed timing info, or None if file not found
     """
     phase_file = output_dir / ".tako_phase"
+    # Untrusted code could point .tako_phase at a host file; never follow it.
+    if phase_file.is_symlink():
+        logger.warning("Phase file is a symlink, ignoring")
+        return None
     if not phase_file.exists():
         return None
 
@@ -394,7 +398,10 @@ class CodeExecutor:
 
             # Read output
             output_file = output_dir / "result.json"
-            if output_file.exists():
+            # Untrusted code could point result.json at a host file; never follow it.
+            if output_file.is_symlink():
+                logger.warning("result.json is a symlink, ignoring")
+            elif output_file.exists():
                 try:
                     output_data = json.loads(output_file.read_text())
                     result["output"] = output_data
@@ -586,7 +593,10 @@ class CodeExecutor:
 
             # Read main JSON result (if present)
             output_file = output_dir / "result.json"
-            if output_file.exists():
+            # Untrusted code could point result.json at a host file; never follow it.
+            if output_file.is_symlink():
+                logger.warning("result.json is a symlink, ignoring")
+            elif output_file.exists():
                 try:
                     record.result_json = json.loads(output_file.read_text(encoding="utf-8"))
                 except json.JSONDecodeError:
@@ -692,6 +702,14 @@ class CodeExecutor:
         artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         for path in output_dir.iterdir():
+            # Reject symlinks before any stat/read/copy: untrusted code in the
+            # container can point a symlink in /output at a host-readable file
+            # (the config file with api_keys, /proc/self/environ, other runs'
+            # data) to exfiltrate it through artifact collection. is_file(),
+            # stat(), and copy2() all follow symlinks; is_symlink() does not.
+            if path.is_symlink():
+                logger.warning("Artifact %s is a symlink, skipping", path.name)
+                continue
             if not path.is_file():
                 continue
 
@@ -718,7 +736,10 @@ class CodeExecutor:
 
                 # Copy file to permanent storage
                 dest_path = _resolve_run_path(self.config.data_dir, job_id, "artifacts", path.name)
-                shutil.copy2(path, dest_path)
+                # follow_symlinks=False guards against a TOCTOU swap of a regular
+                # file for a symlink after the is_symlink() check above (copy2
+                # follows symlinks by default).
+                shutil.copy2(path, dest_path, follow_symlinks=False)
 
                 artifacts.append(
                     Artifact(

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -19,6 +19,7 @@ import logging
 import time
 import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request, Response
@@ -91,6 +92,21 @@ def compute_idempotency_fingerprint(
 def _generate_sync_job_id() -> str:
     """Generate a collision-resistant ID for the legacy sync endpoint."""
     return f"api-{uuid.uuid4()}"
+
+
+def _resolve_under_data_dir(data_dir: Path, storage_key: str) -> Path:
+    """Resolve a stored artifact key under data_dir, rejecting traversal.
+
+    ``storage_key`` is persisted and is not re-validated on read, so a poisoned
+    or legacy record with ``..``, an absolute path, or a symlink must not
+    escape. ``resolve()`` canonicalizes symlinks and ``is_relative_to()`` checks
+    the real target against ``data_dir``. Both the artifact download and the
+    rerun/fork replay path go through this.
+    """
+    candidate = (data_dir / storage_key).resolve()
+    if not candidate.is_relative_to(data_dir):
+        raise HTTPException(status_code=400, detail="Invalid artifact path")
+    return candidate
 
 
 # Keyed lock for idempotency (prevents race conditions under concurrent requests)
@@ -1037,14 +1053,14 @@ def _get_replay_data(record: ExecutionRecord) -> tuple:
     """
     import json
 
-    data_dir = state.config.data_dir
+    data_dir = state.config.data_dir.resolve()
 
     # Find _code.py in input_artifacts
     code_artifact = next((a for a in record.input_artifacts if a.name == "_code.py"), None)
     if not code_artifact:
         raise HTTPException(status_code=400, detail="Original code not available for replay")
 
-    code_path = data_dir / code_artifact.storage_key
+    code_path = _resolve_under_data_dir(data_dir, code_artifact.storage_key)
     if not code_path.exists():
         raise HTTPException(status_code=400, detail="Original code file not found")
     code = code_path.read_text(encoding="utf-8")
@@ -1054,7 +1070,7 @@ def _get_replay_data(record: ExecutionRecord) -> tuple:
     if not input_artifact:
         raise HTTPException(status_code=400, detail="Original input not available for replay")
 
-    input_path = data_dir / input_artifact.storage_key
+    input_path = _resolve_under_data_dir(data_dir, input_artifact.storage_key)
     if not input_path.exists():
         raise HTTPException(status_code=400, detail="Original input file not found")
     input_data = json.loads(input_path.read_text(encoding="utf-8"))
@@ -1194,13 +1210,9 @@ async def download_artifact(job_id: str, artifact_name: str):
     if not artifact:
         raise HTTPException(status_code=404, detail="Artifact not found")
 
-    # PATH TRAVERSAL PREVENTION: resolve and verify path stays under data_dir
-    # Using is_relative_to() for robust path validation (handles symlinks properly)
+    # PATH TRAVERSAL PREVENTION: resolve and verify the path stays under data_dir.
     data_dir = state.config.data_dir.resolve()
-    artifact_path = (data_dir / artifact.storage_key).resolve()
-
-    if not artifact_path.is_relative_to(data_dir):
-        raise HTTPException(status_code=400, detail="Invalid artifact path")
+    artifact_path = _resolve_under_data_dir(data_dir, artifact.storage_key)
 
     if not artifact_path.exists():
         raise HTTPException(status_code=404, detail="Artifact file not found")

--- a/tests/test_artifact_symlink.py
+++ b/tests/test_artifact_symlink.py
@@ -1,0 +1,68 @@
+"""
+Artifact/result collection must reject symlinks.
+
+Untrusted code in the sandbox can drop a symlink in /output pointing at a
+host-readable file (the config with api_keys, /proc/self/environ, another run's
+data). The host-side worker collects artifacts and reads result.json/.tako_phase
+*outside* any sandbox, so following such a symlink would exfiltrate host files.
+These are pure host-side file tests — no Docker required.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution.worker import CodeExecutor, parse_phase_file
+
+
+@pytest.fixture
+def executor(tmp_path):
+    config = TakoVMConfig(security_mode="permissive", data_dir=str(tmp_path / "data"))
+    return CodeExecutor(config=config)
+
+
+def _host_secret(tmp_path: Path) -> Path:
+    secret = tmp_path / "host_secret.txt"
+    secret.write_text("API_KEY=supersecret")
+    return secret
+
+
+class TestArtifactSymlinkRejection:
+    def test_symlink_artifact_is_skipped(self, executor, tmp_path):
+        secret = _host_secret(tmp_path)
+        out = tmp_path / "output"
+        out.mkdir()
+        (out / "real.txt").write_text("ok")
+        (out / "evil.txt").symlink_to(secret)  # points at a host file
+
+        artifacts = executor._collect_artifacts(out, "job-1")
+        names = {a.name for a in artifacts}
+
+        assert "real.txt" in names
+        assert "evil.txt" not in names  # symlink rejected before copy
+        # The secret content must never have been copied into permanent storage.
+        copied = (tmp_path / "data" / "runs" / "job-1" / "artifacts").glob("*")
+        assert all("supersecret" not in p.read_text() for p in copied if p.is_file())
+
+    def test_real_files_still_collected(self, executor, tmp_path):
+        out = tmp_path / "output"
+        out.mkdir()
+        (out / "a.txt").write_text("hello")
+        artifacts = executor._collect_artifacts(out, "job-2")
+        assert {a.name for a in artifacts} == {"a.txt"}
+
+
+class TestPhaseFileSymlinkRejection:
+    def test_symlinked_phase_file_returns_none(self, tmp_path):
+        secret = _host_secret(tmp_path)
+        out = tmp_path / "output"
+        out.mkdir()
+        (out / ".tako_phase").symlink_to(secret)
+        assert parse_phase_file(out) is None
+
+    def test_real_phase_file_is_parsed(self, tmp_path):
+        out = tmp_path / "output"
+        out.mkdir()
+        (out / ".tako_phase").write_text("phase=completed\ntotal_ms=10\n")
+        assert parse_phase_file(out) is not None

--- a/tests/test_replay_containment.py
+++ b/tests/test_replay_containment.py
@@ -1,0 +1,38 @@
+"""
+Replay/download path containment: a poisoned/legacy storage_key must not escape
+data_dir. Exercises the shared _resolve_under_data_dir helper used by both
+download_artifact and the rerun/fork replay path. Requires the server extra.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")  # server deps; skip cleanly if not installed
+
+from fastapi import HTTPException  # noqa: E402
+
+from tako_vm.server.app import _resolve_under_data_dir  # noqa: E402
+
+
+class TestResolveUnderDataDir:
+    def test_normal_key_resolves(self, tmp_path):
+        (tmp_path / "runs" / "abc").mkdir(parents=True)
+        resolved = _resolve_under_data_dir(tmp_path.resolve(), "runs/abc/_code.py")
+        assert resolved == (tmp_path / "runs" / "abc" / "_code.py").resolve()
+
+    def test_dotdot_traversal_rejected(self, tmp_path):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_under_data_dir(tmp_path.resolve(), "../../../etc/passwd")
+        assert exc.value.status_code == 400
+
+    def test_absolute_key_rejected(self, tmp_path):
+        with pytest.raises(HTTPException):
+            _resolve_under_data_dir(tmp_path.resolve(), "/etc/passwd")
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        # A symlink under data_dir pointing outside is caught: resolve() follows
+        # it, is_relative_to() sees the real (escaped) target.
+        data = tmp_path.resolve()
+        (data / "runs").mkdir()
+        (data / "runs" / "evil").symlink_to(tmp_path.parent)
+        with pytest.raises(HTTPException):
+            _resolve_under_data_dir(data, "runs/evil/secret")


### PR DESCRIPTION
## What

Two host-side file sinks in the worker followed symlinks, and the rerun/fork replay path read a persisted `storage_key` with no containment. Because untrusted code writes to the `/output` bind-mount and the host-side worker reads it **outside any sandbox**, submitted code could exfiltrate arbitrary host-readable files (the config file with `api_keys`, `/proc/self/environ`, other runs' data) — regardless of gVisor, and regardless of tenancy.

## Fix

- **`_collect_artifacts`** (`worker.py`): reject `path.is_symlink()` before any `stat`/read/`copy2` (all of which follow symlinks; `is_symlink()` does not).
- **`result.json` / `.tako_phase` reads** (`worker.py`): skip when the file is a symlink.
- **`_get_replay_data`** (`app.py`, rerun/fork): `resolve()` + `is_relative_to(data_dir)` before reading `data_dir / storage_key` — mirrors the existing `download_artifact` containment, so a poisoned/legacy record with `..`/symlinked `storage_key` can't escape.

## Compatibility

No behavior change for legitimate jobs — outputs are real files, and `storage_key` is always generated as `runs/{id}/...`. No tests relied on symlink/`..` behavior.

## Tests

Adds `tests/test_artifact_symlink.py` (Docker-free): a symlinked artifact is skipped while real files are still collected; a symlinked `.tako_phase` returns `None`; real phase files still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
