### PR TITLE
feat(cleanup): reclaim stranded workspaces and on-disk artifacts past TTL

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -75,6 +75,65 @@ def _resolve_run_path(data_dir: Path, execution_id: str, *parts: str) -> Path:
     return resolved
 
 
+def prune_stale_workspaces(max_age_seconds: int) -> int:
+    """Remove stale per-run workspace dirs stranded under WORKSPACE_DIR.
+
+    Each execution creates a temp dir (``job-*`` / ``sandbox-*``) that is
+    normally removed in a finally block, but a hard crash or an rmtree failure
+    leaks it — and there is no other reaper, so host disk grows unbounded. This
+    removes such dirs whose mtime is older than ``max_age_seconds`` (chosen to
+    sit well past any run's max timeout). Fail-soft: per-dir errors are logged
+    and skipped. Returns the number of dirs removed.
+    """
+    workspace_root = Path(WORKSPACE_DIR)
+    if not workspace_root.is_dir():
+        return 0
+    cutoff = time.time() - max_age_seconds
+    removed = 0
+    for entry in workspace_root.iterdir():
+        # Whole body in the try: a concurrent run can delete an entry between
+        # iterdir() and these checks, and stat()/is_dir() would then raise.
+        try:
+            if entry.is_symlink() or not entry.is_dir():
+                continue
+            if not (entry.name.startswith("job-") or entry.name.startswith("sandbox-")):
+                continue
+            if entry.stat().st_mtime >= cutoff:
+                continue
+            shutil.rmtree(entry, ignore_errors=True)
+            removed += 1
+        except OSError as e:
+            logger.warning("Failed to prune stale workspace %s: %s", entry, e)
+    return removed
+
+
+def prune_old_run_dirs(data_dir: Path, ttl_days: int) -> int:
+    """Remove on-disk run artifact dirs (``data_dir/runs/<id>``) past the TTL.
+
+    The DB record cleanup deletes rows but not the on-disk code/input/output
+    artifacts, so they survive the configured retention indefinitely — disk
+    growth plus a retention/compliance gap (the stored source code and inputs
+    outlive their record). This removes ``runs/<id>`` dirs whose mtime is older
+    than ``ttl_days``. Fail-soft per dir. Returns the number of dirs removed.
+    """
+    runs_root = data_dir / "runs"
+    if not runs_root.is_dir():
+        return 0
+    cutoff = time.time() - ttl_days * 86400
+    removed = 0
+    for entry in runs_root.iterdir():
+        try:
+            if entry.is_symlink() or not entry.is_dir():
+                continue
+            if entry.stat().st_mtime >= cutoff:
+                continue
+            shutil.rmtree(entry, ignore_errors=True)
+            removed += 1
+        except OSError as e:
+            logger.warning("Failed to prune old run dir %s: %s", entry, e)
+    return removed
+
+
 def check_gvisor_available() -> bool:
     """
     Check if gVisor (runsc) runtime is available.

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -19,6 +19,7 @@ import logging
 import time
 import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request, Response
@@ -29,7 +30,12 @@ from pydantic import BaseModel, Field, field_validator
 from tako_vm import __version__
 from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.execution.health import get_circuit_breaker, startup_cleanup
-from tako_vm.execution.worker import CodeExecutor, check_gvisor_available
+from tako_vm.execution.worker import (
+    CodeExecutor,
+    check_gvisor_available,
+    prune_old_run_dirs,
+    prune_stale_workspaces,
+)
 from tako_vm.job_types import JobTypeRegistry, merge_config_job_types
 from tako_vm.models import ExecutionRecord, sha256_content, sha256_json
 from tako_vm.security import sanitize_error
@@ -147,8 +153,14 @@ def _get_runtime_config() -> TakoVMConfig:
     return get_config()
 
 
-async def _periodic_cleanup(storage: ExecutionStorage, record_ttl_days: int, dlq_ttl_days: int = 7):
-    """Background task for periodic database cleanup."""
+async def _periodic_cleanup(
+    storage: ExecutionStorage,
+    record_ttl_days: int,
+    data_dir: Path,
+    workspace_max_age_seconds: int,
+    dlq_ttl_days: int = 7,
+):
+    """Background task for periodic database + on-disk cleanup."""
     cleanup_interval = 3600  # Run every hour
     while True:
         try:
@@ -161,6 +173,13 @@ async def _periodic_cleanup(storage: ExecutionStorage, record_ttl_days: int, dlq
             dlq_deleted = await storage.cleanup_old_dlq_entries(dlq_ttl_days)
             if dlq_deleted > 0:
                 logger.info(f"Cleanup: deleted {dlq_deleted} old DLQ entries")
+            # Reclaim stranded workspaces and on-disk artifacts past retention
+            stale_ws = prune_stale_workspaces(workspace_max_age_seconds)
+            if stale_ws > 0:
+                logger.info(f"Cleanup: pruned {stale_ws} stale workspace dir(s)")
+            old_runs = prune_old_run_dirs(data_dir, record_ttl_days)
+            if old_runs > 0:
+                logger.info(f"Cleanup: pruned {old_runs} expired run artifact dir(s)")
         except asyncio.CancelledError:
             logger.info("Periodic cleanup task cancelled")
             break
@@ -198,9 +217,24 @@ async def lifespan(app: FastAPI):
     )
     await state.worker_pool.start()
 
+    # A workspace exists only while its run is alive (created right before the
+    # container, removed in the run's finally block); its container budget is at
+    # most max_startup_timeout + max_timeout (+ grace). So a dir whose mtime is
+    # older than that provably cannot belong to a live run and is safe to reclaim
+    # -- never key the sweep on max_timeout alone (it ignores the startup phase).
+    workspace_max_age = max(3600, state.config.max_startup_timeout + state.config.max_timeout + 300)
+    stranded = prune_stale_workspaces(workspace_max_age)
+    if stranded > 0:
+        logger.info(f"Startup: pruned {stranded} stale workspace dir(s)")
+
     # Start periodic cleanup task
     cleanup_task = asyncio.create_task(
-        _periodic_cleanup(state.storage, state.config.execution_record_ttl_days)
+        _periodic_cleanup(
+            state.storage,
+            state.config.execution_record_ttl_days,
+            state.config.data_dir,
+            workspace_max_age,
+        )
     )
 
     logger.info(f"Tako VM ready (production_mode={state.config.production_mode})")

--- a/tests/test_workspace_prune.py
+++ b/tests/test_workspace_prune.py
@@ -1,0 +1,84 @@
+"""
+Disk-hygiene sweeps: stranded workspace dirs and on-disk run artifacts past TTL.
+
+Run temp dirs (job-*/sandbox-*) are normally removed in a finally block, but a
+crash leaks them with no other reaper; and the DB record cleanup never deletes
+the on-disk runs/<id> artifacts. These pure filesystem sweeps reclaim both.
+No Docker required.
+"""
+
+import os
+import time
+
+import tako_vm.execution.worker as worker
+from tako_vm.execution.worker import prune_old_run_dirs, prune_stale_workspaces
+
+
+def _age(path, seconds_old: int) -> None:
+    t = time.time() - seconds_old
+    os.utime(path, (t, t))
+
+
+class TestPruneStaleWorkspaces:
+    def test_removes_only_old_run_dirs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(worker, "WORKSPACE_DIR", str(tmp_path))
+        old_job = tmp_path / "job-old"
+        old_job.mkdir()
+        (old_job / "f").write_text("x")
+        _age(old_job, 10_000)
+        old_sandbox = tmp_path / "sandbox-old"
+        old_sandbox.mkdir()
+        _age(old_sandbox, 10_000)
+        fresh = tmp_path / "job-fresh"
+        fresh.mkdir()  # mtime ~ now
+        unrelated = tmp_path / "data"
+        unrelated.mkdir()
+        _age(unrelated, 10_000)  # old but not a job-/sandbox- dir
+
+        removed = prune_stale_workspaces(max_age_seconds=3600)
+
+        assert removed == 2
+        assert not old_job.exists()
+        assert not old_sandbox.exists()
+        assert fresh.exists()  # too new
+        assert unrelated.exists()  # wrong prefix, untouched
+
+    def test_missing_workspace_dir_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(worker, "WORKSPACE_DIR", str(tmp_path / "nope"))
+        assert prune_stale_workspaces(max_age_seconds=1) == 0
+
+    def test_symlinked_entry_is_skipped(self, tmp_path, monkeypatch):
+        # A workspace-named symlink must never be followed/removed by the sweep.
+        monkeypatch.setattr(worker, "WORKSPACE_DIR", str(tmp_path))
+        target = tmp_path / "target_dir"
+        target.mkdir()
+        (target / "keep").write_text("x")
+        link = tmp_path / "job-link"
+        link.symlink_to(target)
+
+        removed = prune_stale_workspaces(max_age_seconds=1)
+
+        assert removed == 0
+        assert link.is_symlink()  # the symlink itself untouched
+        assert (target / "keep").exists()  # and its target not deleted
+
+
+class TestPruneOldRunDirs:
+    def test_removes_runs_past_ttl(self, tmp_path):
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        old = runs / "abc"
+        old.mkdir()
+        (old / "_code.py").write_text("x")
+        _age(old, 40 * 86400)
+        fresh = runs / "def"
+        fresh.mkdir()
+
+        removed = prune_old_run_dirs(tmp_path, ttl_days=30)
+
+        assert removed == 1
+        assert not old.exists()
+        assert fresh.exists()
+
+    def test_no_runs_dir_is_noop(self, tmp_path):
+        assert prune_old_run_dirs(tmp_path, ttl_days=30) == 0


### PR DESCRIPTION
## What

Two disk-growth paths had no reaper:
- Per-run temp dirs (`job-*`/`sandbox-*`) under `WORKSPACE_DIR` are removed in a `finally` block, but a crash or `rmtree` failure strands them forever.
- The hourly DB cleanup deletes `execution_records` rows but never the on-disk `runs/<id>` artifacts (code, input, outputs), so they outlive the configured retention indefinitely — disk growth plus a retention/compliance gap (stored source code/inputs outlive their record).

## Fix

Add two fail-soft, age-based sweeps in `worker.py`:
- `prune_stale_workspaces(max_age_seconds)` — removes `job-*`/`sandbox-*` dirs older than `max(3600, 2×max_timeout)`.
- `prune_old_run_dirs(data_dir, ttl_days)` — removes `runs/<id>` dirs older than `execution_record_ttl_days`.

Wired into the server: a one-shot workspace sweep at startup (reclaims dirs stranded by a previous crash) + both sweeps in the existing hourly `_periodic_cleanup`. No storage API change; `cleanup_old_records` is untouched.

## Compatibility

Additive cleanup, gated on existing config (`max_timeout`, `execution_record_ttl_days`). Both sweeps skip symlinks and non-matching names, and are fail-soft per directory.

## Tests

`tests/test_workspace_prune.py` (Docker-free): old `job-*`/`sandbox-*` dirs pruned, fresh and wrong-prefix dirs kept; `runs/<id>` past TTL pruned, fresh kept; missing dirs are no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
