### PR TITLE
feat(sdk): bring the Python client to API parity (async jobs, auth passthrough, history)

### DIFF
--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -21,7 +21,7 @@ tako-vm server                  # start server (auto-starts PostgreSQL via Docke
 
 ## TakoVM Client (Server Mode)
 
-For production deployments with job queuing, persistence, and audit trails, use the HTTP server and client.
+For deployments with job queuing, persistence, and audit trails, use the HTTP server and the `TakoVM` client.
 
 ### Quick Start
 
@@ -47,97 +47,122 @@ result = tako_vm.send(add, Input(10, 20))
 print(result.result)  # 30
 ```
 
----
+The module-level helpers (`tako_vm.send`, `send_raw`, `list_job_types`, `get_job_type`) use a default client configured via `tako_vm.configure()`. For authentication, multiple clients, or the async job lifecycle, instantiate `TakoVM` directly.
 
-## Functions
-
-### `tako_vm.configure()`
-
-Configure the default client.
+### The `TakoVM` client
 
 ```python
-tako_vm.configure(
+from tako_vm import TakoVM
+
+client = TakoVM(
     base_url="http://localhost:8000",
-    timeout=30
+    timeout=30,
+    headers={"X-API-Key": "..."},  # forwarded on every request
+    session=None,                   # optional preconfigured requests.Session
 )
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `base_url` | str | `"http://localhost:8000"` | Server URL |
-| `timeout` | int | 30 | Default execution timeout |
+| `timeout` | int | 30 | Default execution timeout (seconds) |
+| `headers` | dict | `None` | Headers forwarded on every request |
+| `session` | requests.Session | `None` | Preconfigured session (retries, mTLS, proxies, pooling) |
+
+### Authentication
+
+The SDK does **not** implement authentication — it forwards whatever headers you give it, verbatim, on every request. Supply the credential your deployment requires (the server's API key, a bearer token from your gateway, etc.), or use a `session` for transport-level auth (mTLS).
+
+```python
+# API key (matches the server's api_auth_header, default "X-API-Key")
+client = TakoVM("https://tako.internal", headers={"X-API-Key": API_KEY})
+
+# Bearer token
+client = TakoVM("https://tako.internal", headers={"Authorization": f"Bearer {token}"})
+
+# mTLS / custom transport
+import requests
+sess = requests.Session(); sess.cert = ("client.crt", "client.key")
+client = TakoVM("https://tako.internal", session=sess)
+```
+
+`tako_vm.configure(..., headers=...)` does the same for the module-level helpers.
 
 ---
 
-### `tako_vm.send()`
+## Synchronous execution
 
-Execute a typed function and return the result.
+### `send()` / `send_raw()`
+
+Execute a typed function and wait for the result. `send()` returns the output dataclass (raising `ExecutionError` on failure); `send_raw()` returns an `ExecutionResult` and never raises on execution failure.
 
 ```python
-result = tako_vm.send(func, input_data, timeout=None, job_type=None)
+result = client.send(
+    func, input_data,
+    timeout=None,           # execution timeout (s)
+    job_type=None,          # job type name (default: "default")
+    requirements=None,      # runtime packages, e.g. ["pandas", "numpy>=1.20"]
+    startup_timeout=None,   # startup phase timeout (container + deps)
+    idempotency_key=None,   # client key for idempotent submission
+)
 ```
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `func` | Callable | Yes | Function with type hints |
-| `input_data` | dataclass | Yes | Input dataclass instance |
-| `timeout` | int | No | Timeout in seconds |
-| `job_type` | str | No | Environment name |
-
-**Returns**: Output dataclass instance
-
-**Raises**:
-- `ValidationError`: Invalid input/output types
-- `ExecutionError`: Execution failed
+**Raises**: `ValidationError` (invalid input/output types), `ExecutionError` (`send` only).
 
 !!! important "How `send()` works"
-    The function you pass to `send()` does **not** run locally. Instead:
-
-    1. The function's source code is extracted via `inspect.getsource()`
-    2. The input dataclass is serialized to JSON and written to `/input/data.json`
-    3. The code is sent to the Tako VM server and executed in an isolated Docker container
-    4. The output is deserialized back into your output dataclass
-
-    This means:
-
-    - **Do not reference local variables** outside the function — they won't exist in the container
-    - **Imports must be inside the function** or available in the container's Python environment
-    - **The return type annotation** determines how `/output/result.json` is parsed back
+    The function you pass does **not** run locally. Its source is extracted via `inspect.getsource()`, the input dataclass is written to `/input/data.json`, the code runs in an isolated container, and `/output/result.json` is parsed back into your output dataclass. Therefore: **don't reference local variables** outside the function, **put imports inside** the function (or in the job type's image), and the **return annotation** drives output parsing.
 
 ---
 
-### `tako_vm.send_raw()`
+## Async jobs
 
-Execute a function and return raw result (doesn't raise on failure).
+Submit work without blocking, then poll or wait for the result.
 
 ```python
-result = tako_vm.send_raw(func, input_data, timeout=None, job_type=None)
+job_id = client.submit(func, input_data, requirements=["pandas"])   # typed
+job_id = client.submit_code("print(1)", {"x": 1})                   # raw code
+
+client.get_status(job_id)                       # {"status": "running", ...}
+record = client.get_result(job_id, timeout=60)  # waits up to 60s; view="full" for artifacts
+client.cancel(job_id)                           # cancel a queued/running job
+
+new_id = client.rerun(job_id)                   # re-run same code+input
+new_id = client.fork(job_id, "print(2)")        # re-run the input with new code
+
+data = client.download_artifact(job_id, "plot.png")   # -> bytes
 ```
 
-**Returns**: `ExecutionResult` object
+| Method | Endpoint | Returns |
+|--------|----------|---------|
+| `submit(func, input, ...)` / `submit_code(code, input_data, ...)` | `POST /execute/async` | `job_id` (str) |
+| `get_status(job_id)` | `GET /jobs/{id}` | status dict |
+| `get_result(job_id, timeout=, view=)` | `GET /jobs/{id}/result` | execution record |
+| `cancel(job_id)` | `POST /jobs/{id}/cancel` | cancel dict |
+| `rerun(job_id, job_type=, timeout=)` | `POST /jobs/{id}/rerun` | new `job_id` |
+| `fork(job_id, code, job_type=, timeout=)` | `POST /jobs/{id}/fork` | new `job_id` |
+| `download_artifact(job_id, name)` | `GET /jobs/{id}/artifacts/{name}` | `bytes` |
 
 ---
 
-### `tako_vm.list_job_types()`
-
-List available environments.
+## Execution history & metadata
 
 ```python
-job_types = tako_vm.list_job_types()
-for jt in job_types:
-    print(jt["name"], jt["requirements"])
+page = client.list_executions(status="succeeded", job_type=None, limit=50, offset=0, view=None)
+record = client.get_execution(execution_id, view="full")
+
+client.list_job_types()              # available job types
+client.get_job_type("data-processing")
+client.build_job_type("data-processing")   # build its image
+
+client.health()                      # server health
+client.pool_stats()                  # worker pool stats
+client.dlq_stats()                   # dead-letter-queue stats
 ```
 
----
+`list_executions()` returns a paginated response (`{"items": [...], "limit", "offset", "has_more", "count"}`).
 
-### `tako_vm.get_job_type()`
-
-Get a specific environment.
-
-```python
-jt = tako_vm.get_job_type("data-processing")
-print(jt["memory_limit"])  # "1g"
-```
+!!! note "Sessions"
+    A long-lived **session** API is in development and not yet part of this client. Until it lands, drive any session endpoints through `client._request(...)` or raw HTTP.
 
 ---
 

--- a/tako_vm/sdk/client.py
+++ b/tako_vm/sdk/client.py
@@ -20,12 +20,23 @@ Provides a typed interface for executing functions in isolated containers:
 
     result = tako_vm.send(my_func, InputStruct(1, 2))
     print(result.return1)  # 3
+
+Authentication is handled by the *caller*, not the SDK: pass whatever headers
+your deployment requires and they are forwarded verbatim on every request. The
+SDK never interprets credentials.
+
+    client = TakoVM("https://tako.internal", headers={"X-API-Key": KEY})
+
+A preconfigured ``requests.Session`` may be supplied for retries, mTLS, proxies,
+connection pooling, etc.:
+
+    client = TakoVM("https://tako.internal", session=my_session)
 """
 
 import inspect
 import textwrap
 from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass
-from typing import Any, Callable, Optional, TypeVar, cast, get_type_hints
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast, get_type_hints
 
 import requests
 
@@ -70,23 +81,66 @@ class ValidationError(TakoVMError):
 
 class TakoVM:
     """
-    Client for executing typed functions in isolated containers.
+    Client for the secure code executor.
+
+    Covers typed-function execution (``send``), the async job lifecycle
+    (``submit``/``get_status``/``get_result``/``cancel``/``rerun``/``fork``),
+    artifact download, execution history, and metadata.
 
     Example:
         client = TakoVM("http://localhost:8000")
         result = client.send(my_func, InputStruct(1, 2))
     """
 
-    def __init__(self, base_url: str = "http://localhost:8000", timeout: int = 30):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        timeout: int = 30,
+        headers: Optional[Dict[str, str]] = None,
+        session: Optional[requests.Session] = None,
+    ):
         """
         Initialize the TakoVM client.
 
         Args:
-            base_url: URL of the code executor API
-            timeout: Default execution timeout in seconds
+            base_url: URL of the code executor API.
+            timeout: Default execution timeout in seconds.
+            headers: Headers forwarded on every request. Use this to
+                authenticate (e.g. ``{"X-API-Key": ...}`` or
+                ``{"Authorization": "Bearer ..."}``); the SDK does not
+                interpret them.
+            session: Optional preconfigured ``requests.Session`` (retries,
+                mTLS, proxies, pooling). A fresh session is created otherwise.
         """
         self.base_url = base_url.rstrip("/")
         self.default_timeout = timeout
+        self._headers = dict(headers) if headers else {}
+        self._session = session or requests.Session()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        expect_json: bool = True,
+        http_timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Issue a request, forwarding the caller-supplied auth headers."""
+        merged = {**self._headers, **kwargs.pop("headers", {})}
+        response = self._session.request(
+            method,
+            f"{self.base_url}{path}",
+            headers=merged or None,
+            timeout=http_timeout if http_timeout is not None else self.default_timeout + 10,
+            **kwargs,
+        )
+        response.raise_for_status()
+        return response.json() if expect_json else response
+
+    # ------------------------------------------------------------------ #
+    # Typed function execution (synchronous)
+    # ------------------------------------------------------------------ #
 
     def send(
         self,
@@ -94,67 +148,49 @@ class TakoVM:
         input_data: InputT,
         timeout: Optional[int] = None,
         job_type: Optional[str] = None,
+        requirements: Optional[List[str]] = None,
+        startup_timeout: Optional[int] = None,
+        idempotency_key: Optional[str] = None,
     ) -> OutputT:
         """
-        Execute a typed function in an isolated container.
+        Execute a typed function in an isolated container and return its output.
 
         Args:
             func: Function to execute. Must have type hints for input and output.
-            input_data: Input dataclass instance
-            timeout: Execution timeout in seconds (uses job type default if not specified)
-            job_type: Job type name (uses "default" if not specified)
+            input_data: Input dataclass instance.
+            timeout: Execution timeout in seconds (uses job type default if not set).
+            job_type: Job type name (uses "default" if not set).
+            requirements: Python packages to install at runtime, e.g.
+                ``["pandas", "numpy>=1.20"]`` (requires the server to allow it).
+            startup_timeout: Timeout for the startup phase (container + deps).
+            idempotency_key: Client key for idempotent submission.
 
         Returns:
-            Output dataclass instance
+            Output dataclass instance.
 
         Raises:
-            ValidationError: If input/output types are invalid
-            ExecutionError: If execution fails
+            ValidationError: If input/output types are invalid.
+            ExecutionError: If execution fails.
         """
-        # Validate input is a dataclass
-        if not is_dataclass(input_data):
-            raise ValidationError(
-                f"input_data must be a dataclass instance, got {type(input_data)}"
-            )
-
-        # Get type hints from function
-        hints = get_type_hints(func)
-        if "return" not in hints:
-            raise ValidationError("Function must have a return type hint")
-
-        output_type = hints["return"]
-        if not inspect.isclass(output_type) or not is_dataclass(output_type):
-            raise ValidationError(f"Return type must be a dataclass, got {output_type}")
-        output_cls = cast(type[OutputT], output_type)
-
-        # Get input type from first parameter
-        params = list(hints.keys())
-        params.remove("return")
-        if not params:
-            raise ValidationError("Function must have at least one parameter")
-
-        input_type = hints[params[0]]
-        if not inspect.isclass(input_type) or not is_dataclass(input_type):
-            raise ValidationError(f"Input parameter must be a dataclass type, got {input_type}")
-        input_cls = cast(type[Any], input_type)
-
-        # Generate the wrapper code
+        input_cls, output_cls = self._resolve_io_types(func, input_data)
         code = self._generate_code(func, input_cls, output_cls)
-
-        # Serialize input
-        input_dict = asdict(cast(Any, input_data))
-
-        # Execute
-        result = self._execute(code, input_dict, timeout, job_type)
+        result = self._execute(
+            code,
+            asdict(cast(Any, input_data)),
+            timeout=timeout,
+            job_type=job_type,
+            requirements=requirements,
+            startup_timeout=startup_timeout,
+            idempotency_key=idempotency_key,
+        )
 
         if not result.success:
             raise ExecutionError(
                 result.error or "Execution failed", stdout=result.stdout, stderr=result.stderr
             )
 
-        # Deserialize output
         try:
-            return output_cls(**cast(dict[str, Any], result.output))
+            return cast(OutputT, output_cls(**cast(Dict[str, Any], result.output)))
         except (TypeError, ValueError) as e:
             raise ValidationError(
                 f"Failed to deserialize output to {output_cls.__name__}: {e}"
@@ -166,6 +202,9 @@ class TakoVM:
         input_data: InputT,
         timeout: Optional[int] = None,
         job_type: Optional[str] = None,
+        requirements: Optional[List[str]] = None,
+        startup_timeout: Optional[int] = None,
+        idempotency_key: Optional[str] = None,
     ) -> ExecutionResult:
         """
         Execute a typed function and return the raw result.
@@ -173,6 +212,29 @@ class TakoVM:
         Same as send() but returns ExecutionResult instead of raising on failure.
         Useful when you want to handle errors yourself or inspect stdout/stderr.
         """
+        input_cls, output_cls = self._resolve_io_types(func, input_data)
+        code = self._generate_code(func, input_cls, output_cls)
+        result = self._execute(
+            code,
+            asdict(cast(Any, input_data)),
+            timeout=timeout,
+            job_type=job_type,
+            requirements=requirements,
+            startup_timeout=startup_timeout,
+            idempotency_key=idempotency_key,
+        )
+
+        if result.success and result.output:
+            try:
+                result.output = output_cls(**cast(Dict[str, Any], result.output))
+            except (TypeError, ValueError, KeyError):
+                # Keep as dict if deserialization fails (type mismatch, missing fields, etc.)
+                pass
+
+        return result
+
+    def _resolve_io_types(self, func: Callable[..., Any], input_data: Any) -> Tuple[type, type]:
+        """Validate a typed function and return its (input_cls, output_cls)."""
         if not is_dataclass(input_data):
             raise ValidationError(
                 f"input_data must be a dataclass instance, got {type(input_data)}"
@@ -183,31 +245,95 @@ class TakoVM:
             raise ValidationError("Function must have a return type hint")
 
         output_type = hints["return"]
-        params = [k for k in hints.keys() if k != "return"]
-        input_type = hints[params[0]] if params else type(input_data)
-
         if not inspect.isclass(output_type) or not is_dataclass(output_type):
             raise ValidationError(f"Return type must be a dataclass, got {output_type}")
-        output_cls = cast(type[Any], output_type)
 
+        params = [k for k in hints.keys() if k != "return"]
+        if not params:
+            raise ValidationError("Function must have at least one parameter")
+
+        input_type = hints[params[0]]
         if not inspect.isclass(input_type) or not is_dataclass(input_type):
             raise ValidationError(f"Input parameter must be a dataclass type, got {input_type}")
-        input_cls = cast(type[Any], input_type)
 
-        code = self._generate_code(func, input_cls, output_cls)
-        input_dict = asdict(cast(Any, input_data))
+        return cast(type, input_type), cast(type, output_type)
 
-        result = self._execute(code, input_dict, timeout, job_type)
+    def _execute(
+        self,
+        code: str,
+        input_data: dict,
+        *,
+        timeout: Optional[int] = None,
+        job_type: Optional[str] = None,
+        requirements: Optional[List[str]] = None,
+        startup_timeout: Optional[int] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> ExecutionResult:
+        """Execute code synchronously via POST /execute."""
+        payload = self._execute_payload(
+            code,
+            input_data,
+            timeout=timeout,
+            job_type=job_type,
+            requirements=requirements,
+            startup_timeout=startup_timeout,
+            idempotency_key=idempotency_key,
+        )
+        try:
+            data = self._request(
+                "POST",
+                "/execute",
+                json=payload,
+                http_timeout=(timeout or self.default_timeout) + 10,
+            )
+        except requests.exceptions.RequestException as e:
+            return ExecutionResult(
+                success=False,
+                output=None,
+                execution_time=0,
+                stdout="",
+                stderr="",
+                error=f"Request failed: {e}",
+            )
 
-        # Deserialize output if successful
-        if result.success and result.output:
-            try:
-                result.output = output_cls(**cast(dict[str, Any], result.output))
-            except (TypeError, ValueError, KeyError):
-                # Keep as dict if deserialization fails (type mismatch, missing fields, etc.)
-                pass
+        return ExecutionResult(
+            success=data.get("success", False),
+            output=data.get("output"),
+            execution_time=data.get("execution_time", 0),
+            stdout=data.get("stdout", ""),
+            stderr=data.get("stderr", ""),
+            error=data.get("error"),
+            job_type=data.get("job_type"),
+        )
 
-        return result
+    @staticmethod
+    def _execute_payload(
+        code: str,
+        input_data: dict,
+        *,
+        timeout: Optional[int],
+        job_type: Optional[str],
+        requirements: Optional[List[str]],
+        startup_timeout: Optional[int],
+        idempotency_key: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build a /execute(/async) request body, omitting unset optionals."""
+        payload: Dict[str, Any] = {"code": code, "input_data": input_data}
+        if timeout is not None:
+            payload["timeout"] = timeout
+        if startup_timeout is not None:
+            payload["startup_timeout"] = startup_timeout
+        if job_type is not None:
+            payload["job_type"] = job_type
+        if requirements:
+            payload["requirements"] = list(requirements)
+        if idempotency_key is not None:
+            payload["idempotency_key"] = idempotency_key
+        return payload
+
+    # ------------------------------------------------------------------ #
+    # Code generation (sandbox wrapper)
+    # ------------------------------------------------------------------ #
 
     def _generate_code(
         self, func: Callable[..., Any], input_type: type[Any], output_type: type[Any]
@@ -290,94 +416,191 @@ _execute()
             return cast(Any, t).__name__
         return str(t)
 
-    def _execute(
-        self, code: str, input_data: dict, timeout: Optional[int], job_type: Optional[str]
-    ) -> ExecutionResult:
-        """Execute code via the API."""
-        try:
-            payload = {
-                "code": code,
-                "input_data": input_data,
-            }
+    # ------------------------------------------------------------------ #
+    # Async job lifecycle
+    # ------------------------------------------------------------------ #
 
-            # Only include optional fields if specified
-            if timeout is not None:
-                payload["timeout"] = timeout
-            if job_type is not None:
-                payload["job_type"] = job_type
+    def submit_code(
+        self,
+        code: str,
+        input_data: Optional[dict] = None,
+        *,
+        timeout: Optional[int] = None,
+        startup_timeout: Optional[int] = None,
+        job_type: Optional[str] = None,
+        requirements: Optional[List[str]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> str:
+        """Submit raw code for asynchronous execution; returns the job id."""
+        payload = self._execute_payload(
+            code,
+            input_data or {},
+            timeout=timeout,
+            job_type=job_type,
+            requirements=requirements,
+            startup_timeout=startup_timeout,
+            idempotency_key=idempotency_key,
+        )
+        return self._request("POST", "/execute/async", json=payload)["job_id"]
 
-            # Use provided timeout or default for HTTP timeout
-            http_timeout = (timeout or self.default_timeout) + 10
+    def submit(
+        self,
+        func: Callable[[InputT], OutputT],
+        input_data: InputT,
+        *,
+        timeout: Optional[int] = None,
+        startup_timeout: Optional[int] = None,
+        job_type: Optional[str] = None,
+        requirements: Optional[List[str]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> str:
+        """Submit a typed function for asynchronous execution; returns the job id."""
+        input_cls, output_cls = self._resolve_io_types(func, input_data)
+        code = self._generate_code(func, input_cls, output_cls)
+        return self.submit_code(
+            code,
+            asdict(cast(Any, input_data)),
+            timeout=timeout,
+            startup_timeout=startup_timeout,
+            job_type=job_type,
+            requirements=requirements,
+            idempotency_key=idempotency_key,
+        )
 
-            response = requests.post(f"{self.base_url}/execute", json=payload, timeout=http_timeout)
-            response.raise_for_status()
-            data = response.json()
+    def get_status(self, job_id: str) -> dict:
+        """Get an async job's status (GET /jobs/{job_id})."""
+        return self._request("GET", f"/jobs/{job_id}")
 
-            return ExecutionResult(
-                success=data.get("success", False),
-                output=data.get("output"),
-                execution_time=data.get("execution_time", 0),
-                stdout=data.get("stdout", ""),
-                stderr=data.get("stderr", ""),
-                error=data.get("error"),
-                job_type=data.get("job_type"),
-            )
-        except requests.exceptions.RequestException as e:
-            return ExecutionResult(
-                success=False,
-                output=None,
-                execution_time=0,
-                stdout="",
-                stderr="",
-                error=f"Request failed: {e}",
-            )
+    def get_result(
+        self, job_id: str, *, timeout: Optional[int] = None, view: Optional[str] = None
+    ) -> dict:
+        """
+        Get an async job's result, waiting up to ``timeout`` seconds for it
+        (GET /jobs/{job_id}/result). Pass ``view="full"`` for artifacts,
+        resource usage, hashes, and lineage.
+        """
+        params: Dict[str, Any] = {}
+        if timeout is not None:
+            params["timeout"] = timeout
+        if view:
+            params["view"] = view
+        return self._request(
+            "GET",
+            f"/jobs/{job_id}/result",
+            params=params,
+            http_timeout=(timeout or self.default_timeout) + 10,
+        )
+
+    def cancel(self, job_id: str) -> dict:
+        """Cancel a queued or running job (POST /jobs/{job_id}/cancel)."""
+        return self._request("POST", f"/jobs/{job_id}/cancel")
+
+    def rerun(
+        self, job_id: str, *, job_type: Optional[str] = None, timeout: Optional[int] = None
+    ) -> str:
+        """Re-run a previous job with the same code/input; returns the new job id."""
+        body: Dict[str, Any] = {}
+        if job_type is not None:
+            body["job_type"] = job_type
+        if timeout is not None:
+            body["timeout"] = timeout
+        return self._request("POST", f"/jobs/{job_id}/rerun", json=body)["job_id"]
+
+    def fork(
+        self,
+        job_id: str,
+        code: str,
+        *,
+        job_type: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> str:
+        """Re-run a previous job's input with new code; returns the new job id."""
+        body: Dict[str, Any] = {"code": code}
+        if job_type is not None:
+            body["job_type"] = job_type
+        if timeout is not None:
+            body["timeout"] = timeout
+        return self._request("POST", f"/jobs/{job_id}/fork", json=body)["job_id"]
+
+    def download_artifact(self, job_id: str, artifact_name: str) -> bytes:
+        """Download a job artifact's bytes (GET /jobs/{job_id}/artifacts/{name})."""
+        response = self._request(
+            "GET", f"/jobs/{job_id}/artifacts/{artifact_name}", expect_json=False
+        )
+        return response.content
+
+    # ------------------------------------------------------------------ #
+    # Execution history & metadata
+    # ------------------------------------------------------------------ #
+
+    def list_executions(
+        self,
+        *,
+        status: Optional[str] = None,
+        job_type: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+        view: Optional[str] = None,
+    ) -> dict:
+        """List execution records (GET /executions); returns a paginated response."""
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if status:
+            params["status"] = status
+        if job_type:
+            params["job_type"] = job_type
+        if view:
+            params["view"] = view
+        return self._request("GET", "/executions", params=params)
+
+    def get_execution(self, execution_id: str, *, view: Optional[str] = None) -> dict:
+        """Get a single execution record (GET /executions/{execution_id})."""
+        params = {"view": view} if view else {}
+        return self._request("GET", f"/executions/{execution_id}", params=params)
+
+    def pool_stats(self) -> dict:
+        """Worker pool statistics (GET /pool/stats)."""
+        return self._request("GET", "/pool/stats", http_timeout=10)
+
+    def dlq_stats(self) -> dict:
+        """Dead-letter-queue statistics (GET /dlq/stats)."""
+        return self._request("GET", "/dlq/stats", http_timeout=10)
 
     def health(self) -> dict:
         """Check API health status."""
-        response = requests.get(f"{self.base_url}/health", timeout=10)
-        response.raise_for_status()
-        return response.json()
+        return self._request("GET", "/health", http_timeout=10)
 
     def list_job_types(self) -> list:
-        """
-        List available job types.
-
-        Returns:
-            List of job type configurations
-        """
-        response = requests.get(f"{self.base_url}/job-types", timeout=10)
-        response.raise_for_status()
-        return response.json()
+        """List available job types."""
+        return self._request("GET", "/job-types", http_timeout=10)
 
     def get_job_type(self, name: str) -> dict:
-        """
-        Get a specific job type by name.
+        """Get a specific job type by name."""
+        return self._request("GET", f"/job-types/{name}", http_timeout=10)
 
-        Args:
-            name: Job type name
-
-        Returns:
-            Job type configuration
-        """
-        response = requests.get(f"{self.base_url}/job-types/{name}", timeout=10)
-        response.raise_for_status()
-        return response.json()
+    def build_job_type(self, name: str) -> dict:
+        """Build the image for a job type (POST /job-types/{name}/build)."""
+        return self._request("POST", f"/job-types/{name}/build")
 
 
 # Default client instance
 _default_client: Optional[TakoVM] = None
 
 
-def configure(base_url: str = "http://localhost:8000", timeout: int = 30):
+def configure(
+    base_url: str = "http://localhost:8000",
+    timeout: int = 30,
+    headers: Optional[Dict[str, str]] = None,
+) -> None:
     """
-    Configure the default tako_vm client.
+    Configure the default tako_vm client used by the module-level helpers.
 
     Args:
-        base_url: URL of the code executor API
-        timeout: Default execution timeout in seconds
+        base_url: URL of the code executor API.
+        timeout: Default execution timeout in seconds.
+        headers: Headers forwarded on every request (e.g. for authentication).
     """
     global _default_client
-    _default_client = TakoVM(base_url=base_url, timeout=timeout)
+    _default_client = TakoVM(base_url=base_url, timeout=timeout, headers=headers)
 
 
 def _get_client() -> TakoVM:
@@ -393,20 +616,10 @@ def send(
     input_data: InputT,
     timeout: Optional[int] = None,
     job_type: Optional[str] = None,
+    requirements: Optional[List[str]] = None,
 ) -> OutputT:
     """
-    Execute a typed function in an isolated container.
-
-    This is a convenience function using the default client.
-
-    Args:
-        func: Function to execute. Must have type hints for input and output.
-        input_data: Input dataclass instance
-        timeout: Execution timeout in seconds
-        job_type: Job type name (e.g., "data-processing", "ml-inference")
-
-    Returns:
-        Output dataclass instance
+    Execute a typed function in an isolated container (default client).
 
     Example:
         @dataclass
@@ -423,11 +636,10 @@ def send(
 
         result = tako_vm.send(add, Input(1, 2))
         print(result.result)  # 3
-
-        # With job type
-        result = tako_vm.send(process_data, data, job_type="data-processing")
     """
-    return _get_client().send(func, input_data, timeout, job_type)
+    return _get_client().send(
+        func, input_data, timeout=timeout, job_type=job_type, requirements=requirements
+    )
 
 
 def send_raw(
@@ -435,20 +647,23 @@ def send_raw(
     input_data: InputT,
     timeout: Optional[int] = None,
     job_type: Optional[str] = None,
+    requirements: Optional[List[str]] = None,
 ) -> ExecutionResult:
     """
-    Execute a typed function and return the raw result.
+    Execute a typed function and return the raw result (default client).
 
     Same as send() but returns ExecutionResult instead of raising on failure.
     """
-    return _get_client().send_raw(func, input_data, timeout, job_type)
+    return _get_client().send_raw(
+        func, input_data, timeout=timeout, job_type=job_type, requirements=requirements
+    )
 
 
 def list_job_types() -> list:
-    """List available job types."""
+    """List available job types (default client)."""
     return _get_client().list_job_types()
 
 
 def get_job_type(name: str) -> dict:
-    """Get a specific job type by name."""
+    """Get a specific job type by name (default client)."""
     return _get_client().get_job_type(name)

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -1,12 +1,13 @@
 """
 Tests for Tako VM SDK client.
 
-Tests the typed function execution client with mocked HTTP responses.
+Tests the typed function execution client, the async job lifecycle, auth
+passthrough, and execution history with a mocked HTTP session.
 """
 
 from dataclasses import dataclass
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,11 +15,9 @@ from tako_vm.sdk.client import (
     ExecutionError,
     ExecutionResult,
     TakoVM,
-    TakoVMError,
     ValidationError,
     _get_client,
     configure,
-    send,
 )
 
 
@@ -40,6 +39,17 @@ class OutputData:
 def add_numbers(input: InputData) -> OutputData:
     """Test function that adds two numbers."""
     return OutputData(result=input.x + input.y)
+
+
+def _mock_session(json_value: Any = None, content: bytes = b"") -> MagicMock:
+    """A requests.Session mock whose .request() returns a canned response."""
+    response = MagicMock()
+    response.json.return_value = json_value
+    response.content = content
+    response.raise_for_status = MagicMock()
+    session = MagicMock()
+    session.request.return_value = response
+    return session
 
 
 class TestTakoVMClient:
@@ -138,44 +148,31 @@ class TestValidation:
 
 
 class TestExecution:
-    """Tests for execution with mocked HTTP."""
+    """Tests for synchronous execution (mocked HTTP session)."""
 
-    @patch("tako_vm.sdk.client.requests.post")
-    def test_send_success(self, mock_post):
-        """send() returns deserialized output on success."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "success": True,
-            "output": {"result": 15},
-            "execution_time": 0.5,
-            "stdout": "",
-            "stderr": "",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        client = TakoVM()
+    def test_send_success(self):
+        session = _mock_session({"success": True, "output": {"result": 15}, "execution_time": 0.5})
+        client = TakoVM(session=session)
         result = client.send(add_numbers, InputData(x=5, y=10))
 
         assert isinstance(result, OutputData)
         assert result.result == 15
+        method, url = session.request.call_args.args
+        assert method == "POST"
+        assert url.endswith("/execute")
 
-    @patch("tako_vm.sdk.client.requests.post")
-    def test_send_execution_failure(self, mock_post):
-        """send() raises ExecutionError on failure."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "success": False,
-            "output": None,
-            "execution_time": 0.1,
-            "stdout": "some output",
-            "stderr": "error details",
-            "error": "Execution failed: ZeroDivisionError",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        client = TakoVM()
+    def test_send_execution_failure(self):
+        session = _mock_session(
+            {
+                "success": False,
+                "output": None,
+                "execution_time": 0.1,
+                "stdout": "some output",
+                "stderr": "error details",
+                "error": "Execution failed: ZeroDivisionError",
+            }
+        )
+        client = TakoVM(session=session)
 
         with pytest.raises(ExecutionError) as exc_info:
             client.send(add_numbers, InputData(x=1, y=2))
@@ -184,201 +181,182 @@ class TestExecution:
         assert exc_info.value.stdout == "some output"
         assert exc_info.value.stderr == "error details"
 
-    @patch("tako_vm.sdk.client.requests.post")
-    def test_send_raw_returns_result(self, mock_post):
-        """send_raw() returns ExecutionResult instead of raising."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "success": False,
-            "output": None,
-            "execution_time": 0.1,
-            "stdout": "output",
-            "stderr": "error",
-            "error": "Failed",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        client = TakoVM()
+    def test_send_raw_returns_result(self):
+        session = _mock_session(
+            {"success": False, "output": None, "execution_time": 0.1, "error": "Failed"}
+        )
+        client = TakoVM(session=session)
         result = client.send_raw(add_numbers, InputData(x=1, y=2))
 
         assert isinstance(result, ExecutionResult)
         assert result.success is False
         assert result.error == "Failed"
 
-    @patch("tako_vm.sdk.client.requests.post")
-    def test_send_with_job_type(self, mock_post):
-        """send() passes job_type to API."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "success": True,
-            "output": {"result": 3},
-            "execution_time": 0.5,
-            "stdout": "",
-            "stderr": "",
-            "job_type": "custom-job",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+    def test_send_passes_all_execute_params(self):
+        session = _mock_session({"success": True, "output": {"result": 3}, "execution_time": 0.1})
+        client = TakoVM(session=session)
+        client.send(
+            add_numbers,
+            InputData(1, 2),
+            job_type="custom",
+            timeout=60,
+            requirements=["pandas", "numpy>=1.20"],
+            startup_timeout=120,
+            idempotency_key="abc12345",
+        )
 
-        client = TakoVM()
-        client.send(add_numbers, InputData(x=1, y=2), job_type="custom-job")
+        payload = session.request.call_args.kwargs["json"]
+        assert payload["job_type"] == "custom"
+        assert payload["timeout"] == 60
+        assert payload["requirements"] == ["pandas", "numpy>=1.20"]
+        assert payload["startup_timeout"] == 120
+        assert payload["idempotency_key"] == "abc12345"
 
-        # Verify job_type was included in request
-        call_args = mock_post.call_args
-        assert call_args[1]["json"]["job_type"] == "custom-job"
+    def test_request_failure_returns_failed_result(self):
+        import requests
 
-    @patch("tako_vm.sdk.client.requests.post")
-    def test_send_with_timeout(self, mock_post):
-        """send() passes timeout to API."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "success": True,
-            "output": {"result": 3},
-            "execution_time": 0.5,
-            "stdout": "",
-            "stderr": "",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        client = TakoVM()
-        client.send(add_numbers, InputData(x=1, y=2), timeout=60)
-
-        call_args = mock_post.call_args
-        assert call_args[1]["json"]["timeout"] == 60
+        session = MagicMock()
+        session.request.side_effect = requests.exceptions.ConnectionError("boom")
+        client = TakoVM(session=session)
+        result = client.send_raw(add_numbers, InputData(1, 2))
+        assert result.success is False
+        assert "Request failed" in (result.error or "")
 
 
-class TestHealthCheck:
-    """Tests for health check endpoint."""
+class TestAuthPassthrough:
+    """The SDK forwards caller-supplied headers and never interprets them."""
 
-    @patch("tako_vm.sdk.client.requests.get")
-    def test_health_success(self, mock_get):
-        """health() returns server status."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "status": "healthy",
-            "docker_available": True,
-            "version": "1.0.0",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    def test_headers_forwarded_on_every_request(self):
+        session = _mock_session({"status": "healthy"})
+        client = TakoVM(session=session, headers={"X-API-Key": "secret"})
+        client.health()
+        assert session.request.call_args.kwargs["headers"]["X-API-Key"] == "secret"
 
-        client = TakoVM()
-        result = client.health()
-
-        assert result["status"] == "healthy"
-        assert result["docker_available"] is True
+    def test_no_headers_sends_none(self):
+        session = _mock_session({"status": "healthy"})
+        client = TakoVM(session=session)
+        client.health()
+        assert session.request.call_args.kwargs["headers"] is None
 
 
-class TestJobTypes:
-    """Tests for job type endpoints."""
+class TestAsyncLifecycle:
+    """Tests for the async job lifecycle."""
 
-    @patch("tako_vm.sdk.client.requests.get")
-    def test_list_job_types(self, mock_get):
-        """list_job_types() returns job type list."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = [
-            {"name": "default", "requirements": []},
-            {"name": "data-processing", "requirements": ["pandas"]},
-        ]
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    def test_submit_code_returns_job_id(self):
+        session = _mock_session({"job_id": "job-123"})
+        client = TakoVM(session=session)
+        job_id = client.submit_code(
+            "print(1)", {"x": 1}, requirements=["numpy"], idempotency_key="k1"
+        )
+        assert job_id == "job-123"
+        method, url = session.request.call_args.args
+        assert method == "POST"
+        assert url.endswith("/execute/async")
+        payload = session.request.call_args.kwargs["json"]
+        assert payload["requirements"] == ["numpy"]
+        assert payload["idempotency_key"] == "k1"
 
-        client = TakoVM()
+    def test_submit_typed(self):
+        session = _mock_session({"job_id": "job-xyz"})
+        client = TakoVM(session=session)
+        assert client.submit(add_numbers, InputData(1, 2), job_type="t") == "job-xyz"
+        assert session.request.call_args.kwargs["json"]["job_type"] == "t"
+
+    def test_get_status(self):
+        session = _mock_session({"job_id": "j", "status": "running"})
+        client = TakoVM(session=session)
+        assert client.get_status("j")["status"] == "running"
+        assert session.request.call_args.args == ("GET", "http://localhost:8000/jobs/j")
+
+    def test_get_result_passes_timeout_and_view(self):
+        session = _mock_session({"status": "completed"})
+        client = TakoVM(session=session)
+        client.get_result("j", timeout=30, view="full")
+        assert session.request.call_args.kwargs["params"] == {"timeout": 30, "view": "full"}
+        assert session.request.call_args.args[1].endswith("/jobs/j/result")
+
+    def test_cancel(self):
+        session = _mock_session({"status": "cancelled", "job_id": "j"})
+        client = TakoVM(session=session)
+        assert client.cancel("j")["status"] == "cancelled"
+        assert session.request.call_args.args == ("POST", "http://localhost:8000/jobs/j/cancel")
+
+    def test_rerun_returns_new_job_id(self):
+        session = _mock_session({"job_id": "new-job"})
+        client = TakoVM(session=session)
+        assert client.rerun("j", timeout=10) == "new-job"
+        assert session.request.call_args.kwargs["json"] == {"timeout": 10}
+
+    def test_fork_returns_new_job_id(self):
+        session = _mock_session({"job_id": "forked"})
+        client = TakoVM(session=session)
+        assert client.fork("j", "print(2)") == "forked"
+        assert session.request.call_args.args[1].endswith("/jobs/j/fork")
+        assert session.request.call_args.kwargs["json"]["code"] == "print(2)"
+
+    def test_download_artifact_returns_bytes(self):
+        session = _mock_session(content=b"BINARY")
+        client = TakoVM(session=session)
+        data = client.download_artifact("j", "out.png")
+        assert data == b"BINARY"
+        assert session.request.call_args.args[1].endswith("/jobs/j/artifacts/out.png")
+
+
+class TestExecutionHistory:
+    """Tests for execution listing and metadata."""
+
+    def test_list_executions(self):
+        session = _mock_session(
+            {
+                "items": [{"execution_id": "a"}],
+                "limit": 50,
+                "offset": 0,
+                "has_more": False,
+                "count": 1,
+            }
+        )
+        client = TakoVM(session=session)
+        page = client.list_executions(status="succeeded", limit=10)
+        assert page["count"] == 1
+        params = session.request.call_args.kwargs["params"]
+        assert params["status"] == "succeeded"
+        assert params["limit"] == 10
+        assert session.request.call_args.args[1].endswith("/executions")
+
+    def test_get_execution(self):
+        session = _mock_session({"execution_id": "a"})
+        client = TakoVM(session=session)
+        assert client.get_execution("a", view="full")["execution_id"] == "a"
+        assert session.request.call_args.kwargs["params"] == {"view": "full"}
+
+    def test_list_job_types(self):
+        session = _mock_session([{"name": "default"}, {"name": "data-processing"}])
+        client = TakoVM(session=session)
         result = client.list_job_types()
-
         assert len(result) == 2
         assert result[0]["name"] == "default"
 
-    @patch("tako_vm.sdk.client.requests.get")
-    def test_get_job_type(self, mock_get):
-        """get_job_type() returns specific job type."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "name": "data-processing",
-            "requirements": ["pandas", "numpy"],
-            "timeout": 60,
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    def test_get_job_type(self):
+        session = _mock_session({"name": "data-processing", "requirements": ["pandas"]})
+        client = TakoVM(session=session)
+        assert client.get_job_type("data-processing")["name"] == "data-processing"
 
-        client = TakoVM()
-        result = client.get_job_type("data-processing")
-
-        assert result["name"] == "data-processing"
-        assert "pandas" in result["requirements"]
+    def test_health(self):
+        session = _mock_session({"status": "healthy", "docker_available": True})
+        client = TakoVM(session=session)
+        assert client.health()["status"] == "healthy"
 
 
 class TestModuleLevelFunctions:
     """Tests for module-level convenience functions."""
 
-    def test_configure(self):
-        """configure() sets default client."""
-        configure(base_url="http://test:9000", timeout=45)
+    def test_configure_with_headers(self):
+        configure(base_url="http://test:9000", timeout=45, headers={"X-API-Key": "k"})
         client = _get_client()
-
         assert client.base_url == "http://test:9000"
         assert client.default_timeout == 45
+        assert client._headers == {"X-API-Key": "k"}
 
     def test_get_client_creates_default(self):
-        """_get_client() creates default client if not configured."""
-        # Reset by setting to a known URL first
         configure(base_url="http://localhost:8000")
-        client = _get_client()
-        assert client is not None
-
-    @patch("tako_vm.sdk.client.requests.post")
-    def test_send_module_function(self, mock_post):
-        """Module-level send() uses default client."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "success": True,
-            "output": {"result": 5},
-            "execution_time": 0.1,
-            "stdout": "",
-            "stderr": "",
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        configure(base_url="http://localhost:8000")
-        result = send(add_numbers, InputData(x=2, y=3))
-
-        assert result.result == 5
-
-
-class TestExecutionResult:
-    """Tests for ExecutionResult dataclass."""
-
-    def test_execution_result_fields(self):
-        """ExecutionResult has expected fields."""
-        result = ExecutionResult(
-            success=True,
-            output={"key": "value"},
-            execution_time=1.5,
-            stdout="output",
-            stderr="",
-            error=None,
-            job_type="default",
-        )
-        assert result.success is True
-        assert result.output == {"key": "value"}
-        assert result.execution_time == 1.5
-        assert result.job_type == "default"
-
-
-class TestExceptionHierarchy:
-    """Tests for exception classes."""
-
-    def test_tako_vm_error_base(self):
-        """TakoVMError is base exception."""
-        assert issubclass(ExecutionError, TakoVMError)
-        assert issubclass(ValidationError, TakoVMError)
-
-    def test_execution_error_captures_output(self):
-        """ExecutionError captures stdout/stderr."""
-        error = ExecutionError("Failed", stdout="out", stderr="err")
-        assert str(error) == "Failed"
-        assert error.stdout == "out"
-        assert error.stderr == "err"
+        assert _get_client() is not None


### PR DESCRIPTION
## What

The Python SDK (`tako_vm/sdk/client.py`) only covered **synchronous `/execute` + health + job-type metadata**, sent a fixed payload, and had **no auth support**. It predated the async job queue, executions, DLQ, and the API-key auth feature — so it couldn't talk to an authenticated server or drive any async workflow. This brings it to parity with the current API.

## Changes

- **Auth-agnostic transport.** All requests go through a configurable `requests.Session` with caller-supplied `headers` forwarded on **every** call. The SDK never interprets credentials — pass an API key, a bearer token, or hand it a `session` for mTLS/retries. `__init__` and `configure()` gain `headers` (and `session`).
  ```python
  client = TakoVM("https://tako.internal", headers={"X-API-Key": KEY})
  ```
- **Full `/execute` params:** `requirements`, `startup_timeout`, `idempotency_key`.
- **Async job lifecycle:** `submit`/`submit_code`, `get_status`, `get_result` (server-side wait + `view`), `cancel`, `rerun`, `fork`, `download_artifact`.
- **History & metadata:** `list_executions`, `get_execution`, `build_job_type`, `pool_stats`, `dlq_stats`.

## Compatibility

Backwards compatible — `send`/`send_raw`/`configure`/`list_job_types`/`get_job_type` keep their signatures (new params are optional; `headers`/`session` default to none). No public names removed.

## Tests & docs

- `tests/test_sdk_client.py` rewritten to mock the HTTP **session** (31 cases): validation + codegen (unchanged), all execute params, **auth header passthrough**, the full async lifecycle, executions, and request-failure handling. Mocked because a live SDK↔server test needs Postgres + Docker (the repo's existing SDK tests are mocked too); methods are matched against the actual server request/response models.
- `docs/api/sdk.md` updated to match (auth, the `TakoVM` client, async jobs, history). The long-lived **session API** is in development and noted as not-yet-included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
