### PR TITLE
fix(entrypoint): SIGTERM-ignoring code must not defeat timeouts; keep uv logs out of user stdout

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -46,12 +46,16 @@ if [ -s "$REQS_FILE" ]; then
         )
     fi
 
-    # Capture install result (don't exit on error yet so we can record timing)
+    # Capture install result (don't exit on error yet so we can record timing).
+    # uv output goes to stderr (1>&2): user stdout stays clean, and the server
+    # classifies dependency_error patterns against stderr only.
+    # --kill-after sends SIGKILL if the process survives SIGTERM, so a hung
+    # installer cannot outlive the timeout.
     set +e
     if [ -n "$TAKO_STARTUP_TIMEOUT" ]; then
-        timeout --signal=TERM "${TAKO_STARTUP_TIMEOUT}s" "${UV_INSTALL_CMD[@]}" 2>&1
+        timeout --signal=TERM --kill-after=10s "${TAKO_STARTUP_TIMEOUT}s" "${UV_INSTALL_CMD[@]}" 1>&2
     else
-        "${UV_INSTALL_CMD[@]}" 2>&1
+        "${UV_INSTALL_CMD[@]}" 1>&2
     fi
     DEP_EXIT_CODE=$?
     set -e
@@ -63,6 +67,16 @@ if [ -s "$REQS_FILE" ]; then
 
     # Record dep install completion
     END_DEP=$(get_time_ms)
+
+    # GNU timeout exits 124 when the command stops on SIGTERM, but 137 when the
+    # --kill-after SIGKILL was needed. Tako VM treats 124 as an internal timeout
+    # and 137 as an OOM kill, so map kill-after deaths back to 124 when this
+    # phase ran for at least the full time limit.
+    if [ -n "$TAKO_STARTUP_TIMEOUT" ] && [ "$DEP_EXIT_CODE" -eq 137 ] \
+        && [ $((END_DEP - START_STARTUP)) -ge $((TAKO_STARTUP_TIMEOUT * 1000)) ]; then
+        DEP_EXIT_CODE=124
+    fi
+
     echo "dep_install_ms=$((END_DEP - START_STARTUP))" >> "$PHASE_FILE"
     echo "dep_install_exit_code=$DEP_EXIT_CODE" >> "$PHASE_FILE"
 
@@ -92,10 +106,12 @@ START_EXEC=$(get_time_ms)
 echo "execution_start_ms=$START_EXEC" >> "$PHASE_FILE"
 
 # Drop privileges and run user code as sandbox user
-# Using exec replaces this process, so we need a wrapper to capture timing
+# Using exec replaces this process, so we need a wrapper to capture timing.
+# --kill-after sends SIGKILL after a grace period so untrusted code that
+# ignores/traps SIGTERM (signal.SIG_IGN) cannot outlive the timeout.
 set +e
 if [ -n "$TAKO_EXECUTION_TIMEOUT" ]; then
-    timeout --signal=TERM "${TAKO_EXECUTION_TIMEOUT}s" gosu sandbox python -u /code/main.py
+    timeout --signal=TERM --kill-after=10s "${TAKO_EXECUTION_TIMEOUT}s" gosu sandbox python -u /code/main.py
 else
     gosu sandbox python -u /code/main.py
 fi
@@ -104,6 +120,16 @@ set -e
 
 # Record execution completion
 END_EXEC=$(get_time_ms)
+
+# GNU timeout exits 124 when the command stops on SIGTERM, but 137 when the
+# --kill-after SIGKILL was needed. Tako VM treats 124 as an internal timeout
+# and 137 as an OOM kill, so map kill-after deaths back to 124 when this
+# phase ran for at least the full time limit.
+if [ -n "$TAKO_EXECUTION_TIMEOUT" ] && [ "$EXEC_EXIT_CODE" -eq 137 ] \
+    && [ $((END_EXEC - START_EXEC)) -ge $((TAKO_EXECUTION_TIMEOUT * 1000)) ]; then
+    EXEC_EXIT_CODE=124
+fi
+
 echo "execution_ms=$((END_EXEC - START_EXEC))" >> "$PHASE_FILE"
 echo "execution_exit_code=$EXEC_EXIT_CODE" >> "$PHASE_FILE"
 


### PR DESCRIPTION
## Bug 1: Timeouts only sent SIGTERM — trivially ignorable by sandboxed code

Both `timeout` invocations in `docker/entrypoint.sh` (dependency install and code execution) used `--signal=TERM` with no kill backstop. Untrusted code can simply do:

```python
import signal, time
signal.signal(signal.SIGTERM, signal.SIG_IGN)
time.sleep(10**6)
```

and survive the in-container timeout entirely, running until the host-side container kill fires — at which point the result is classified from the host-kill path instead of as a clean internal timeout, and the sandbox burns the full host budget (`startup_timeout + timeout + 5s`) instead of stopping at its limit.

**Fix:** add `--kill-after=10s` to both `timeout` invocations, so SIGKILL follows SIGTERM after a 10s grace period. Well-behaved code still gets a graceful TERM.

### Exit-code contract

GNU timeout exits **124** when the command dies to the first signal, but **137** (128+SIGKILL) when `--kill-after` had to fire. The worker (`tako_vm/execution/worker.py`) treats exit 124 as an internal timeout and exit 137 as an OOM kill — so without normalization, TERM-ignoring code killed by the backstop would be misreported as `oom`. The entrypoint now maps 137 back to 124 when the phase ran for at least its full configured limit (timing is already tracked per phase in ms). A genuine OOM kill before the limit still exits 137 and is reported as `oom`; the phase file (`failed_phase=startup` / `execution_ms`) continues to resolve the correct timeout phase via `determine_timeout_phase`.

Note: in the worst case (dep install consuming its full window, then exec timing out), the host-side kill at +5s slack can still preempt the in-container `--kill-after` at +10s — that path is unchanged from today and is still classified as a timeout via the phase file.

## Bug 2: uv install output merged into user stdout (`2>&1`)

The dependency-install step redirected uv's stderr into container stdout. Two consequences:

- The user's execution stdout was polluted with package-install logs.
- `classify_error` (`tako_vm/security.py`) matches `dependency_error` patterns ("No matching distribution", "Failed to download", ...) against **stderr only**, so install failures could never be classified — every uv failure fell through to generic classification.

**Fix:** route all uv output to stderr (`1>&2`). Install diagnostics now land where classification looks, and user stdout stays clean. Verified nothing downstream parses install output from stdout (the worker only caps and stores it).

## Verification

- `bash -n docker/entrypoint.sh` passes.
- Stub harness exercised all normalization branches: TERM-honored timeout (124→124), kill-after timeout (137→124), early OOM (137 stays 137), no timeout configured (137 stays 137), success/failure passthrough.
- No behavioral test is feasible in CI without a Docker daemon, so this PR touches only the entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)