### PR TITLE
fix(queue): wait=true result polls must not cancel queued jobs

### DIFF
--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -254,7 +254,12 @@ class WorkerPool:
             raise KeyError(f"Job {job_id} has no future (internal error)")
 
         if timeout:
-            return await asyncio.wait_for(job.future, timeout=timeout)
+            # Shield the job future: asyncio.wait_for cancels the awaited
+            # future on timeout, which would make the worker loop treat the
+            # job as user-cancelled (never executing it) and surface
+            # CancelledError to any concurrent waiters. A read-only wait
+            # timing out must never affect the job itself.
+            return await asyncio.wait_for(asyncio.shield(job.future), timeout=timeout)
         else:
             return await job.future
 
@@ -280,10 +285,24 @@ class WorkerPool:
             if job_id in self._active_jobs:
                 job = self._active_jobs[job_id]
                 if job.future and job.future.done():
+                    # Derive a real terminal status from the finished future.
+                    # "completed" is not a valid QueueStatus and would fail
+                    # response validation in the API layer.
+                    if job.future.cancelled():
+                        status = "cancelled"
+                        duration_ms = None
+                    elif job.future.exception() is not None:
+                        status = "failed"
+                        duration_ms = None
+                    else:
+                        record = job.future.result()
+                        status = record.status
+                        duration_ms = record.duration_ms
                     return {
                         "job_id": job_id,
-                        "status": "completed",
+                        "status": status,
                         "created_at": job.created_at.isoformat(),
+                        "duration_ms": duration_ms,
                     }
                 queue_position = self._estimate_queue_position_unlocked(job_id)
                 return {

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,12 +2,25 @@
 
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from tako_vm.models import ExecutionRecord
 from tako_vm.server.queue import QueuedJob, WorkerPool
+
+
+def make_record(job_id: str, status: str = "succeeded", **kwargs) -> ExecutionRecord:
+    """Build a minimal ExecutionRecord for tests."""
+    return ExecutionRecord(
+        execution_id=job_id,
+        status=status,
+        created_at=datetime.now(timezone.utc),
+        queued_at=datetime.now(timezone.utc),
+        code_hash="a" * 64,
+        input_hash="b" * 64,
+        **kwargs,
+    )
 
 
 @pytest.mark.asyncio
@@ -69,3 +82,135 @@ async def test_execute_job_timeout_includes_startup_timeout(monkeypatch):
 
     assert record.execution_id == "job-123"
     assert captured["timeout"] == 180
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_timeout_does_not_cancel_future():
+    """A wait=true poll timing out must not cancel the underlying job future."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-123",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+
+    async with pool._jobs_lock:
+        pool._active_jobs[job.job_id] = job
+
+    with pytest.raises(asyncio.TimeoutError):
+        await pool.wait_for_result("job-123", timeout=0.05)
+
+    # The job must remain executable: future not cancelled, no cancel flag,
+    # so the worker dequeue guard would not treat it as user-cancelled.
+    assert job.future.cancelled() is False
+    assert job.cancelled is False
+
+    # A later result must still reach waiters.
+    record = make_record("job-123")
+    job.future.set_result(record)
+    result = await pool.wait_for_result("job-123", timeout=1.0)
+    assert result.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_timeout_does_not_break_concurrent_waiters():
+    """One waiter timing out must not raise CancelledError in other waiters."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-123",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+
+    async with pool._jobs_lock:
+        pool._active_jobs[job.job_id] = job
+
+    patient_waiter = asyncio.create_task(pool.wait_for_result("job-123", timeout=5.0))
+    impatient_waiter = asyncio.create_task(pool.wait_for_result("job-123", timeout=0.05))
+
+    with pytest.raises(asyncio.TimeoutError):
+        await impatient_waiter
+
+    job.future.set_result(make_record("job-123"))
+    result = await patient_waiter
+    assert result.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_job_still_executes_after_wait_timeout():
+    """A queued job survives a timed-out wait and is executed by the worker."""
+    executor = MagicMock()
+    storage = AsyncMock()
+    pool = WorkerPool(executor=executor, storage=storage, max_workers=1, queue_wait_timeout=0.05)
+
+    job_id = await pool.submit({"code": "print('hi')", "input_data": {}})
+    executor.execute_job_with_record.return_value = make_record(job_id)
+
+    # Wait times out before any worker has started.
+    with pytest.raises(asyncio.TimeoutError):
+        await pool.wait_for_result(job_id, timeout=0.05)
+
+    # Grab the future before workers start (the job is removed from the
+    # active map once a worker finishes it).
+    async with pool._jobs_lock:
+        future = pool._active_jobs[job_id].future
+
+    await pool.start()
+    try:
+        result = await asyncio.wait_for(future, timeout=5.0)
+    finally:
+        await pool.stop(timeout=5.0)
+
+    # The job ran (was not skipped as cancelled) and produced the real record.
+    assert executor.execute_job_with_record.called
+    assert result.execution_id == job_id
+    assert result.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_get_job_status_done_future_reports_record_status():
+    """A done future must surface the record's terminal status, never 'completed'."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-123",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    async with pool._jobs_lock:
+        pool._active_jobs[job.job_id] = job
+
+    job.future.set_result(make_record("job-123", status="failed"))
+
+    status = await pool.get_job_status("job-123")
+
+    assert status is not None
+    assert status["status"] == "failed"
+    assert status["status"] != "completed"
+
+
+@pytest.mark.asyncio
+async def test_get_job_status_cancelled_future_reports_cancelled():
+    """A cancelled future must map to the 'cancelled' API status."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-123",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    async with pool._jobs_lock:
+        pool._active_jobs[job.job_id] = job
+
+    job.future.cancel()
+
+    status = await pool.get_job_status("job-123")
+
+    assert status is not None
+    assert status["status"] == "cancelled"


### PR DESCRIPTION
## Summary

Fixes two bugs in `WorkerPool` (`tako_vm/server/queue.py`):

### Bug 1 (critical): a timed-out result wait destroys the job

`wait_for_result` awaited the job future with `asyncio.wait_for(job.future, timeout=timeout)`. `asyncio.wait_for` **cancels** the awaited future when the timeout fires. The worker dequeue loop checks `job.future.cancelled()` and treats that as a user cancellation: it saves a cancelled `ExecutionRecord` and never executes the job.

Failure scenario: a client submits an async job, then polls `GET /jobs/{id}/result?wait=true`. If the poll times out (queue busy, slow startup), the read-only poll silently cancels the queued job — it will never run, and its record shows `cancelled` even though no one cancelled it. Any concurrent waiters on the same future get `CancelledError` instead of a result.

**Fix:** wrap the future in `asyncio.shield()` inside the `wait_for`. A wait timeout still raises `asyncio.TimeoutError` to the caller (app.py keeps mapping it to HTTP 408), but the underlying job future is untouched and the job executes normally.

### Bug 2: `get_job_status` emits invalid status "completed" → 500

For an active job whose future was already done, `get_job_status` returned `{"status": "completed"}`. `completed` is not a member of the API's `QueueStatus` literal (`queued/pending/running/succeeded/failed/timeout/oom/cancelled`), so `JobStatusResponse(**status)` raised a `ValidationError` and `GET /jobs/{id}` returned 500 in exactly the window between future completion and job-map cleanup.

**Fix:** derive the real status from the finished future — the `ExecutionRecord`'s terminal status when it resolved normally, `failed` if it holds an exception, `cancelled` if it was cancelled — and include `duration_ms` when available, matching the storage-backed branch.

## Tests

New regression tests in `tests/test_queue.py` (all verified to fail against the previous implementation where applicable):

- `test_wait_for_result_timeout_does_not_cancel_future` — timeout raises but leaves the future resolvable
- `test_wait_for_result_timeout_does_not_break_concurrent_waiters` — one impatient waiter no longer poisons others
- `test_job_still_executes_after_wait_timeout` — end-to-end through the worker loop with a fake executor: the job still runs and yields its real record
- `test_get_job_status_done_future_reports_record_status` / `test_get_job_status_cancelled_future_reports_cancelled` — never emits `completed`

Verified locally: `ruff check` and `ruff format --check` clean; `pytest tests/test_queue.py` — 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)