### PR TITLE
fix(cli): wire --workers, fix --reload and explicit host/port handling

### DIFF
--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -56,11 +56,21 @@ def main():
 
     # Server command
     server_parser = subparsers.add_parser("server", help="Start the Tako VM server")
-    server_parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
-    server_parser.add_argument("--port", type=int, default=8000, help="Port to bind to")
-    server_parser.add_argument("--reload", action="store_true", help="Enable auto-reload")
     server_parser.add_argument(
-        "--workers", type=int, help="Number of worker processes (overrides config)"
+        "--host", default=None, help="Host to bind to (default: from config, 0.0.0.0)"
+    )
+    server_parser.add_argument(
+        "--port", type=int, default=None, help="Port to bind to (default: from config, 8000)"
+    )
+    server_parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable auto-reload (cannot be combined with --workers > 1)",
+    )
+    server_parser.add_argument(
+        "--workers",
+        type=int,
+        help="Number of worker processes (default: 1; cannot be combined with --reload)",
     )
     server_parser.set_defaults(auto_start_postgres=True)
     server_parser.add_argument(
@@ -79,8 +89,12 @@ def main():
         action="store_true",
         help="Start API server after PostgreSQL is ready",
     )
-    dev_up_parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
-    dev_up_parser.add_argument("--port", type=int, default=8000, help="Port to bind to")
+    dev_up_parser.add_argument(
+        "--host", default=None, help="Host to bind to (default: from config, 0.0.0.0)"
+    )
+    dev_up_parser.add_argument(
+        "--port", type=int, default=None, help="Port to bind to (default: from config, 8000)"
+    )
     dev_up_parser.add_argument("--reload", action="store_true", help="Enable auto-reload")
     dev_up_parser.set_defaults(auto_start_postgres=True)
     dev_subparsers.add_parser("status", help="Show local PostgreSQL status")
@@ -269,14 +283,39 @@ def run_server(args):
         sys.exit(1)
 
     # Use CLI args if provided, otherwise fall back to config values
-    host = args.host if args.host != "0.0.0.0" else config.server_host
-    port = args.port if args.port != 8000 else config.server_port
+    host = args.host if args.host is not None else config.server_host
+    port = args.port if args.port is not None else config.server_port
+
+    workers = getattr(args, "workers", None)
+    if workers is None:
+        workers = 1
+    if workers < 1:
+        print("Error: --workers must be >= 1", file=sys.stderr)
+        sys.exit(1)
+    if args.reload and workers > 1:
+        print(
+            "Error: --reload cannot be combined with --workers > 1 "
+            "(uvicorn's reloader manages a single worker process)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # uvicorn requires the app as an import string for --reload or multiple
+    # workers (it silently disables them when given an app object). Those modes
+    # spawn subprocesses that re-import the app, so carry an explicit --config
+    # through the environment for get_config() in the child processes.
+    use_import_string = args.reload or workers > 1
+    if use_import_string:
+        explicit_config = getattr(args, "config", None)
+        if explicit_config:
+            os.environ["TAKO_VM_CONFIG"] = str(explicit_config)
 
     uvicorn.run(
-        app,
+        "tako_vm.server.app:app" if use_import_string else app,
         host=host,
         port=port,
         reload=args.reload,
+        workers=workers,
     )
 
 
@@ -329,7 +368,7 @@ def _ensure_managed_postgres() -> None:
                 "-e",
                 "POSTGRES_DB=tako_vm",
                 "-p",
-                "55432:5432",
+                "127.0.0.1:55432:5432",
                 "-v",
                 f"{MANAGED_POSTGRES_VOLUME}:/var/lib/postgresql/data",
                 "postgres:16-alpine",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -576,6 +576,7 @@ class TestRunServerFunction:
             args.port = 9000
             args.reload = True
             args.workers = None
+            args.config = None
 
             run_server(args)
 
@@ -585,6 +586,257 @@ class TestRunServerFunction:
         assert call_kwargs["reload"] is True
 
         reset_config()
+
+    def test_run_server_explicit_default_host_port_not_overridden_by_config(self):
+        """Explicit --host 0.0.0.0/--port 8000 are honored even when config differs."""
+        import uvicorn
+
+        from tako_vm import config as config_module
+        from tako_vm.cli import run_server
+        from tako_vm.config import TakoVMConfig, reset_config
+
+        reset_config()
+
+        mock_config = TakoVMConfig(
+            server_host="127.0.0.1",
+            server_port=9999,
+            security_mode="permissive",
+        )
+
+        args = argparse.Namespace(
+            host="0.0.0.0",
+            port=8000,
+            reload=False,
+            workers=None,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(config_module, "get_config", return_value=mock_config):
+            with patch.object(uvicorn, "run", mock_run):
+                run_server(args)
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["host"] == "0.0.0.0"
+        assert call_kwargs["port"] == 8000
+
+        reset_config()
+
+    def test_run_server_host_port_fall_back_to_config(self):
+        """Without --host/--port, config.server_host/server_port are used."""
+        import uvicorn
+
+        from tako_vm import config as config_module
+        from tako_vm.cli import run_server
+        from tako_vm.config import TakoVMConfig, reset_config
+
+        reset_config()
+
+        mock_config = TakoVMConfig(
+            server_host="127.0.0.1",
+            server_port=9999,
+            security_mode="permissive",
+        )
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=False,
+            workers=None,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(config_module, "get_config", return_value=mock_config):
+            with patch.object(uvicorn, "run", mock_run):
+                run_server(args)
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["host"] == "127.0.0.1"
+        assert call_kwargs["port"] == 9999
+
+        reset_config()
+
+    def test_run_server_workers_passed_through(self):
+        """--workers is forwarded to uvicorn with the app as an import string."""
+        import uvicorn
+
+        from tako_vm.cli import run_server
+        from tako_vm.config import reset_config
+
+        reset_config()
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=False,
+            workers=4,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(uvicorn, "run", mock_run):
+            run_server(args)
+
+        app_arg = mock_run.call_args[0][0]
+        call_kwargs = mock_run.call_args[1]
+        assert app_arg == "tako_vm.server.app:app"
+        assert call_kwargs["workers"] == 4
+
+        reset_config()
+
+    def test_run_server_default_single_worker_uses_app_object(self):
+        """Without --workers/--reload, the app object is passed with workers=1."""
+        import uvicorn
+
+        from tako_vm.cli import run_server
+        from tako_vm.config import reset_config
+        from tako_vm.server.app import app
+
+        reset_config()
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=False,
+            workers=None,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(uvicorn, "run", mock_run):
+            run_server(args)
+
+        app_arg = mock_run.call_args[0][0]
+        call_kwargs = mock_run.call_args[1]
+        assert app_arg is app
+        assert call_kwargs["workers"] == 1
+
+        reset_config()
+
+    def test_run_server_reload_uses_import_string(self):
+        """--reload passes the app as an import string so uvicorn can reload it."""
+        import uvicorn
+
+        from tako_vm.cli import run_server
+        from tako_vm.config import reset_config
+
+        reset_config()
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=True,
+            workers=None,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(uvicorn, "run", mock_run):
+            run_server(args)
+
+        app_arg = mock_run.call_args[0][0]
+        call_kwargs = mock_run.call_args[1]
+        assert app_arg == "tako_vm.server.app:app"
+        assert call_kwargs["reload"] is True
+
+        reset_config()
+
+    def test_run_server_reload_and_workers_mutually_exclusive(self, capsys):
+        """--reload with --workers > 1 errors out instead of starting."""
+        import uvicorn
+
+        from tako_vm.cli import run_server
+        from tako_vm.config import reset_config
+
+        reset_config()
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=True,
+            workers=2,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(uvicorn, "run", mock_run):
+            with pytest.raises(SystemExit) as exc_info:
+                run_server(args)
+
+        assert exc_info.value.code == 1
+        mock_run.assert_not_called()
+        captured = capsys.readouterr()
+        assert "--reload cannot be combined with --workers" in captured.err
+
+        reset_config()
+
+    def test_run_server_invalid_workers_rejected(self, capsys):
+        """--workers < 1 errors out instead of starting."""
+        import uvicorn
+
+        from tako_vm.cli import run_server
+        from tako_vm.config import reset_config
+
+        reset_config()
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=False,
+            workers=0,
+            config=None,
+            auto_start_postgres=False,
+        )
+
+        mock_run = MagicMock()
+        with patch.object(uvicorn, "run", mock_run):
+            with pytest.raises(SystemExit) as exc_info:
+                run_server(args)
+
+        assert exc_info.value.code == 1
+        mock_run.assert_not_called()
+        captured = capsys.readouterr()
+        assert "--workers must be >= 1" in captured.err
+
+        reset_config()
+
+    def test_run_server_workers_exports_explicit_config_path(self, tmp_path, monkeypatch):
+        """Multi-worker mode exports --config via TAKO_VM_CONFIG for subprocesses."""
+        import uvicorn
+
+        from tako_vm.cli import run_server
+        from tako_vm.config import reset_config
+
+        reset_config()
+        monkeypatch.delenv("TAKO_VM_CONFIG", raising=False)
+
+        config_file = tmp_path / "tako_vm.yaml"
+        config_file.write_text("max_workers: 4\nsecurity_mode: permissive\n")
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            reload=False,
+            workers=2,
+            config=config_file,
+            auto_start_postgres=False,
+        )
+
+        with patch.object(uvicorn, "run", MagicMock()):
+            run_server(args)
+
+        try:
+            assert os.environ.get("TAKO_VM_CONFIG") == str(config_file)
+        finally:
+            os.environ.pop("TAKO_VM_CONFIG", None)
+            reset_config()
 
     def test_run_server_configuration_error(self):
         """run_server exits on configuration error."""


### PR DESCRIPTION
## Summary

Fixes four verified CLI bugs (F22) in `tako_vm/cli.py`:

1. **`--workers` was a no-op** — parsed but never read by `run_server`; `uvicorn.run` was called without `workers=`. It is now forwarded (default 1; config has no server-workers field). Because uvicorn ignores `workers` when given an app object, the app is passed as the import string `tako_vm.server.app:app` when `workers > 1`.
2. **`--reload` was silently disabled** — the app *object* was passed to `uvicorn.run`, so uvicorn warned "You must pass the application as an import string" and dropped reload. Reload now uses the import string. Since the reloader/worker subprocesses re-import the app and config is resolved lazily in lifespan via `get_config()`, an explicit `--config` path is exported through `TAKO_VM_CONFIG` so children load the same configuration. The default single-worker path still passes the app object, preserving existing behavior.
3. **Explicit `--host 0.0.0.0` / `--port 8000` silently overridden** — the old code compared against the argparse defaults by value, so an explicit default value was indistinguishable from "not provided" and got replaced by `config.server_host`/`server_port`. `--host`/`--port` now default to `None` (help text shows the effective defaults) and only fall back to config when omitted; applied to both `server` and `dev up`.
4. **Dev postgres exposed on all interfaces** — the managed dev container published `-p 55432:5432` with `postgres:postgres` credentials. Now bound to `127.0.0.1:55432:5432`.

Also: `--reload` with `--workers > 1` (mutually exclusive in uvicorn) and `--workers < 1` now fail fast with a clear error instead of being silently ignored.

## Tests

Added to `tests/test_cli.py`:
- explicit `--host 0.0.0.0`/`--port 8000` not overridden by config
- host/port fall back to config when omitted
- `--workers` forwarded with import-string app; default path keeps app object with `workers=1`
- `--reload` uses import string
- `--reload` + `--workers 2` and `--workers 0` error out
- `TAKO_VM_CONFIG` exported for multi-worker mode with explicit `--config`

`uv run --extra all --extra dev pytest tests/test_cli.py` — **51 passed**. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)