### PR TITLE
fix(durability): reconcile stale job records on startup and persist shutdown/running transitions

### DIFF
--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -198,6 +198,7 @@ ErrorType = Literal[
     "service_unavailable",  # Circuit breaker open
     "config_error",  # Configuration error
     "internal_error",  # Internal Tako VM error
+    "interrupted",  # Job interrupted by server restart/shutdown
     "runtime_error",  # Generic runtime error
     "unknown",  # Unknown error type
 ]

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -223,6 +223,16 @@ async def lifespan(app: FastAPI):
     state.executor = CodeExecutor(registry=state.registry, config=state.config)
     state.storage = ExecutionStorage(state.config.database_url)
     await state.storage.init()
+
+    # Reconcile records orphaned by a previous crash/restart before workers
+    # start. The job queue is in-memory, so any record still 'queued' or
+    # 'running' at this point can never complete; mark it failed so clients
+    # stop polling into the void. Safe because Tako VM runs as a single
+    # server (no multi-server coordination exists).
+    stale_records = await state.storage.reconcile_stale_records()
+    if stale_records > 0:
+        logger.warning(f"Startup: marked {stale_records} interrupted execution record(s) as failed")
+
     state.worker_pool = WorkerPool(
         executor=state.executor,
         storage=state.storage,

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -123,14 +123,28 @@ class WorkerPool:
 
         self._shutdown = True
 
-        # Cancel all pending jobs
+        # Cancel all pending jobs, persisting a terminal record first so their
+        # DB rows don't stay stuck at 'queued' after a graceful restart/deploy.
         while not self._queue.empty():
             try:
                 job = self._queue.get_nowait()
-                if job.future and not job.future.done():
-                    job.future.cancel()
             except asyncio.QueueEmpty:
                 break
+
+            # Best-effort: a storage failure during shutdown must not
+            # prevent shutdown (startup reconciliation covers the gap).
+            try:
+                record = self._build_cancelled_record(
+                    job, message="Job cancelled: server shut down before execution started"
+                )
+                await self.storage.save_record(record)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to persist shutdown record for pending job {job.job_id}: {e}"
+                )
+
+            if job.future and not job.future.done():
+                job.future.cancel()
 
         # Wait for workers with timeout
         if self._workers:
@@ -367,7 +381,9 @@ class WorkerPool:
 
         return True
 
-    def _build_cancelled_record(self, job: QueuedJob) -> ExecutionRecord:
+    def _build_cancelled_record(
+        self, job: QueuedJob, message: str = "Execution was cancelled by user"
+    ) -> ExecutionRecord:
         """Create a final cancelled record for a job."""
         job_type_name = job.job_data.get("job_type") or "default"
         return ExecutionRecord(
@@ -380,7 +396,7 @@ class WorkerPool:
             code_hash=sha256_content(job.job_data.get("code", "")),
             input_hash=sha256_json(job.job_data.get("input_data", {})),
             client_ip=job.client_ip,
-            error=ExecutionError(type="cancelled", message="Execution was cancelled by user"),
+            error=ExecutionError(type="cancelled", message=message),
             idempotency_key=job.job_data.get("idempotency_key"),
             idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
             parent_execution_id=job.job_data.get("parent_execution_id"),
@@ -467,6 +483,18 @@ class WorkerPool:
                 # Move to running
                 async with self._jobs_lock:
                     self._running_jobs[job.job_id] = job
+
+                # Persist the queued -> running transition before executing so
+                # the DB reflects in-flight work: if the server crashes mid-run,
+                # forensics see 'running' (not a misleading 'queued') and startup
+                # reconciliation marks it failed. Best-effort: execution proceeds
+                # even if this write fails.
+                try:
+                    await self.storage.mark_record_running(
+                        job.job_id, worker_id=f"worker-{worker_id}"
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to persist running state for job {job.job_id}: {e}")
 
                 # Set correlation ID from job data for logging
                 correlation_id = job.job_data.get("correlation_id")

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -390,6 +390,70 @@ class ExecutionStorage:
 
         return [self._row_to_record(cast(RowMapping, row)) for row in rows]
 
+    async def reconcile_stale_records(self) -> int:
+        """
+        Mark stale 'queued'/'running' records as failed after a restart.
+
+        The job queue is in-memory (asyncio.Queue), so it does not survive a
+        process restart: any record still marked 'queued' or 'running' when the
+        server starts belongs to a job that was lost in a crash or shutdown and
+        will never complete. Without this reconciliation, clients poll those
+        records forever.
+
+        NOTE: This assumes a single-server deployment (the only supported
+        topology). There is no multi-server coordination anywhere in Tako VM,
+        so no other live server process can legitimately own in-flight records
+        when this runs at startup.
+
+        Returns:
+            Number of records transitioned to 'failed'.
+        """
+        now = datetime.now(timezone.utc)
+        error_json = ExecutionError(
+            type="interrupted",
+            message="job interrupted by server restart before completion",
+        ).model_dump()
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                UPDATE execution_records
+                SET status = 'failed',
+                    ended_at = %s,
+                    error_json = %s
+                WHERE status IN ('queued', 'running')
+                """,
+                (now, Jsonb(error_json)),
+            )
+            return cursor.rowcount
+
+    async def mark_record_running(self, execution_id: str, worker_id: Optional[str] = None) -> bool:
+        """
+        Persist the queued -> running transition for an execution record.
+
+        Targeted UPDATE so the in-flight state is visible in the database
+        during execution (and reconcilable after a crash) without rewriting
+        the whole row.
+
+        Returns:
+            True if a queued record was transitioned to running.
+        """
+        now = datetime.now(timezone.utc)
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                UPDATE execution_records
+                SET status = 'running',
+                    dequeued_at = %s,
+                    worker_id = %s
+                WHERE execution_id = %s AND status = 'queued'
+                """,
+                (now, worker_id, execution_id),
+            )
+            return cursor.rowcount > 0
+
     async def cleanup_old_records(self, ttl_days: int) -> int:
         """Delete records older than TTL."""
         cutoff = datetime.now(timezone.utc) - timedelta(days=ttl_days)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -214,3 +214,150 @@ async def test_get_job_status_cancelled_future_reports_cancelled():
 
     assert status is not None
     assert status["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_stop_persists_terminal_records_for_drained_jobs():
+    """Graceful shutdown must persist a terminal record for each pending job."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    pool = WorkerPool(executor=MagicMock(), storage=storage)
+    pool._started = True  # simulate a started pool without real worker tasks
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-shutdown",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    pool._queue.put_nowait(job)
+    pool._active_jobs[job.job_id] = job
+
+    await pool.stop(timeout=0.1)
+
+    storage.save_record.assert_awaited_once()
+    record = storage.save_record.await_args.args[0]
+    assert record.execution_id == "job-shutdown"
+    assert record.status == "cancelled"
+    assert record.error is not None
+    assert record.error.type == "cancelled"
+    assert "server shut down" in record.error.message
+    # Record is persisted before the future is resolved/cancelled
+    assert job.future.cancelled() is True
+
+
+@pytest.mark.asyncio
+async def test_stop_storage_failure_does_not_prevent_shutdown():
+    """Persistence errors during shutdown are best-effort: shutdown completes."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock(side_effect=RuntimeError("db unavailable"))
+    pool = WorkerPool(executor=MagicMock(), storage=storage)
+    pool._started = True
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-db-down",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    pool._queue.put_nowait(job)
+
+    await pool.stop(timeout=0.1)
+
+    assert pool._started is False
+    assert pool._queue.empty()
+    assert job.future.cancelled() is True
+
+
+@pytest.mark.asyncio
+async def test_worker_loop_persists_running_transition_before_execute():
+    """The worker must persist queued -> running before executing the job."""
+    call_order = []
+
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+
+    async def record_running(*args, **kwargs):
+        call_order.append("mark_running")
+        return True
+
+    storage.mark_record_running = AsyncMock(side_effect=record_running)
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage, queue_wait_timeout=0.05)
+
+    async def fake_execute(job):
+        call_order.append("execute")
+        return ExecutionRecord(
+            execution_id=job.job_id,
+            status="succeeded",
+            created_at=datetime.now(timezone.utc),
+            queued_at=datetime.now(timezone.utc),
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+        )
+
+    pool._execute_job = fake_execute
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-running",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    pool._active_jobs[job.job_id] = job
+    pool._queue.put_nowait(job)
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        record = await asyncio.wait_for(job.future, timeout=2.0)
+    finally:
+        pool._shutdown = True
+        await asyncio.wait_for(worker, timeout=2.0)
+
+    assert record.status == "succeeded"
+    assert call_order == ["mark_running", "execute"]
+    storage.mark_record_running.assert_awaited_once_with("job-running", worker_id="worker-0")
+
+
+@pytest.mark.asyncio
+async def test_worker_loop_executes_even_if_running_persist_fails():
+    """A failure persisting the running state must not block execution."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    storage.mark_record_running = AsyncMock(side_effect=RuntimeError("db unavailable"))
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage, queue_wait_timeout=0.05)
+
+    async def fake_execute(job):
+        return ExecutionRecord(
+            execution_id=job.job_id,
+            status="succeeded",
+            created_at=datetime.now(timezone.utc),
+            queued_at=datetime.now(timezone.utc),
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+        )
+
+    pool._execute_job = fake_execute
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-persist-fail",
+        job_data={"code": "print('hi')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    pool._active_jobs[job.job_id] = job
+    pool._queue.put_nowait(job)
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        record = await asyncio.wait_for(job.future, timeout=2.0)
+    finally:
+        pool._shutdown = True
+        await asyncio.wait_for(worker, timeout=2.0)
+
+    assert record.status == "succeeded"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -533,3 +533,103 @@ class TestDeadLetterQueue:
         remaining = storage.list_dlq_entries()
         assert len(remaining) == 1
         assert remaining[0].job_id == "recent-job"
+
+
+class TestReconcileStaleRecords:
+    """Tests for startup reconciliation of stale queued/running records."""
+
+    @staticmethod
+    def _make_record(execution_id: str, status: str, **kwargs) -> ExecutionRecord:
+        return ExecutionRecord(
+            execution_id=execution_id,
+            status=status,
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            **kwargs,
+        )
+
+    def test_reconcile_marks_queued_and_running_as_failed(self, storage):
+        """Stale queued/running records become failed with an interrupted error."""
+        storage.save_record(self._make_record("stale-queued", "queued"))
+        storage.save_record(self._make_record("stale-running", "running"))
+
+        count = storage.reconcile_stale_records()
+        assert count == 2
+
+        for execution_id in ("stale-queued", "stale-running"):
+            record = storage.get_record(execution_id)
+            assert record is not None
+            assert record.status == "failed"
+            assert record.ended_at is not None
+            assert record.error is not None
+            assert record.error.type == "interrupted"
+            assert "interrupted by server restart" in record.error.message
+
+    def test_reconcile_leaves_terminal_records_untouched(self, storage):
+        """Records already in a terminal state are not modified."""
+        storage.save_record(self._make_record("done-ok", "succeeded", exit_code=0, stdout="ok"))
+        storage.save_record(
+            self._make_record(
+                "done-cancelled",
+                "cancelled",
+                error=ExecutionError(type="cancelled", message="cancelled by user"),
+            )
+        )
+        storage.save_record(self._make_record("stale-queued-2", "queued"))
+
+        count = storage.reconcile_stale_records()
+        assert count == 1
+
+        succeeded = storage.get_record("done-ok")
+        assert succeeded.status == "succeeded"
+        assert succeeded.error is None
+
+        cancelled = storage.get_record("done-cancelled")
+        assert cancelled.status == "cancelled"
+        assert cancelled.error.type == "cancelled"
+
+    def test_reconcile_with_no_stale_records(self, storage):
+        """Reconcile returns 0 when nothing is stale."""
+        storage.save_record(self._make_record("done", "succeeded", exit_code=0))
+        assert storage.reconcile_stale_records() == 0
+
+
+class TestMarkRecordRunning:
+    """Tests for persisting the queued -> running transition."""
+
+    def test_mark_running_updates_queued_record(self, storage):
+        """A queued record transitions to running with dequeued_at/worker_id set."""
+        record = ExecutionRecord(
+            execution_id="run-me",
+            status="queued",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+        )
+        storage.save_record(record)
+
+        updated = storage.mark_record_running("run-me", worker_id="worker-3")
+        assert updated is True
+
+        retrieved = storage.get_record("run-me")
+        assert retrieved.status == "running"
+        assert retrieved.dequeued_at is not None
+        assert retrieved.worker_id == "worker-3"
+
+    def test_mark_running_skips_non_queued_records(self, storage):
+        """Terminal records are never moved back to running."""
+        record = ExecutionRecord(
+            execution_id="already-done",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            exit_code=0,
+        )
+        storage.save_record(record)
+
+        updated = storage.mark_record_running("already-done", worker_id="worker-1")
+        assert updated is False
+        assert storage.get_record("already-done").status == "succeeded"
+
+    def test_mark_running_missing_record(self, storage):
+        """Marking a nonexistent record returns False."""
+        assert storage.mark_record_running("nope") is False


### PR DESCRIPTION
## Problem

The async job queue is in-memory (`asyncio.Queue` in `tako_vm/server/queue.py`), while execution records live in PostgreSQL. Three durability gaps left DB rows stuck at `queued` forever, with clients polling jobs that could never complete:

1. **No startup reconciliation.** After a crash/restart, records stuck at `queued`/`running` were never resolved — `startup_cleanup()` only handles orphaned containers.
2. **Graceful shutdown lost pending jobs.** `WorkerPool.stop()` drained the queue with `get_nowait()` and cancelled futures, but wrote no terminal state to storage. Every deploy/restart stranded pending jobs in the DB.
3. **The running transition was never persisted.** A job's DB row stayed `status='queued'` for its entire execution (only rewritten at completion), so forensics on a crashed run showed nothing.

## Changes

- **`ExecutionStorage.reconcile_stale_records()`** — single `UPDATE` that marks all `queued`/`running` rows as `failed` with an `ExecutionError` of type `interrupted` ("job interrupted by server restart before completion") and sets `ended_at`. Called from the lifespan startup, after `storage.init()` and before workers start, logging the count. This assumes a single-server deployment — the only supported topology; there is no multi-server coordination anywhere in Tako VM, so no other live process can own in-flight records at startup.
- **`WorkerPool.stop()`** — persists a `cancelled` record ("Job cancelled: server shut down before execution started") for each drained pending job before cancelling its future. Best-effort: storage failures are logged and never block shutdown (startup reconciliation covers the gap).
- **Running transition** — the worker loop now calls a targeted `ExecutionStorage.mark_record_running()` (`status='running'`, `dequeued_at`, `worker_id`, guarded by `WHERE status = 'queued'`) before executing, so in-flight work is visible in the DB. Best-effort; execution proceeds even if the write fails. (Deliberately does not touch `execute_job_with_record`'s own record construction — its timestamp clobbering is a separate fix.)
- **`models.py`** — adds `interrupted` to the `ErrorType` literal so the reconciled error payload round-trips through `_row_to_record` validation.

## Tests

- `tests/test_storage.py`: `reconcile_stale_records` fails queued+running rows with the `interrupted` error and leaves terminal rows untouched; `mark_record_running` sets `dequeued_at`/`worker_id`, refuses non-queued rows. (Postgres-backed; run in CI.)
- `tests/test_queue.py` (appended at end to minimize conflicts with #64): `stop()` persists terminal records for drained jobs and survives storage failure; the worker loop persists the running transition before execute and proceeds if persistence fails. All 6 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)