### PR TITLE
fix(config): redact secrets from validation errors and surface insecure-default warnings

### DIFF
--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -5,6 +5,7 @@ Uses Pydantic for validation with strict bounds checking.
 Loads configuration from YAML file with optional env var overrides.
 """
 
+import logging
 import os
 from importlib.resources import files as _resource_files
 from pathlib import Path
@@ -12,7 +13,9 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
 
 # Default config file locations (searched in order)
 CONFIG_SEARCH_PATHS = [
@@ -25,6 +28,22 @@ CONFIG_SEARCH_PATHS = [
 _SAFE_PROXY_URL_CHARS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/=,+-[]{}@%"
 )
+
+_LOOPBACK_HOSTS = frozenset({"localhost", "::1", "[::1]"})
+
+
+def _sanitize_validation_error(e: ValidationError) -> str:
+    """
+    Format a pydantic ValidationError WITHOUT echoing input values.
+
+    Default str(ValidationError) embeds ``input_value=...``, which can leak
+    secrets (database passwords, API keys) into CLI output and logs.
+    """
+    lines: List[str] = []
+    for err in e.errors(include_input=False, include_url=False):
+        loc = ".".join(str(part) for part in err.get("loc", ())) or "config"
+        lines.append(f"field {loc}: {err.get('msg', 'invalid value')}")
+    return "; ".join(lines) or "validation failed"
 
 
 def get_default_data_dir() -> Path:
@@ -232,14 +251,26 @@ class TakoVMConfig(BaseModel):
     )
 
     # Server
-    server_host: str = Field(default="0.0.0.0", description="Server host to bind to")
+    server_host: str = Field(
+        default="0.0.0.0",
+        description=(
+            "Server host to bind to. The default (0.0.0.0, all interfaces) is "
+            "development-friendly; production should bind to a loopback or internal interface"
+        ),
+    )
     server_port: int = Field(default=8000, ge=1, le=65535, description="Server port to bind to")
 
     # API-layer request protection
     api_max_payload_bytes: int = Field(
         default=2097152, ge=1024, le=104857600, description="Maximum HTTP request payload size"
     )
-    api_auth_enabled: bool = Field(default=False, description="Require API key authentication")
+    api_auth_enabled: bool = Field(
+        default=False,
+        description=(
+            "Require API key authentication. The default (false) is development-friendly; "
+            "production deployments should enable this"
+        ),
+    )
     api_keys: List[str] = Field(
         default_factory=list,
         description="Accepted API keys when api_auth_enabled is true",
@@ -411,7 +442,11 @@ class TakoVMConfig(BaseModel):
     # Security mode
     security_mode: str = Field(
         default="permissive",
-        description="Security mode: 'strict' fails if gVisor unavailable, 'permissive' allows fallback to runc",
+        description=(
+            "Security mode: 'strict' fails if gVisor unavailable, 'permissive' allows fallback "
+            "to runc. The default (permissive) is development-friendly; production should use "
+            "'strict'"
+        ),
     )
 
     @field_validator("container_runtime")
@@ -516,6 +551,35 @@ class TakoVMConfig(BaseModel):
     @property
     def seccomp_profile_path_resolved(self) -> Path:
         return self.seccomp_profile_path
+
+    def security_warnings(self) -> List[str]:
+        """
+        Return human-readable warnings for insecure (development-default) settings.
+
+        The defaults make Tako VM easy to try locally, but combined they expose an
+        unauthenticated, network-reachable code-execution service that may silently
+        fall back from gVisor to runc. Surface that loudly.
+        """
+        warnings: List[str] = []
+
+        host = self.server_host.strip().lower()
+        is_loopback = host in _LOOPBACK_HOSTS or host.startswith("127.")
+        if not self.api_auth_enabled and not is_loopback:
+            warnings.append(
+                f"API authentication is disabled (api_auth_enabled=false) while the server "
+                f"binds to non-loopback host '{self.server_host}': anyone who can reach the "
+                "port can execute code. Enable api_auth_enabled and set api_keys, or bind "
+                "server_host to 127.0.0.1."
+            )
+
+        if self.security_mode == "permissive":
+            warnings.append(
+                "security_mode is 'permissive': execution may silently fall back from gVisor "
+                "(runsc) to runc if gVisor is unavailable, weakening sandbox isolation. Use "
+                "security_mode='strict' in production."
+            )
+
+        return warnings
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get config value by key (for backward compatibility)."""
@@ -663,9 +727,17 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
     try:
         config = TakoVMConfig(**config_dict)
         config.resolve_paths()
-        return config
+    except ValidationError as e:
+        # Use sanitized formatting: str(ValidationError) embeds input values,
+        # which can leak secrets (e.g. database_url passwords) into logs/CLI output.
+        raise ConfigurationError(f"Invalid configuration: {_sanitize_validation_error(e)}") from e
     except Exception as e:
         raise ConfigurationError(f"Invalid configuration: {e}") from e
+
+    for warning in config.security_warnings():
+        logger.warning(warning)
+
+    return config
 
 
 # Global config instance (lazy loaded)
@@ -725,6 +797,9 @@ def validate_config_file(path: Path) -> List[str]:
         errors.append(f"Config file not found: {path}")
     except yaml.YAMLError as e:
         errors.append(f"Invalid YAML: {e}")
+    except ValidationError as e:
+        # Sanitized: str(ValidationError) embeds input values (potential secrets).
+        errors.append(_sanitize_validation_error(e))
     except Exception as e:
         errors.append(str(e))
     return errors

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ Tests for Tako VM configuration module.
 Tests config loading, validation, and environment variable overrides.
 """
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -371,6 +372,55 @@ class TestTakoVMConfig:
             TakoVMConfig.model_validate({"unknown_field": "value"})
 
 
+class TestSecurityWarnings:
+    """Tests for TakoVMConfig.security_warnings()."""
+
+    def test_security_warnings_default_config(self):
+        """Default config warns about disabled auth and permissive mode."""
+        warnings = TakoVMConfig().security_warnings()
+
+        assert len(warnings) == 2
+        assert any("api_auth_enabled" in w for w in warnings)
+        assert any("permissive" in w for w in warnings)
+
+    def test_security_warnings_empty_for_locked_down_config(self):
+        """Auth enabled + strict mode produces no warnings."""
+        config = TakoVMConfig(
+            api_auth_enabled=True,
+            api_keys=["aaaaaaaaaaaaaaaa"],
+            security_mode="strict",
+        )
+        assert config.security_warnings() == []
+
+    def test_security_warnings_empty_for_loopback_strict_config(self):
+        """Loopback host suppresses the auth warning even without auth."""
+        config = TakoVMConfig(server_host="127.0.0.1", security_mode="strict")
+        assert config.security_warnings() == []
+
+        config = TakoVMConfig(server_host="localhost", security_mode="strict")
+        assert config.security_warnings() == []
+
+    def test_security_warnings_permissive_only(self):
+        """Auth-enabled config in permissive mode warns about gVisor fallback only."""
+        config = TakoVMConfig(
+            api_auth_enabled=True,
+            api_keys=["aaaaaaaaaaaaaaaa"],
+            security_mode="permissive",
+        )
+        warnings = config.security_warnings()
+
+        assert len(warnings) == 1
+        assert "permissive" in warnings[0]
+
+    def test_load_config_logs_security_warnings(self, caplog):
+        """load_config emits security warnings via logging."""
+        with caplog.at_level(logging.WARNING, logger="tako_vm.config"):
+            load_config()
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("permissive" in message for message in messages)
+
+
 class TestConfigLoading:
     """Tests for config file loading."""
 
@@ -475,6 +525,59 @@ max_workers: -1  # Invalid: must be >= 1
                 load_config(config_path)
         finally:
             config_path.unlink()
+
+    def test_load_config_redacts_database_password_from_errors(self):
+        """ConfigurationError must not echo secrets embedded in invalid values."""
+        password = "sup3r-s3cret-hunter2"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(f'database_url: "mysql://tako:{password}@db.internal:3306/tako"\n')
+            f.flush()
+            config_path = Path(f.name)
+
+        try:
+            with pytest.raises(ConfigurationError) as exc_info:
+                load_config(config_path)
+        finally:
+            config_path.unlink()
+
+        message = str(exc_info.value)
+        assert password not in message
+        assert "database_url" in message
+
+    def test_load_config_redacts_api_keys_from_errors(self):
+        """Too-short API keys are not echoed back in the error message."""
+        secret_key = "hunter2secret"  # < 16 chars, fails validation
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(f'api_keys: ["{secret_key}"]\n')
+            f.flush()
+            config_path = Path(f.name)
+
+        try:
+            with pytest.raises(ConfigurationError) as exc_info:
+                load_config(config_path)
+        finally:
+            config_path.unlink()
+
+        message = str(exc_info.value)
+        assert secret_key not in message
+        assert "api_keys" in message
+
+    def test_validate_config_file_redacts_secrets(self):
+        """validate_config_file errors must not echo secret input values."""
+        password = "sup3r-s3cret-hunter2"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(f'database_url: "mysql://tako:{password}@db.internal:3306/tako"\n')
+            f.flush()
+            config_path = Path(f.name)
+
+        try:
+            errors = validate_config_file(config_path)
+        finally:
+            config_path.unlink()
+
+        assert len(errors) > 0
+        assert all(password not in error for error in errors)
+        assert any("database_url" in error for error in errors)
 
     def test_validate_config_file_valid(self):
         """validate_config_file returns empty list for valid file."""


### PR DESCRIPTION
## Summary

Fixes two verified config-layer security issues (F20), touching only `tako_vm/config.py` and `tests/test_config.py`.

### 1. Secret leak via pydantic validation errors
`load_config` (and `validate_config_file`) stringified pydantic `ValidationError`s verbatim. Pydantic v2 error strings embed `input_value=...`, so a malformed `database_url` (containing the real password) or a too-short `api_keys` entry was echoed into CLI output and logs.

**Fix:** new `_sanitize_validation_error()` helper builds messages from `e.errors(include_input=False, include_url=False)`, producing `field <loc>: <msg>` lines with no input values. Both ValidationError stringification sites in `config.py` now use it.

### 2. Insecure-default visibility
Defaults are `server_host=0.0.0.0`, `api_auth_enabled=false`, `security_mode=permissive` — a default deployment is an unauthenticated, network-exposed code-exec service that may silently fall back from gVisor to runc.

**Fix (minimal, non-breaking):** `TakoVMConfig.security_warnings() -> list[str]` returns warnings for (a) auth disabled while bound to a non-loopback host, (b) permissive security mode. `load_config` emits each via `logger.warning` after a successful load, so every server/CLI entry point that loads config surfaces them without touching `app.py` (owned by another in-flight PR). Field descriptions for `server_host` / `api_auth_enabled` / `security_mode` now note the defaults are development-friendly.

## Tests
- Redaction: invalid `database_url` with a fake password and a too-short `api_keys` entry raise `ConfigurationError` whose message names the field but never contains the secret (also covered for `validate_config_file`).
- `security_warnings()`: two warnings for default config; empty for locked-down configs (auth+strict, or loopback+strict); permissive-only case.
- `load_config` logs warnings (caplog).

`uv run --extra all --extra dev pytest tests/test_config.py`: **55 passed**. ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)