### PR TITLE
fix(sandbox): enforce in-container timeouts, strict requirements validation, preserve partial output

### DIFF
--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -40,6 +40,22 @@ _SAFE_PROXY_URL_CHARS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/=,+-[]{}@%"
 )
 
+DEFAULT_STARTUP_TIMEOUT = 120
+"""Default startup (dependency install) timeout in seconds, matching server defaults."""
+
+
+def _decode_stream(value: Any) -> str:
+    """Decode partial subprocess output that may be None, bytes, or str.
+
+    subprocess.TimeoutExpired carries raw bytes even when subprocess.run
+    was invoked with text=True.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
 
 @dataclass
 class SandboxResult:
@@ -103,6 +119,9 @@ class SandboxConfig:
 
     timeout: int = 30
     """Default timeout in seconds."""
+
+    startup_timeout: int = DEFAULT_STARTUP_TIMEOUT
+    """Timeout in seconds for the startup phase (runtime dependency installation)."""
 
     memory_limit: str = "512m"
     """Memory limit for containers."""
@@ -171,6 +190,7 @@ class Sandbox:
         enable_runtime_dependency_cache: bool = False,
         package_dirs: Optional[List[str]] = None,
         auto_build: bool = True,
+        startup_timeout: int = DEFAULT_STARTUP_TIMEOUT,
     ):
         """
         Initialize the sandbox.
@@ -186,10 +206,12 @@ class Sandbox:
             enable_runtime_dependency_cache: Whether to use a shared uv cache volume
             package_dirs: Local directories to mount as Python packages
             auto_build: Whether to auto-build image if missing
+            startup_timeout: Timeout in seconds for runtime dependency installation
         """
         self.config = SandboxConfig(
             image=image,
             timeout=timeout,
+            startup_timeout=startup_timeout,
             memory_limit=memory_limit,
             cpu_limit=cpu_limit,
             network_enabled=network_enabled,
@@ -382,12 +404,20 @@ class Sandbox:
             except ValueError as e:
                 return SandboxResult(success=False, exit_code=-1, error=str(e))
 
-            # Execute
+            # Execute. The container enforces its own timeouts via
+            # TAKO_STARTUP_TIMEOUT / TAKO_EXECUTION_TIMEOUT; this subprocess
+            # timeout is a backstop with a grace period for container overhead.
+            # Dependency installation happens before code runs, so budget the
+            # startup phase separately when requirements are present.
+            subprocess_timeout = timeout + 5
+            if requirements:
+                subprocess_timeout += self.config.startup_timeout
+
             start_time = time.time()
             try:
                 proc = subprocess.run(
                     cmd,
-                    timeout=timeout + 5,  # Grace period for container overhead
+                    timeout=subprocess_timeout,
                     capture_output=True,
                     text=True,
                     check=False,
@@ -412,13 +442,13 @@ class Sandbox:
                     duration_ms=duration_ms,
                 )
 
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
                 # Kill the orphaned container (subprocess died but container keeps running)
                 kill_container(container_name)
                 duration_ms = int((time.time() - start_time) * 1000)
                 return SandboxResult(
-                    stdout="",
-                    stderr="",
+                    stdout=_decode_stream(exc.stdout),
+                    stderr=_decode_stream(exc.stderr),
                     exit_code=-1,
                     success=False,
                     error=f"Execution timed out after {timeout}s",
@@ -447,22 +477,23 @@ class Sandbox:
         """
         validated_reqs = []
         if requirements:
-            if len(requirements) > MAX_REQUIREMENTS:
-                raise ValueError(
-                    f"Too many requirements ({len(requirements)} > {MAX_REQUIREMENTS})"
-                )
-            for req in requirements:
-                if validate_pip_requirement(req):
-                    validated_reqs.append(req)
-                else:
-                    logger.warning("Skipping invalid pip requirement: %s", req)
-
-        if validated_reqs:
+            # Enforce the policy before validation so an all-invalid list
+            # cannot bypass the allow_runtime_requirements check.
             if not self.config.allow_runtime_requirements:
                 raise ValueError(
                     "Runtime dependency installation is disabled. "
                     "Use pre-built images or set allow_runtime_requirements=True."
                 )
+            if len(requirements) > MAX_REQUIREMENTS:
+                raise ValueError(
+                    f"Too many requirements ({len(requirements)} > {MAX_REQUIREMENTS})"
+                )
+            for req in requirements:
+                if not validate_pip_requirement(req):
+                    raise ValueError(f"Invalid pip requirement: {req!r}")
+                validated_reqs.append(req)
+
+        if validated_reqs:
             requirements_file = input_dir / "_requirements.txt"
             requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
             requirements_file.chmod(0o444)
@@ -535,6 +566,12 @@ class Sandbox:
 
         if has_requirements and self.config.dependency_proxy_url:
             cmd.append(f"--env=TAKO_DEPENDENCY_PROXY_URL={self.config.dependency_proxy_url}")
+
+        # In-container timeout enforcement (entrypoint.sh wraps each phase in
+        # timeout(1)). Without these the container would run forever if the
+        # parent process died before its subprocess timeout fired.
+        cmd.append(f"--env=TAKO_STARTUP_TIMEOUT={self.config.startup_timeout}")
+        cmd.append(f"--env=TAKO_EXECUTION_TIMEOUT={timeout}")
 
         # Image
         cmd.append(self.config.image)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -4,14 +4,26 @@ Tests for the Sandbox class (library mode).
 These tests verify the direct Docker sandbox execution without a server.
 """
 
+import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from tako_vm.constants import UV_CACHE_VOLUME
-from tako_vm.sandbox import Sandbox, SandboxResult
+from tako_vm.sandbox import DEFAULT_STARTUP_TIMEOUT, Sandbox, SandboxResult
 from tako_vm.sandbox import run as sandbox_run
+
+
+def _make_workspace_dirs(tmp_path):
+    """Create code/input/output dirs for _build_docker_command unit tests."""
+    code_dir = tmp_path / "code"
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    code_dir.mkdir()
+    input_dir.mkdir()
+    output_dir.mkdir()
+    return code_dir, input_dir, output_dir
 
 
 class TestSandboxResult:
@@ -328,6 +340,39 @@ print(f"version: {requests.__version__}")
 
         assert not any(arg.startswith("--env=TAKO_DEPENDENCY_PROXY_URL=") for arg in cmd)
 
+    def test_sandbox_rejects_invalid_requirement(self, tmp_path):
+        """Invalid pip requirements raise instead of being silently dropped."""
+        code_dir, input_dir, output_dir = _make_workspace_dirs(tmp_path)
+
+        sb = Sandbox(allow_runtime_requirements=True)
+        with pytest.raises(ValueError, match="Invalid pip requirement") as excinfo:
+            sb._build_docker_command(
+                code_dir=code_dir,
+                input_dir=input_dir,
+                output_dir=output_dir,
+                timeout=30,
+                requirements=["requests", "evil`touch /tmp/pwned`"],
+            )
+
+        # The error names the offending requirement
+        assert "evil`touch /tmp/pwned`" in str(excinfo.value)
+        # Nothing was written before the validation failure
+        assert not (input_dir / "_requirements.txt").exists()
+
+    def test_sandbox_policy_checked_before_validation(self, tmp_path):
+        """An all-invalid requirements list cannot bypass the policy check."""
+        code_dir, input_dir, output_dir = _make_workspace_dirs(tmp_path)
+
+        sb = Sandbox()  # allow_runtime_requirements=False
+        with pytest.raises(ValueError, match="Runtime dependency installation is disabled"):
+            sb._build_docker_command(
+                code_dir=code_dir,
+                input_dir=input_dir,
+                output_dir=output_dir,
+                timeout=30,
+                requirements=["evil`touch /tmp/pwned`"],
+            )
+
     @pytest.mark.parametrize(
         ("cache_enabled", "expect_cache_mount"),
         [(False, False), (True, True)],
@@ -357,6 +402,99 @@ print(f"version: {requests.__version__}")
         expected_cache_dir = "/root/.cache/uv" if cache_enabled else "/tmp/uv-cache"
         assert (cache_mount in cmd) is expect_cache_mount
         assert f"--env=UV_CACHE_DIR={expected_cache_dir}" in cmd
+
+
+class TestSandboxTimeoutEnforcement:
+    """Unit tests for in-container timeout enforcement (no container needed)."""
+
+    def test_docker_command_includes_timeout_env_vars(self, tmp_path):
+        """Both timeout env vars are passed so the container self-enforces limits."""
+        code_dir, input_dir, output_dir = _make_workspace_dirs(tmp_path)
+
+        sb = Sandbox(startup_timeout=90)
+        cmd, _ = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=7,
+        )
+
+        assert "--env=TAKO_STARTUP_TIMEOUT=90" in cmd
+        assert "--env=TAKO_EXECUTION_TIMEOUT=7" in cmd
+        # Env vars must come before the image name to be docker run options
+        assert cmd.index("--env=TAKO_EXECUTION_TIMEOUT=7") < cmd.index(sb.config.image)
+
+    def test_docker_command_default_startup_timeout(self, tmp_path):
+        """Default startup timeout matches the server default (120s)."""
+        code_dir, input_dir, output_dir = _make_workspace_dirs(tmp_path)
+
+        sb = Sandbox()
+        assert sb.config.startup_timeout == DEFAULT_STARTUP_TIMEOUT
+        cmd, _ = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+        )
+
+        assert f"--env=TAKO_STARTUP_TIMEOUT={DEFAULT_STARTUP_TIMEOUT}" in cmd
+        assert "--env=TAKO_EXECUTION_TIMEOUT=30" in cmd
+
+    def test_subprocess_budget_includes_startup_timeout_with_requirements(self, monkeypatch):
+        """Dependency install time is budgeted separately from code timeout."""
+        recorded = {}
+
+        def fake_run(cmd, **kwargs):
+            recorded["timeout"] = kwargs.get("timeout")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        sb = Sandbox(allow_runtime_requirements=True, startup_timeout=100)
+        sb._image_checked = True  # Skip docker image inspect
+        monkeypatch.setattr(
+            Sandbox,
+            "_build_docker_command",
+            lambda self, **kwargs: (["docker", "run", "fake"], "fake-container"),
+        )
+        monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
+
+        sb.run("print('hi')", timeout=10, requirements=["requests"])
+        assert recorded["timeout"] == 100 + 10 + 5
+
+        sb.run("print('hi')", timeout=10)
+        assert recorded["timeout"] == 10 + 5
+
+    def test_timeout_preserves_partial_output(self, monkeypatch):
+        """Partial stdout/stderr from TimeoutExpired is surfaced in the result."""
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd,
+                kwargs.get("timeout"),
+                output=b"partial stdout",
+                stderr=b"partial stderr",
+            )
+
+        killed = {}
+        sb = Sandbox()
+        sb._image_checked = True  # Skip docker image inspect
+        monkeypatch.setattr(
+            Sandbox,
+            "_build_docker_command",
+            lambda self, **kwargs: (["docker", "run", "fake"], "fake-container"),
+        )
+        monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "tako_vm.sandbox.kill_container", lambda name: killed.setdefault("name", name)
+        )
+
+        result = sb.run("print('hi')", timeout=2)
+
+        assert result.success is False
+        assert result.exit_code == -1
+        assert result.stdout == "partial stdout"
+        assert result.stderr == "partial stderr"
+        assert "timed out" in result.error.lower()
+        assert killed["name"] == "fake-container"
 
 
 @pytest.mark.requires_host_mounts


### PR DESCRIPTION
## Summary

Fixes four verified bugs (F17) in the library-mode `Sandbox` (`tako_vm/sandbox.py`), bringing it in line with the server execution path (`execution/worker.py` + `docker/entrypoint.sh`):

1. **Containers could run forever if the parent died.** `_build_docker_command` accepted `timeout` but never used it — neither `TAKO_STARTUP_TIMEOUT` nor `TAKO_EXECUTION_TIMEOUT` was passed, so the only enforcement was the parent's `subprocess.run(timeout=...)`. If the parent process was SIGKILLed or crashed, the container kept running (`--rm` only fires on exit). Both env vars are now passed, enabling in-container enforcement by `entrypoint.sh` via `timeout(1)`, exactly like the server path.

2. **Dependency install time was charged against the code timeout.** With requirements, the entrypoint installs packages before running code, but the subprocess budget was just `timeout + 5`. A new `startup_timeout` setting (default 120s, matching server defaults; added at the end of the `Sandbox()` signature for backward compatibility) is wired into `SandboxConfig`, and the subprocess budget becomes `startup_timeout + timeout + 5` when requirements are present.

3. **Requirements validation was lossy and bypassable.** Invalid pip requirements were silently dropped (`logger.warning`), and an all-invalid list skipped the `allow_runtime_requirements` policy check entirely (the `if validated_reqs:` gate). The policy is now checked before validation whenever any requirements are passed, and the first invalid requirement raises `ValueError` naming it.

4. **Partial output was discarded on timeout.** On `subprocess.TimeoutExpired`, `SandboxResult` returned empty stdout/stderr even though the exception carries partial captured output (raw bytes even with `text=True`). Partial output is now decoded (`utf-8`, `errors="replace"`) and preserved.

## Tests

New unit tests in `tests/test_sandbox.py` (no container execution required):
- `_build_docker_command` includes both timeout env vars before the image name; default startup timeout is 120s
- `ValueError` on the first invalid requirement, naming it; no `_requirements.txt` written
- Policy `ValueError` when `allow_runtime_requirements=False`, even with an all-invalid list
- Subprocess budget includes `startup_timeout` only when requirements are present (monkeypatched `subprocess.run`)
- `TimeoutExpired` partial stdout/stderr (bytes) is decoded and surfaced; orphaned container is killed

Verified locally: `ruff check`/`ruff format` clean, all logic exercised directly (Docker unavailable locally, so the pytest suite auto-skips; CI has Docker and will run them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)