### PR TITLE
fix(job-types): move registry to data dir, atomic writes, validate on load

### DIFF
--- a/tako_vm/job_types.py
+++ b/tako_vm/job_types.py
@@ -17,13 +17,46 @@ Example:
 from __future__ import annotations
 
 import json
+import logging
+import os
+import tempfile
 from dataclasses import dataclass, field
 from importlib.resources import files as _resource_files
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    fcntl = None  # type: ignore[assignment]
+
 if TYPE_CHECKING:
     from tako_vm.config import JobTypeConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _default_registry_path() -> Path:
+    """
+    Default location for the writable job type registry file.
+
+    Lives under the Tako VM data directory (TAKO_VM_DATA_DIR or
+    ~/.tako_vm), never inside the installed package: site-packages may be
+    read-only and is shared by every consumer of the same environment.
+    """
+    from tako_vm.config import get_default_data_dir
+
+    data_dir = os.environ.get("TAKO_VM_DATA_DIR")
+    base = Path(data_dir) if data_dir else get_default_data_dir()
+    return base / "job_types.json"
+
+
+def _legacy_registry_path() -> Optional[Path]:
+    """Legacy registry location inside the installed package (read-only)."""
+    try:
+        return Path(str(_resource_files("tako_vm").joinpath("job_types.json")))
+    except (ModuleNotFoundError, TypeError):  # pragma: no cover - defensive
+        return None
 
 
 @dataclass
@@ -108,10 +141,17 @@ class JobType:
 
     @classmethod
     def from_dict(cls, data: dict) -> JobType:
-        """Create from dictionary."""
+        """
+        Create from dictionary, validating against JobTypeConfig bounds.
+
+        Raw registry JSON is untrusted (hand-edited or tampered files feed
+        directly into container launches), so entries are validated with the
+        same pydantic constraints as the YAML config path. Raises
+        pydantic.ValidationError on out-of-bounds or malformed values.
+        """
         gpu = data.get("gpu") or {}
 
-        return cls(
+        candidate = cls(
             name=data["name"],
             requirements=list(data.get("requirements", [])),
             python_version=data.get("python_version", "3.11"),
@@ -129,6 +169,10 @@ class JobType:
             gpu_count=data.get("gpu_count", gpu.get("count")),
             gpu_device_ids=list(data.get("gpu_device_ids", gpu.get("device_ids", []))),
         )
+        # Round-trip through the pydantic model to enforce bounds (memory_limit
+        # format, cpu_limit/timeout ranges, GPU cross-field rules) and pick up
+        # normalized values.
+        return cls.from_config(candidate.to_config())
 
     @classmethod
     def from_config(cls, config: JobTypeConfig) -> JobType:
@@ -203,28 +247,77 @@ class JobTypeRegistry:
         Initialize the registry.
 
         Args:
-            config_path: Path to config file. Defaults to job_types.json in package dir.
+            config_path: Path to config file. Defaults to job_types.json in the
+                Tako VM data directory (TAKO_VM_DATA_DIR or ~/.tako_vm).
         """
+        self._legacy_path: Optional[Path] = None
         if config_path is None:
-            config_path = Path(str(_resource_files("tako_vm").joinpath("job_types.json")))
+            config_path = _default_registry_path()
+            # Older releases stored the registry inside site-packages. Read
+            # from there once if the data-dir file does not exist yet, but
+            # never write back to the package directory.
+            self._legacy_path = _legacy_registry_path()
         self.config_path = config_path
         self._job_types: dict[str, JobType] = {}
         self._load()
 
     def _load(self):
         """Load job types from config file."""
-        if self.config_path.exists():
-            with open(self.config_path, encoding="utf-8") as f:
-                data = json.load(f)
-                for item in data.get("job_types", []):
-                    jt = JobType.from_dict(item)
-                    self._job_types[jt.name] = jt
+        path = self.config_path
+        if not path.exists() and self._legacy_path is not None and self._legacy_path.exists():
+            path = self._legacy_path
+
+        if not path.exists():
+            return
+
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        for item in data.get("job_types", []):
+            try:
+                jt = JobType.from_dict(item)
+            except Exception as exc:
+                name = item.get("name", "<unknown>") if isinstance(item, dict) else "<unknown>"
+                logger.error(
+                    "Skipping invalid job type %r in %s: %s",
+                    name,
+                    path,
+                    exc,
+                )
+                continue
+            self._job_types[jt.name] = jt
 
     def _save(self):
-        """Save job types to config file."""
+        """Save job types to config file atomically."""
         data = {"job_types": [jt.to_dict() for jt in self._job_types.values()]}
-        with open(self.config_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
+        directory = self.config_path.parent
+        directory.mkdir(parents=True, exist_ok=True)
+
+        lock_path = self.config_path.with_name(self.config_path.name + ".lock")
+        with open(lock_path, "a", encoding="utf-8") as lock_file:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                # Write to a temp file in the same directory, then atomically
+                # replace, so readers never observe a torn/partial file.
+                fd, tmp_name = tempfile.mkstemp(
+                    dir=directory, prefix=self.config_path.name + ".", suffix=".tmp"
+                )
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as f:
+                        json.dump(data, f, indent=2)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    os.replace(tmp_name, self.config_path)
+                except BaseException:
+                    try:
+                        os.unlink(tmp_name)
+                    except OSError:
+                        pass
+                    raise
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     def register(self, job_type: JobType, persist: bool = True) -> None:
         """

--- a/tests/test_job_types.py
+++ b/tests/test_job_types.py
@@ -4,6 +4,10 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
+import tako_vm.job_types as job_types_module
 from tako_vm.config import JobTypeConfig, JobTypeGPUConfig
 from tako_vm.job_types import JobType, JobTypeRegistry, merge_config_job_types
 
@@ -117,3 +121,110 @@ def test_merge_config_job_types_overrides_in_memory_without_persistence():
 
         # Persist=False means disk config should be untouched.
         assert config_path.read_text(encoding="utf-8") == original_on_disk
+
+
+def test_default_registry_path_is_under_data_dir(tmp_path, monkeypatch):
+    """Default registry lives in the data dir, never in site-packages."""
+    monkeypatch.setenv("TAKO_VM_DATA_DIR", str(tmp_path))
+
+    registry = JobTypeRegistry()
+
+    assert registry.config_path == tmp_path / "job_types.json"
+
+    registry.register(JobType(name="persisted"))
+
+    assert (tmp_path / "job_types.json").exists()
+    # Saving never touches the legacy site-packages location.
+    legacy_path = job_types_module._legacy_registry_path()
+    if legacy_path is not None and legacy_path.exists():
+        legacy_data = json.loads(legacy_path.read_text(encoding="utf-8"))
+        assert "persisted" not in {jt["name"] for jt in legacy_data["job_types"]}
+
+
+def test_default_registry_migrates_from_legacy_site_packages_file(tmp_path, monkeypatch):
+    """If only the legacy site-packages file exists, it is read (not written)."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    legacy_path = tmp_path / "legacy" / "job_types.json"
+    legacy_path.parent.mkdir()
+    legacy_path.write_text(
+        json.dumps({"job_types": [{"name": "legacy-entry", "timeout": 42}]}),
+        encoding="utf-8",
+    )
+    original_legacy_content = legacy_path.read_text(encoding="utf-8")
+
+    monkeypatch.setenv("TAKO_VM_DATA_DIR", str(data_dir))
+    monkeypatch.setattr(job_types_module, "_legacy_registry_path", lambda: legacy_path)
+
+    registry = JobTypeRegistry()
+
+    migrated = registry.get("legacy-entry")
+    assert migrated is not None
+    assert migrated.timeout == 42
+
+    # Persisting writes to the data dir; the legacy file is left untouched.
+    registry.register(JobType(name="new-entry"))
+    assert (data_dir / "job_types.json").exists()
+    assert legacy_path.read_text(encoding="utf-8") == original_legacy_content
+
+    # Once the data-dir file exists, the legacy file is no longer consulted.
+    legacy_path.write_text(
+        json.dumps({"job_types": [{"name": "should-not-load"}]}), encoding="utf-8"
+    )
+    reloaded = JobTypeRegistry()
+    assert reloaded.get("should-not-load") is None
+    assert reloaded.get("new-entry") is not None
+
+
+def test_save_is_atomic_and_leaves_valid_json(tmp_path):
+    """_save writes via temp file + os.replace, leaving valid JSON and no temp litter."""
+    config_path = tmp_path / "job_types.json"
+    registry = JobTypeRegistry(config_path=config_path)
+
+    registry.register(JobType(name="alpha"))
+    registry.register(JobType(name="beta", memory_limit="1g", cpu_limit=2.0))
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert {jt["name"] for jt in data["job_types"]} == {"alpha", "beta"}
+
+    leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_load_skips_invalid_entries(tmp_path, caplog):
+    """Tampered entries with out-of-bounds limits are rejected, valid ones kept."""
+    config_path = tmp_path / "job_types.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "job_types": [
+                    {"name": "valid", "timeout": 30},
+                    {"name": "huge-cpu", "cpu_limit": 999},
+                    {"name": "negative-timeout", "timeout": -5},
+                    {"name": "bad-memory", "memory_limit": "lots"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("ERROR"):
+        registry = JobTypeRegistry(config_path=config_path)
+
+    assert registry.get("valid") is not None
+    assert registry.get("huge-cpu") is None
+    assert registry.get("negative-timeout") is None
+    assert registry.get("bad-memory") is None
+    assert "huge-cpu" in caplog.text
+
+
+def test_from_dict_rejects_out_of_bounds_values():
+    """from_dict enforces the same bounds as the YAML JobTypeConfig path."""
+    with pytest.raises(ValidationError):
+        JobType.from_dict({"name": "bad", "cpu_limit": 999})
+
+    with pytest.raises(ValidationError):
+        JobType.from_dict({"name": "bad", "timeout": -1})
+
+    with pytest.raises(ValidationError):
+        JobType.from_dict({"name": "bad", "memory_limit": "999999g"})


### PR DESCRIPTION
## Summary

Fixes three verified safety issues (F21) in `tako_vm/job_types.py`:

### 1. Registry no longer lives in site-packages
`JobTypeRegistry()` defaulted its persistence file to `job_types.json` inside the installed package. `_save()` wrote there: it failed on read-only installs and mutated state shared by every consumer of the same venv. The default is now `<data_dir>/job_types.json`, honoring `TAKO_VM_DATA_DIR` and falling back to `get_default_data_dir()` (`~/.tako_vm` / XDG), consistent with the rest of the project and with test isolation.

**Backward compat:** if the data-dir file does not exist yet but the legacy site-packages file does, the registry loads from the legacy path on first read. It never writes back to site-packages; the first `_save()` lands in the data dir, after which the legacy file is no longer consulted. Call sites passing an explicit `config_path` (tests, builder) are unaffected.

### 2. Atomic saves
`_save()` was a plain `open(path, 'w')` + `json.dump` — torn/lost writes under concurrency. It now writes to a temp file in the same directory and `os.replace()`s it into place (atomic on POSIX), with an `fcntl.flock` on a sidecar `.lock` file as an inter-process guard (gracefully disabled where `fcntl` is unavailable). The temp file is unlinked on failure.

### 3. Loaded entries are validated
`JobType.from_dict()` applied raw `int()`/`float()` casts with zero bounds validation, while the YAML path went through pydantic `JobTypeConfig`. A tampered or hand-edited `job_types.json` could inject arbitrary limits, `network_enabled`, or env vars straight into container launches. `from_dict()` now round-trips through `JobTypeConfig` (same memory-limit format, cpu/timeout bounds, and GPU cross-field rules), and `_load()` logs and skips invalid entries instead of crashing the whole registry.

## Tests
Added to `tests/test_job_types.py`:
- default path resolves under `TAKO_VM_DATA_DIR`; saves never touch site-packages
- legacy site-packages file is migrated read-only on first load, ignored once the data-dir file exists
- save leaves valid JSON and no temp-file litter
- invalid entries (cpu_limit 999, negative timeout, bad memory format) are skipped on load with an error log
- `from_dict` raises `ValidationError` on out-of-bounds values

`uv run --extra all --extra dev pytest tests/test_job_types.py -q`: 9 passed. `tests/test_builder.py` (registry consumer): 3 passed. ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)