### PR TITLE
fix(worker): treat docker infra failures as failures and classify host timeouts correctly

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -55,6 +55,29 @@ logger = logging.getLogger(__name__)
 # Cache for runtime availability check
 _gvisor_available: Optional[bool] = None
 
+# stderr patterns that indicate the docker CLI could not reach the daemon.
+# These are infrastructure failures, never the fault of the user's code.
+_DOCKER_INFRA_STDERR_PATTERNS = (
+    "cannot connect to the docker daemon",
+    "error during connect",
+    "docker daemon is not running",
+)
+
+
+def _coerce_output(value: Any) -> str:
+    """Coerce captured subprocess output to ``str``.
+
+    ``subprocess.TimeoutExpired.stdout``/``.stderr`` hold the raw ``bytes``
+    captured before the kill even when ``subprocess.run`` was invoked with
+    ``text=True`` (CPython populates them from the byte buffers), so this
+    must handle ``str``, ``bytes``, and ``None``.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
 
 def _require_safe_execution_id(execution_id: str) -> str:
     """Reject execution IDs that are unsafe for filesystem-backed storage."""
@@ -597,6 +620,12 @@ class CodeExecutor:
                         job_id=job_id,
                     )
 
+                    # Host-level timeout: the job already consumed its full
+                    # time budget, so never retry it.
+                    if result.get("timed_out"):
+                        timed_out = True
+                        break
+
                     # Check for transient Docker errors in result
                     if not result.get("success") and result.get("error"):
                         error_msg = result.get("error", "").lower()
@@ -605,6 +634,7 @@ class CodeExecutor:
                             for pattern in [
                                 "circuit breaker",
                                 "docker daemon",
+                                "docker infrastructure failure",
                                 "connection refused",
                             ]
                         ):
@@ -615,12 +645,15 @@ class CodeExecutor:
                     break  # Success or non-transient error
 
                 except subprocess.TimeoutExpired:
+                    # Safety net only: _run_container catches TimeoutExpired
+                    # itself and returns a dict with timed_out=True instead.
                     timed_out = True
                     result = {
                         "success": False,
                         "stdout": "",
                         "stderr": "",
                         "exit_code": -1,
+                        "timed_out": True,
                     }
                     break  # Timeout is not retriable
 
@@ -694,10 +727,13 @@ class CodeExecutor:
                         phase="execution",
                     )
                 else:
-                    # Fallback to generic timeout if we can't determine phase
+                    # Fallback to generic timeout if we can't determine phase.
+                    # For a host-level timeout, _run_container already built
+                    # the message (e.g. "Execution timeout exceeded (Ns)").
                     record.error = ExecutionError(
                         type="timeout",
-                        message=f"Execution exceeded time limit ({timeout}s)",
+                        message=result.get("error")
+                        or f"Execution exceeded time limit ({timeout}s)",
                         phase=timing.phase_at_exit if timing else None,
                     )
             elif result.get("exit_code") == 137:
@@ -712,11 +748,23 @@ class CodeExecutor:
                 record.status = "succeeded"
             else:
                 record.status = "failed"
-                error_type, error_msg = classify_error(
-                    result.get("exit_code", 1), result.get("stderr", ""), timed_out
-                )
                 phase = timing.phase_at_exit if timing else None
-                record.error = ExecutionError(type=error_type, message=error_msg, phase=phase)
+                if result.get("infra_failure"):
+                    # Docker-level failure (daemon down, circuit breaker open):
+                    # don't run classify_error on daemon stderr — it would
+                    # misattribute the failure to the user's code.
+                    record.error = ExecutionError(
+                        type="service_unavailable",
+                        message=sanitize_error(
+                            result.get("error") or "Docker infrastructure failure"
+                        ),
+                        phase=phase,
+                    )
+                else:
+                    error_type, error_msg = classify_error(
+                        result.get("exit_code", 1), result.get("stderr", ""), timed_out
+                    )
+                    record.error = ExecutionError(type=error_type, message=error_msg, phase=phase)
 
             return record
 
@@ -911,6 +959,7 @@ class CodeExecutor:
                 "stdout": "",
                 "stderr": "Circuit breaker is open due to repeated Docker failures. Service will retry automatically.",
                 "exit_code": -1,
+                "infra_failure": True,
             }
 
         # Validate runtime requirements before deciding network and tmpfs policy.
@@ -1084,7 +1133,38 @@ class CodeExecutor:
                 cmd, timeout=container_timeout, capture_output=True, text=True, check=False
             )
 
-            # Record success with circuit breaker
+            # `docker run` reserves exit code 125 for failures of docker itself
+            # (daemon unreachable, image pull failure, bad flags); container
+            # exit codes pass through unchanged otherwise, and our entrypoint
+            # never exits 125 in normal operation. Treat 125 — or daemon
+            # connectivity errors on stderr of a failed run — as infrastructure
+            # failures: they must count against the circuit breaker, be marked
+            # retriable via the "error" key, and never be attributed to the
+            # user's code by classify_error.
+            stderr_lower = (result.stderr or "").lower()
+            is_infra_failure = result.returncode == 125 or (
+                result.returncode != 0
+                and any(pattern in stderr_lower for pattern in _DOCKER_INFRA_STDERR_PATTERNS)
+            )
+            if is_infra_failure:
+                stderr_lines = (result.stderr or "").strip().splitlines()
+                detail = (
+                    stderr_lines[0]
+                    if stderr_lines
+                    else f"docker run exited with code {result.returncode}"
+                )
+                circuit_breaker.record_failure(detail)
+                return {
+                    "success": False,
+                    "error": sanitize_error(f"Docker infrastructure failure: {detail}"),
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                    "exit_code": result.returncode,
+                    "infra_failure": True,
+                }
+
+            # The container ran to completion: any exit code here (including a
+            # non-zero exit from user code) means Docker itself is healthy.
             circuit_breaker.record_success()
 
             return {
@@ -1094,17 +1174,22 @@ class CodeExecutor:
                 "exit_code": result.returncode,
             }
 
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             # Timeout is not a Docker failure, don't record with circuit breaker
             # Kill the orphaned container (subprocess died but container keeps running)
             kill_container(container_name)
             return {
                 "success": False,
                 "error": f"Execution timeout exceeded ({timeout}s)",
-                "stdout": "",
-                "stderr": "",
+                # Preserve partial output captured up to the kill so the user
+                # can see how far their code got before the host-level kill.
+                "stdout": _coerce_output(e.stdout),
+                "stderr": _coerce_output(e.stderr),
                 "exit_code": -1,
                 "timeout": timeout,
+                # Marker for the caller: this run hit the host-level timeout,
+                # must be recorded as status="timeout", and must not retry.
+                "timed_out": True,
             }
         except FileNotFoundError:
             # Docker command not found - record failure

--- a/tests/test_worker_errors.py
+++ b/tests/test_worker_errors.py
@@ -1,0 +1,257 @@
+"""
+Error plumbing tests for CodeExecutor._run_container / execute_job_with_record.
+
+Covers two bugs:
+
+1. Docker infrastructure failures (daemon down, `docker run` exit 125) were
+   recorded as circuit breaker *successes*, returned without an "error" key
+   (so the retry loop never fired), and classified against the user's code.
+
+2. Host-level subprocess timeouts returned a dict with empty output and no
+   marker, so jobs killed by the host got status "failed" instead of
+   "timeout" and the partial stdout/stderr captured before the kill was
+   discarded.
+
+All tests mock subprocess.run — no Docker required.
+"""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import tako_vm.execution.worker as worker_module
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution.worker import CodeExecutor
+from tako_vm.job_types import JobType
+
+DAEMON_DOWN_STDERR = (
+    "docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. "
+    "Is the docker daemon running?"
+)
+
+
+class FakeCircuitBreaker:
+    """Records breaker calls; always reports available."""
+
+    def __init__(self):
+        self.successes = 0
+        self.failures = []
+
+    @property
+    def is_available(self):
+        return True
+
+    def record_success(self):
+        self.successes += 1
+
+    def record_failure(self, error=None):
+        self.failures.append(error)
+
+
+@pytest.fixture(autouse=True)
+def mock_gvisor_available(monkeypatch):
+    monkeypatch.setattr(worker_module, "_gvisor_available", True)
+
+
+@pytest.fixture
+def breaker(monkeypatch):
+    fake = FakeCircuitBreaker()
+    monkeypatch.setattr(worker_module, "get_circuit_breaker", lambda: fake)
+    return fake
+
+
+@pytest.fixture
+def executor(tmp_path):
+    config = TakoVMConfig(
+        security_mode="permissive",
+        data_dir=str(tmp_path / "data"),
+        max_retry_attempts=2,
+        retry_base_delay=0.1,
+    )
+    return CodeExecutor(config=config)
+
+
+@pytest.fixture
+def io_dirs(tmp_path):
+    dirs = []
+    for name in ("code", "input", "output"):
+        d = tmp_path / name
+        d.mkdir()
+        dirs.append(d)
+    return dirs
+
+
+def _run_container(executor, io_dirs):
+    code_dir, input_dir, output_dir = io_dirs
+    return executor._run_container(
+        code_dir=code_dir,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        timeout=30,
+        startup_timeout=45,
+        job_type=JobType(name="default", requirements=[]),
+        job_id="job-err-test",
+    )
+
+
+def _patch_subprocess(monkeypatch, side_effect):
+    """Replace subprocess.run in the worker module; returns the call counter."""
+    calls = {"count": 0}
+
+    def fake_run(*args, **kwargs):
+        calls["count"] += 1
+        result = side_effect()
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+    return calls
+
+
+class TestDockerInfraFailure:
+    """`docker run` failing (exit 125 / daemon unreachable) is an infra failure."""
+
+    def test_exit_125_records_breaker_failure_and_returns_error_key(
+        self, executor, breaker, io_dirs, monkeypatch
+    ):
+        _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(returncode=125, stdout="", stderr=DAEMON_DOWN_STDERR),
+        )
+
+        result = _run_container(executor, io_dirs)
+
+        assert result["success"] is False
+        assert "Docker infrastructure failure" in result["error"]
+        assert "Cannot connect to the Docker daemon" in result["error"]
+        assert result["infra_failure"] is True
+        assert breaker.failures, "infra failure must count against the circuit breaker"
+        assert breaker.successes == 0, "infra failure must NOT reset the circuit breaker"
+
+    def test_daemon_stderr_pattern_with_nonzero_exit_is_infra_failure(
+        self, executor, breaker, io_dirs, monkeypatch
+    ):
+        _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="error during connect: this error may indicate the docker daemon is not running",
+            ),
+        )
+
+        result = _run_container(executor, io_dirs)
+
+        assert result["success"] is False
+        assert "Docker infrastructure failure" in result["error"]
+        assert len(breaker.failures) == 1
+        assert breaker.successes == 0
+
+    def test_daemon_down_retries_and_record_is_service_unavailable(
+        self, executor, breaker, monkeypatch
+    ):
+        calls = _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(returncode=125, stdout="", stderr=DAEMON_DOWN_STDERR),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-infra-1", {"code": "print('hi')", "input_data": {}}
+        )
+
+        # Retry loop fired: both configured attempts hit Docker
+        assert calls["count"] == 2
+        assert len(breaker.failures) == 2
+        assert breaker.successes == 0
+
+        # Classified as an infra/service error, not the user's code
+        assert record.status == "failed"
+        assert record.error is not None
+        assert record.error.type == "service_unavailable"
+        assert "Docker infrastructure failure" in record.error.message
+
+
+class TestHostTimeout:
+    """Host-level subprocess timeout must become status='timeout' with partial output."""
+
+    def test_run_container_preserves_partial_output(self, executor, breaker, io_dirs, monkeypatch):
+        monkeypatch.setattr(worker_module, "kill_container", lambda name: None)
+        # TimeoutExpired carries the bytes captured before the kill
+        _patch_subprocess(
+            monkeypatch,
+            lambda: subprocess.TimeoutExpired(
+                ["docker", "run"], 80, output=b"partial stdout", stderr=b"partial stderr"
+            ),
+        )
+
+        result = _run_container(executor, io_dirs)
+
+        assert result["success"] is False
+        assert result["timed_out"] is True
+        assert result["stdout"] == "partial stdout"
+        assert result["stderr"] == "partial stderr"
+        assert "timeout" in result["error"].lower()
+        # Host timeout is not a Docker health problem
+        assert breaker.failures == []
+
+    def test_record_status_is_timeout_and_no_retry(self, executor, breaker, monkeypatch):
+        killed = []
+        monkeypatch.setattr(worker_module, "kill_container", killed.append)
+        calls = _patch_subprocess(
+            monkeypatch,
+            lambda: subprocess.TimeoutExpired(
+                ["docker", "run"], 80, output=b"got this far", stderr=None
+            ),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-timeout-1", {"code": "while True: pass", "input_data": {}, "timeout": 30}
+        )
+
+        assert calls["count"] == 1, "host timeout must not be retried"
+        assert killed, "orphaned container must be killed"
+        assert record.status == "timeout"
+        assert record.error is not None
+        assert "timeout" in record.error.message.lower() or "time limit" in record.error.message
+        assert record.stdout == "got this far"
+
+
+class TestUserCodeFailure:
+    """Non-zero exits from user code are not infra failures and never retry."""
+
+    def test_nonzero_user_exit_records_success_no_retry(self, executor, breaker, monkeypatch):
+        calls = _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="Traceback (most recent call last):\n  ...\nValueError: boom",
+            ),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-user-1", {"code": "raise ValueError('boom')", "input_data": {}}
+        )
+
+        assert calls["count"] == 1, "user-code failures must not retry"
+        assert breaker.successes == 1, "container completed: Docker is healthy"
+        assert breaker.failures == []
+        assert record.status == "failed"
+        assert record.error is not None
+        assert record.error.type == "value_error"
+
+    def test_successful_run_records_success(self, executor, breaker, monkeypatch):
+        _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(returncode=0, stdout="ok", stderr=""),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-ok-1", {"code": "print('ok')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert breaker.successes == 1
+        assert breaker.failures == []


### PR DESCRIPTION
## Summary

Fixes two verified error-plumbing bugs in `CodeExecutor` (`tako_vm/execution/worker.py`).

### Bug 1: Docker infrastructure failures recorded as circuit-breaker successes

`_run_container` ran `subprocess.run(cmd, ..., check=False)` and then **unconditionally** called `circuit_breaker.record_success()`. When the docker CLI itself failed (daemon down → exit 125, stderr `Cannot connect to the Docker daemon`):

- the breaker recorded a *success*, resetting its failure count — the breaker could never open for the most common infra failure;
- the returned dict had no `"error"` key, so the transient-error retry gate in `execute_job_with_record` never fired;
- `classify_error` ran against daemon stderr and attributed the failure to the user's code.

**Fix:** `docker run` reserves exit code 125 for failures of docker itself (container exit codes pass through otherwise, and our entrypoint never exits 125 in normal operation). Exit 125 — or daemon-connectivity stderr patterns on a failed run — is now treated as an infrastructure failure: `record_failure()`, an `error` key (`Docker infrastructure failure: <first stderr line>`, sanitized) that triggers the existing retry loop, and an `infra_failure` marker so the final record gets `type="service_unavailable"` instead of a user error. Normal completions with any container exit code (including failing user code) still `record_success()`. The circuit-breaker-open early return is flagged the same way so it also classifies as `service_unavailable`.

### Bug 2: Host-level timeouts misreported as `failed` with output discarded

`_run_container`'s `TimeoutExpired` handler returned `exit_code: -1` with **empty** stdout/stderr and no marker, so the outer `except subprocess.TimeoutExpired` in `execute_job_with_record` was dead code: `timed_out` stayed `False`, host-killed jobs got status `failed` (classified as a generic user error), and the partial output captured up to the kill (`TimeoutExpired.stdout`/`.stderr`) was thrown away.

**Fix:** the handler now preserves partial output (decoding the raw `bytes` CPython stores on `TimeoutExpired` even under `text=True`) and returns `"timed_out": True`. `execute_job_with_record` uses the marker to set `status="timeout"` with the `Execution timeout exceeded (Ns)` message on the record, and to **skip the retry path** (the job already consumed its time budget). The outer except is kept as a safety net only.

### Retry semantics (unchanged intent, now actually enforced)

- Infra failures → retried (`max_retry_attempts`), breaker counts failures
- User-code failures → no retry, breaker counts success (docker is healthy)
- Host timeouts → no retry

## Tests

New `tests/test_worker_errors.py` (8 tests, mocked `subprocess.run`, no Docker needed):

- exit 125 / daemon stderr → `record_failure`, `error` key present, retry loop attempts twice, record is `service_unavailable`
- `TimeoutExpired` → partial stdout preserved, `record.status == "timeout"`, container killed, no retry
- non-zero user exit → `record_success`, no retry, classified `value_error`; clean run → `succeeded`

```
uv run --extra all --extra dev pytest tests/test_worker_errors.py tests/test_runtime.py -q
27 passed
uv run --extra all --extra dev pytest tests/test_security.py tests/test_artifact_symlink.py tests/test_workspace_prune.py tests/test_models.py -q
84 passed
```

ruff check / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)