### PR TITLE
fix(server): run sync /execute off the event loop and persist an ExecutionRecord

### DIFF
--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -362,6 +362,10 @@ class ExecuteResponse(BaseModel):
     exit_code: Optional[int] = None
     error: Optional[str] = None
     job_type: Optional[str] = None
+    execution_id: Optional[str] = Field(
+        default=None,
+        description="Execution ID correlating this run with /executions records and logs",
+    )
 
 
 # Status type aliases for API type safety
@@ -806,7 +810,7 @@ async def health_check():
 
 
 @app.post("/execute", response_model=ExecuteResponse)
-async def execute_code(request: ExecuteRequest):
+async def execute_code(request: ExecuteRequest, http_request: Request):
     """
     Execute Python code synchronously (legacy endpoint).
 
@@ -818,9 +822,10 @@ async def execute_code(request: ExecuteRequest):
 
     Args:
         request: Execution request with code, input_data, and timeout
+        http_request: Incoming HTTP request (used for client IP auditing)
 
     Returns:
-        Execution results including output, stdout, stderr
+        Execution results including output, stdout, stderr, and execution_id
     """
     job_id = _generate_sync_job_id()
 
@@ -829,7 +834,6 @@ async def execute_code(request: ExecuteRequest):
 
     try:
         job = {
-            "id": job_id,
             "code": request.code,
             "input_data": request.input_data,
             "job_type": request.job_type,
@@ -844,20 +848,46 @@ async def execute_code(request: ExecuteRequest):
         if request.requirements is not None:
             job["requirements"] = request.requirements
 
-        result = state.executor.execute_job(job)
+        client_ip = http_request.client.host if http_request.client else None
+
+        # Docker execution is fully synchronous (blocking subprocess) and can
+        # take up to startup_timeout + timeout. Run it off the event loop so a
+        # sync request cannot freeze /health, job polling, and the worker pool.
+        # CodeExecutor is already invoked from threads by the async worker pool
+        # (WorkerPool thread_pool), so threaded use is consistent.
+        record = await asyncio.to_thread(
+            state.executor.execute_job_with_record,
+            job_id=job_id,
+            job=job,
+            client_ip=client_ip,
+        )
         execution_time = time.time() - start_time
+
+        # Persist the audit record, best-effort: the code already ran, so a
+        # storage failure must not turn a completed execution into an error.
+        # Log a warning and still return the result to the client.
+        try:
+            await state.storage.save_record(record)
+        except Exception as storage_err:
+            logger.warning(
+                "Failed to persist execution record %s: %s",
+                job_id,
+                storage_err,
+                exc_info=True,
+            )
 
         logger.info(f"Job {job_id} completed in {execution_time:.2f}s")
 
         return ExecuteResponse(
-            success=result["success"],
-            output=result.get("output"),
+            success=record.status == "succeeded",
+            output=record.result_json,
             execution_time=execution_time,
-            stdout=result.get("stdout", ""),
-            stderr=result.get("stderr", ""),
-            exit_code=result.get("exit_code"),
-            error=result.get("error"),
-            job_type=result.get("job_type"),
+            stdout=record.stdout,
+            stderr=record.stderr,
+            exit_code=record.exit_code,
+            error=record.error.message if record.error else None,
+            job_type=record.job_type,
+            execution_id=record.execution_id,
         )
 
     except Exception as e:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,10 @@ Tests job submission, status checking, and result retrieval
 using FastAPI's TestClient (no running server required).
 """
 
+import threading
+import time
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -73,6 +77,7 @@ print("Done!")
         assert data["output"] == {"sum": 30}
         assert "Done!" in data["stdout"]
         assert data["exit_code"] == 0
+        assert data["execution_id"].startswith("api-")
 
     def test_execute_syntax_error(self, client):
         """Execute code with syntax error."""
@@ -88,6 +93,122 @@ print("Done!")
         response = client.post("/execute", json={"code": "", "input_data": {}})
 
         assert response.status_code == 422  # Validation error
+
+
+def _make_succeeded_record(execution_id: str):
+    """Build a minimal succeeded ExecutionRecord for mocked executor tests."""
+    from tako_vm.models import ExecutionRecord
+
+    return ExecutionRecord(
+        execution_id=execution_id,
+        status="succeeded",
+        stdout="mocked stdout",
+        stderr="",
+        exit_code=0,
+        result_json={"answer": 42},
+        duration_ms=5,
+    )
+
+
+class TestSyncExecutionRecord:
+    """Tests for sync /execute audit trail and event-loop behavior (mocked executor)."""
+
+    def test_execute_returns_execution_id_and_saves_record(self, client):
+        """Sync /execute returns an execution_id and persists an ExecutionRecord."""
+        from tako_vm.server.app import state
+
+        def fake_execute(job_id, job, client_ip=None):
+            # The handler must pass through the request payload and timeouts
+            assert job["code"] == "print('hi')"
+            assert job["timeout"] == 7
+            assert job["startup_timeout"] == 33
+            return _make_succeeded_record(job_id)
+
+        save_mock = AsyncMock()
+        with (
+            patch.object(state.executor, "execute_job_with_record", side_effect=fake_execute),
+            patch.object(state.storage, "save_record", save_mock),
+        ):
+            response = client.post(
+                "/execute",
+                json={"code": "print('hi')", "timeout": 7, "startup_timeout": 33},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["execution_id"].startswith("api-")
+        assert data["output"] == {"answer": 42}
+        assert data["stdout"] == "mocked stdout"
+        assert data["exit_code"] == 0
+
+        # The saved record carries the same execution_id returned to the client
+        save_mock.assert_awaited_once()
+        saved_record = save_mock.await_args.args[0]
+        assert saved_record.execution_id == data["execution_id"]
+        assert saved_record.status == "succeeded"
+
+    def test_health_stays_responsive_during_sync_execute(self, client):
+        """A slow sync execution must not block the event loop (e.g. /health)."""
+        from tako_vm.server.app import state
+
+        started = threading.Event()
+        finished = threading.Event()
+
+        def slow_execute(job_id, job, client_ip=None):
+            started.set()
+            time.sleep(3)
+            finished.set()
+            return _make_succeeded_record(job_id)
+
+        execute_result = {}
+
+        def run_execute():
+            execute_result["response"] = client.post("/execute", json={"code": "print('slow')"})
+
+        with (
+            patch.object(state.executor, "execute_job_with_record", side_effect=slow_execute),
+            patch.object(state.storage, "save_record", AsyncMock()),
+        ):
+            execute_thread = threading.Thread(target=run_execute)
+            execute_thread.start()
+            try:
+                assert started.wait(timeout=10), "sync execution never started"
+
+                # While the sync execution sleeps in its thread, the event loop
+                # must still serve other requests.
+                health_response = client.get("/health")
+                health_done_before_execute = not finished.is_set()
+            finally:
+                execute_thread.join(timeout=30)
+
+        assert health_response.status_code == 200
+        assert health_done_before_execute, (
+            "/health only completed after the sync execution finished - event loop was blocked"
+        )
+        assert execute_result["response"].status_code == 200
+        assert execute_result["response"].json()["success"] is True
+
+    def test_execute_returns_result_when_storage_save_fails(self, client):
+        """A storage failure after execution still returns the result (code already ran)."""
+        from tako_vm.server.app import state
+
+        def fake_execute(job_id, job, client_ip=None):
+            return _make_succeeded_record(job_id)
+
+        save_mock = AsyncMock(side_effect=RuntimeError("database is down"))
+        with (
+            patch.object(state.executor, "execute_job_with_record", side_effect=fake_execute),
+            patch.object(state.storage, "save_record", save_mock),
+        ):
+            response = client.post("/execute", json={"code": "print('hi')"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["execution_id"].startswith("api-")
+        assert data["output"] == {"answer": 42}
+        save_mock.assert_awaited_once()
 
 
 class TestAsyncExecution:


### PR DESCRIPTION
## Problem (F4)

The sync `POST /execute` handler had three verified bugs in `tako_vm/server/app.py`:

1. **Event loop blocking**: the `async def` handler called `state.executor.execute_job(job)` — a fully synchronous function (blocking `subprocess` docker run, up to `startup_timeout + timeout + 5`s). One sync request froze the entire server: `/health`, all polling, all async workers.
2. **No audit trail**: the sync path used the legacy dict-returning `execute_job` and never touched storage — code executed via `POST /execute` left no `ExecutionRecord` at all.
3. **No id in the response**: `ExecuteResponse` had no execution id, so a sync client had no token to correlate with `/executions` records or logs.

## Fix

- Run execution via `await asyncio.to_thread(state.executor.execute_job_with_record, ...)`. `CodeExecutor` is already invoked from threads by the async queue path (`WorkerPool.\_thread\_pool` -> `_run_job_sync`), so threaded use is consistent.
- Switch to `execute_job_with_record` (same interface the async path uses) and persist the record with `await state.storage.save_record(record)`. Persistence is **best-effort**: the code already ran, so a storage failure logs a warning and still returns the execution result to the client instead of a 500.
- Add `execution_id: Optional[str]` to `ExecuteResponse` (defaults to `None`, so existing clients parsing the model stay compatible) and populate it from the record; the handler-generated `api-<uuid>` job id is the same id used for the record.
- Pass the client IP through (`http_request.client.host`) for auditing, consistent with the async submission path.
- Response semantics preserved: `success`/`output`/`stdout`/`stderr`/`exit_code`/`error`/`job_type`/`execution_time` mapped from the record (`record.status == "succeeded"`, `record.result_json`, `record.error.message`, ...). Request `timeout`/`startup_timeout`/`requirements` still pass through in the job dict.

Behavior note: unexpected executor exceptions are now captured inside `execute_job_with_record` and returned as a failed record (200 with `success=false` + error), matching the async path, instead of bubbling to a 500.

## Tests (`tests/test_api.py`)

- `test_execute_returns_execution_id_and_saves_record` — response carries `execution_id`; `save_record` called with a record bearing the same id; timeouts passed through.
- `test_health_stays_responsive_during_sync_execute` — while a mocked sync execution sleeps 3s in its thread, a concurrent `/health` completes before the execution finishes (event-loop liveness; fails on the old blocking code).
- `test_execute_returns_result_when_storage_save_fails` — storage failure during save still returns 200 with the result.
- Extended `test_execute_simple_code` to assert `execution_id` is returned.

## Verification

- `ruff check` / `ruff format --check` clean.
- `uv run --extra all --extra dev pytest tests/test_api.py -q`: all 42 tests **skip** in this environment (conftest auto-skips `test_api` without Docker; Postgres also unavailable locally) — they need CI services to run.
- Direct smoke test of the new handler with stubbed executor/storage: fields mapped correctly, `timeout`/`startup_timeout`/`client_ip` passed through, storage failure tolerated, `execution_id` returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)