### PR TITLE
fix(queue): watchdog honors job-type budgets, kills the container, and records timeout

### DIFF
--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -642,25 +642,125 @@ class WorkerPool:
             job: Job to execute
 
         Returns:
-            ExecutionRecord with results
-
-        Raises:
-            asyncio.TimeoutError: If execution exceeds timeout + buffer
+            ExecutionRecord with results (including a terminal "timeout" record
+            if the watchdog budget is exceeded)
         """
         loop = asyncio.get_running_loop()
 
         # Include both startup and execution budgets, plus buffer for Docker orchestration.
-        job_timeout = job.job_data.get("timeout", 30)
-        startup_timeout = job.job_data.get("startup_timeout", 120)
+        job_timeout, startup_timeout = self._resolve_timeout_budget(job)
         executor_timeout = startup_timeout + job_timeout + 60
 
         # Run synchronous execution in thread pool with timeout protection
-        record = await asyncio.wait_for(
-            loop.run_in_executor(self._thread_pool, self._run_job_sync, job),
-            timeout=executor_timeout,
-        )
+        try:
+            record = await asyncio.wait_for(
+                loop.run_in_executor(self._thread_pool, self._run_job_sync, job),
+                timeout=executor_timeout,
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            return await self._handle_watchdog_timeout(job, executor_timeout)
 
         return record
+
+    def _resolve_timeout_budget(self, job: QueuedJob) -> tuple:
+        """
+        Resolve the (job_timeout, startup_timeout) budget for the watchdog.
+
+        Mirrors the executor's own resolution (CodeExecutor falls back to the
+        job type's timeout/startup_timeout when the job omits them), so the
+        watchdog never undercuts a legitimate job-type budget. Falls back to
+        the executor's built-in defaults when the job type is missing or the
+        registry lookup fails.
+
+        Args:
+            job: Job whose budget to resolve
+
+        Returns:
+            Tuple of (job_timeout, startup_timeout) in seconds
+        """
+        # Matches CodeExecutor's DEFAULT_JOB_TYPE (timeout=30, startup_timeout=120).
+        default_timeout: float = 30
+        default_startup_timeout: float = 120
+
+        job_type_name = job.job_data.get("job_type")
+        if job_type_name:
+            try:
+                # Strip version specifier (job_type@version), like the executor does.
+                name = job_type_name.split("@", 1)[0]
+                registry = getattr(self.executor, "registry", None)
+                job_type = registry.get(name) if registry is not None else None
+                if job_type is not None:
+                    default_timeout = float(job_type.timeout)
+                    default_startup_timeout = float(job_type.startup_timeout)
+            except Exception as e:
+                logger.warning(
+                    f"Could not resolve job-type budget for job {job.job_id} "
+                    f"(job_type={job_type_name!r}): {e}; using built-in defaults"
+                )
+
+        job_timeout = job.job_data.get("timeout", default_timeout)
+        startup_timeout = job.job_data.get("startup_timeout", default_startup_timeout)
+        return job_timeout, startup_timeout
+
+    async def _handle_watchdog_timeout(
+        self, job: QueuedJob, executor_timeout: float
+    ) -> ExecutionRecord:
+        """
+        Handle a watchdog (wait_for) timeout for a job.
+
+        The asyncio timeout only cancels the awaiting wrapper -- the executor
+        thread keeps running. Kill the container immediately so the sandboxed
+        workload stops now instead of when the thread's subprocess backstop
+        eventually fires, and return a terminal "timeout" record (this is a
+        budget overrun, not an internal error, so it must not be DLQ'd).
+
+        Args:
+            job: Job that exceeded the watchdog budget
+            executor_timeout: Budget in seconds that was exceeded
+
+        Returns:
+            ExecutionRecord with status "timeout"
+        """
+        container_name = generate_container_name("tako", job.job_id)
+        killed = await asyncio.to_thread(kill_container, container_name)
+        if killed:
+            logger.warning(
+                f"Job {job.job_id} exceeded watchdog budget of {executor_timeout}s; "
+                f"killed container {container_name}"
+            )
+        else:
+            logger.warning(
+                f"Job {job.job_id} exceeded watchdog budget of {executor_timeout}s; "
+                f"container {container_name} was not running (already exited?)"
+            )
+        logger.warning(
+            f"Executor thread for job {job.job_id} is stranded until its subprocess "
+            "timeout backstop fires; the worker slot is freed now"
+        )
+
+        job_type_name = job.job_data.get("job_type") or "default"
+        return ExecutionRecord(
+            execution_id=job.job_id,
+            status="timeout",
+            job_type=job_type_name,
+            job_ref=f"{job_type_name}@latest",
+            created_at=job.created_at,
+            queued_at=job.created_at,
+            code_hash=sha256_content(job.job_data.get("code", "")),
+            input_hash=sha256_json(job.job_data.get("input_data", {})),
+            client_ip=job.client_ip,
+            error=ExecutionError(
+                type="execution_timeout",
+                message=(
+                    f"Execution exceeded the watchdog budget of {executor_timeout}s "
+                    "(startup + execution + orchestration buffer); container was killed"
+                ),
+            ),
+            idempotency_key=job.job_data.get("idempotency_key"),
+            idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
+            parent_execution_id=job.job_data.get("parent_execution_id"),
+            relationship=job.job_data.get("relationship"),
+        )
 
     def _run_job_sync(self, job: QueuedJob) -> ExecutionRecord:
         """

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -361,3 +361,223 @@ async def test_worker_loop_executes_even_if_running_persist_fails():
         await asyncio.wait_for(worker, timeout=2.0)
 
     assert record.status == "succeeded"
+
+
+def _patch_budget_probe(monkeypatch, job_id: str) -> dict:
+    """Capture the watchdog timeout passed to asyncio.wait_for in _execute_job."""
+    captured = {}
+
+    class DummyLoop:
+        def run_in_executor(self, executor, fn, arg):
+            return asyncio.sleep(0, result=make_record(job_id))
+
+    async def fake_wait_for(awaitable, timeout):
+        captured["timeout"] = timeout
+        return await awaitable
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: DummyLoop())
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_watchdog_budget_uses_job_type_defaults(monkeypatch):
+    """When job_data omits timeouts, the watchdog must use the job type's budget."""
+    from tako_vm.job_types import JobType
+
+    executor = MagicMock()
+    executor.registry = MagicMock()
+    executor.registry.get.return_value = JobType(
+        name="ml-inference", timeout=120, startup_timeout=180
+    )
+    pool = WorkerPool(executor=executor, storage=MagicMock())
+    pool._thread_pool = MagicMock()
+    job = QueuedJob(
+        job_id="job-jt",
+        job_data={"job_type": "ml-inference", "code": "print('hi')", "input_data": {}},
+        client_ip=None,
+    )
+
+    captured = _patch_budget_probe(monkeypatch, "job-jt")
+
+    record = await pool._execute_job(job)
+
+    assert record.execution_id == "job-jt"
+    # 180 (startup) + 120 (execution) + 60 (orchestration buffer)
+    assert captured["timeout"] == 360
+    executor.registry.get.assert_called_once_with("ml-inference")
+
+
+@pytest.mark.asyncio
+async def test_watchdog_budget_strips_version_specifier(monkeypatch):
+    """job_type@version must resolve the registry entry by bare name."""
+    from tako_vm.job_types import JobType
+
+    executor = MagicMock()
+    executor.registry = MagicMock()
+    executor.registry.get.return_value = JobType(
+        name="data-processing", timeout=60, startup_timeout=180
+    )
+    pool = WorkerPool(executor=executor, storage=MagicMock())
+    pool._thread_pool = MagicMock()
+    job = QueuedJob(
+        job_id="job-ver",
+        job_data={"job_type": "data-processing@v2", "code": "x", "input_data": {}},
+        client_ip=None,
+    )
+
+    captured = _patch_budget_probe(monkeypatch, "job-ver")
+
+    await pool._execute_job(job)
+
+    assert captured["timeout"] == 300
+    executor.registry.get.assert_called_once_with("data-processing")
+
+
+@pytest.mark.asyncio
+async def test_watchdog_budget_explicit_timeouts_win(monkeypatch):
+    """Explicit job_data timeouts override the job type's defaults."""
+    from tako_vm.job_types import JobType
+
+    executor = MagicMock()
+    executor.registry = MagicMock()
+    executor.registry.get.return_value = JobType(
+        name="ml-inference", timeout=120, startup_timeout=180
+    )
+    pool = WorkerPool(executor=executor, storage=MagicMock())
+    pool._thread_pool = MagicMock()
+    job = QueuedJob(
+        job_id="job-explicit",
+        job_data={
+            "job_type": "ml-inference",
+            "timeout": 30,
+            "startup_timeout": 90,
+            "code": "x",
+            "input_data": {},
+        },
+        client_ip=None,
+    )
+
+    captured = _patch_budget_probe(monkeypatch, "job-explicit")
+
+    await pool._execute_job(job)
+
+    assert captured["timeout"] == 180
+
+
+@pytest.mark.asyncio
+async def test_watchdog_budget_unknown_job_type_falls_back(monkeypatch):
+    """Unknown job types fall back to the executor's built-in defaults."""
+    executor = MagicMock()
+    executor.registry = MagicMock()
+    executor.registry.get.return_value = None
+    pool = WorkerPool(executor=executor, storage=MagicMock())
+    pool._thread_pool = MagicMock()
+    job = QueuedJob(
+        job_id="job-unknown",
+        job_data={"job_type": "does-not-exist", "code": "x", "input_data": {}},
+        client_ip=None,
+    )
+
+    captured = _patch_budget_probe(monkeypatch, "job-unknown")
+
+    await pool._execute_job(job)
+
+    # DEFAULT_JOB_TYPE budget: 120 (startup) + 30 (execution) + 60 (buffer)
+    assert captured["timeout"] == 210
+
+
+@pytest.mark.asyncio
+async def test_watchdog_timeout_kills_container_and_returns_timeout_record(monkeypatch):
+    """A watchdog timeout must kill the container and yield status='timeout'."""
+    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    pool._thread_pool = MagicMock()
+    job = QueuedJob(
+        job_id="job-wd",
+        job_data={"timeout": 1, "startup_timeout": 1, "code": "x", "input_data": {}},
+        client_ip=None,
+    )
+
+    kill_calls = []
+    monkeypatch.setattr(
+        "tako_vm.server.queue.kill_container", lambda name: kill_calls.append(name) or True
+    )
+
+    class DummyLoop:
+        def run_in_executor(self, executor, fn, arg):
+            return asyncio.sleep(0, result=make_record("job-wd"))
+
+    async def fake_wait_for(awaitable, timeout):
+        awaitable.close()  # avoid 'coroutine never awaited' warning
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: DummyLoop())
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+
+    record = await pool._execute_job(job)
+
+    assert record.status == "timeout"
+    assert record.error is not None
+    assert record.error.type == "execution_timeout"
+    assert "watchdog budget" in record.error.message
+    assert kill_calls == ["tako-job-wd"]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_timeout_saves_timeout_record_and_skips_dlq(monkeypatch):
+    """End-to-end through the worker loop: watchdog timeout is not an internal error.
+
+    The persisted record must have status 'timeout' (not failed/internal_error)
+    and the job must NOT be pushed to the dead letter queue.
+    """
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    storage.mark_record_running = AsyncMock()
+    storage.add_to_dlq = AsyncMock()
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage, queue_wait_timeout=0.05)
+
+    kill_calls = []
+    monkeypatch.setattr(
+        "tako_vm.server.queue.kill_container", lambda name: kill_calls.append(name) or True
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def fake_wait_for(awaitable, timeout):
+        # The worker loop's queue wait and the test's own waits use small
+        # timeouts; only the watchdog budget is >= 60s.
+        if timeout >= 60:
+            if asyncio.isfuture(awaitable):
+                awaitable.cancel()
+            raise asyncio.TimeoutError()
+        return await real_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-dlq",
+        job_data={"code": "x", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    pool._active_jobs[job.job_id] = job
+    pool._queue.put_nowait(job)
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        record = await asyncio.wait_for(job.future, timeout=5.0)
+    finally:
+        pool._shutdown = True
+        await asyncio.wait_for(worker, timeout=5.0)
+
+    assert record.status == "timeout"
+    assert record.error is not None
+    assert record.error.type == "execution_timeout"
+    assert kill_calls == ["tako-job-dlq"]
+
+    # Watchdog timeouts are budget overruns, not internal errors: no DLQ entry.
+    storage.add_to_dlq.assert_not_awaited()
+    saved = storage.save_record.await_args.args[0]
+    assert saved.status == "timeout"


### PR DESCRIPTION
## Problem (F5)

`WorkerPool._execute_job` computed the watchdog budget from hardcoded defaults (`timeout=30`, `startup_timeout=120`) instead of the defaults the executor actually resolves from the job type (`worker.py`: `timeout = job.get("timeout", job_type.timeout)`). Built-in job types like `ml-inference` carry `timeout=120 / startup_timeout=180`, so a legitimate job omitting explicit timeouts got watchdog-killed at 210s instead of 360s.

Worse, when the watchdog fired:
- only the asyncio wrapper was cancelled — the executor thread and its Docker container kept running until the subprocess backstop eventually reaped them, minutes later;
- the `TimeoutError` fell into the generic `except Exception` handler, producing a `failed`/`internal_error` record and a dead-letter entry for what is actually a budget overrun.

## Fix (`tako_vm/server/queue.py`)

- **`_resolve_timeout_budget`**: mirrors `CodeExecutor`'s job-type resolution (`self.executor.registry.get(name)` with `@version` stripping) so the watchdog never undercuts the executor's own budget. Unknown/missing job types fall back to the built-in defaults (30/120, matching `DEFAULT_JOB_TYPE`). The +60s orchestration buffer is preserved.
- **`_handle_watchdog_timeout`**: `_execute_job` now catches `asyncio.TimeoutError` and (a) immediately kills the container via `asyncio.to_thread(kill_container, generate_container_name("tako", job_id))` — same mechanism as `cancel()`; (b) returns a terminal record with `status="timeout"` and `ExecutionError(type="execution_timeout")` instead of raising; (c) therefore bypasses the DLQ path reserved for internal errors; (d) logs a warning that the executor thread is stranded until its subprocess timeout backstop fires.

## Tests (`tests/test_queue.py`, appended at EOF)

- budget uses job-type defaults when `job_data` omits timeouts (120+180+60 = 360)
- `job_type@version` resolves by bare name
- explicit `job_data` timeouts still win
- unknown job type falls back to 30+120+60 = 210
- watchdog timeout kills the container and returns `status="timeout"` / `execution_timeout`
- end-to-end worker-loop test: persisted record is `timeout`, `storage.add_to_dlq` is never called

`uv run --extra all --extra dev pytest tests/test_queue.py -q` → 17 passed. ruff check/format clean. No changes to app.py / worker.py / storage.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)