### PR TITLE
fix(storage): robust record hydration and strict digest resolution

### DIFF
--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -6,6 +6,7 @@ Provides async CRUD operations for ExecutionRecords and JobVersions.
 
 import asyncio
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, List, Mapping, Optional, cast
 
@@ -28,6 +29,15 @@ logger = logging.getLogger(__name__)
 
 MIGRATION_LOCK_ID = 94857231
 RowMapping = Mapping[str, Any]
+
+# Minimum digest prefix length accepted by get_version_by_digest. Shorter
+# prefixes are too ambiguous to resolve safely (and an empty prefix would
+# match every stored version).
+MIN_DIGEST_PREFIX_LEN = 12
+
+# Full digests and digest prefixes must be lowercase hex (sha256 hexdigest).
+# This also guarantees the value cannot contain SQL LIKE wildcards ('%'/'_').
+_DIGEST_RE = re.compile(rf"^[0-9a-f]{{{MIN_DIGEST_PREFIX_LEN},64}}$")
 
 
 MIGRATIONS: list[tuple[str, str]] = [
@@ -467,8 +477,13 @@ class ExecutionStorage:
 
     def _row_to_record(self, row: RowMapping) -> ExecutionRecord:
         """Convert database row to ExecutionRecord."""
+        # All ResourceUsage fields are independently nullable, so rebuild the
+        # model if ANY metric column was stored — gating on wall_time_ms alone
+        # would silently drop records saved with only max_rss_mb/cpu_time_ms.
         resource_usage = None
-        if row.get("wall_time_ms") is not None:
+        if any(
+            row.get(column) is not None for column in ("max_rss_mb", "cpu_time_ms", "wall_time_ms")
+        ):
             resource_usage = ResourceUsage(
                 max_rss_mb=row.get("max_rss_mb"),
                 cpu_time_ms=row.get("cpu_time_ms"),
@@ -481,8 +496,11 @@ class ExecutionStorage:
             try:
                 input_artifacts = [InputArtifact(**a) for a in input_artifacts_data]
             except (TypeError, ValueError) as e:
-                logger.warning(
-                    "Failed to parse input_artifacts_json for %s: %s", row["execution_id"], e
+                logger.error(
+                    "Corrupt stored field input_artifacts_json for execution %s; "
+                    "degrading to empty list: %s",
+                    row["execution_id"],
+                    e,
                 )
 
         artifacts = []
@@ -491,7 +509,12 @@ class ExecutionStorage:
             try:
                 artifacts = [Artifact(**a) for a in artifacts_data]
             except (TypeError, ValueError) as e:
-                logger.warning("Failed to parse artifacts_json for %s: %s", row["execution_id"], e)
+                logger.error(
+                    "Corrupt stored field artifacts_json for execution %s; "
+                    "degrading to empty list: %s",
+                    row["execution_id"],
+                    e,
+                )
 
         error = None
         error_data = _decode_json_field(row.get("error_json"))
@@ -499,7 +522,19 @@ class ExecutionStorage:
             try:
                 error = ExecutionError(**error_data)
             except (TypeError, ValueError) as e:
-                logger.warning("Failed to parse error_json for %s: %s", row["execution_id"], e)
+                logger.error(
+                    "Corrupt stored field error_json for execution %s; "
+                    "substituting fallback internal_error: %s",
+                    row["execution_id"],
+                    e,
+                )
+                # Surface the corruption loudly rather than presenting the
+                # record as error-free: a stored error payload existed but no
+                # longer matches the ExecutionError model.
+                error = ExecutionError(
+                    type="internal_error",
+                    message="stored error payload could not be decoded",
+                )
 
         result_json = _decode_json_field(row.get("result_json"))
 
@@ -509,7 +544,11 @@ class ExecutionStorage:
             try:
                 timing = ExecutionTiming(**timing_data)
             except (TypeError, ValueError) as e:
-                logger.warning("Failed to parse timing_json for %s: %s", row["execution_id"], e)
+                logger.error(
+                    "Corrupt stored field timing_json for execution %s; degrading to None: %s",
+                    row["execution_id"],
+                    e,
+                )
 
         return ExecutionRecord(
             execution_id=row["execution_id"],
@@ -580,25 +619,56 @@ class ExecutionStorage:
             )
 
     async def get_version_by_digest(self, job_type_name: str, digest: str) -> Optional[JobVersion]:
-        """Get version by digest."""
+        """
+        Get version by full digest or an unambiguous digest prefix.
+
+        Args:
+            job_type_name: Job type name.
+            digest: Full 64-character hex digest, or a prefix of at least
+                MIN_DIGEST_PREFIX_LEN hex characters.
+
+        Returns:
+            Matching JobVersion, or None if no version matches.
+
+        Raises:
+            ValueError: If the digest is empty, shorter than
+                MIN_DIGEST_PREFIX_LEN, not lowercase hex (which also rejects
+                SQL LIKE wildcards), or if a prefix matches more than one
+                stored version.
+        """
+        if not _DIGEST_RE.fullmatch(digest):
+            raise ValueError(
+                f"Invalid digest {digest!r}: must be {MIN_DIGEST_PREFIX_LEN}-64 "
+                "lowercase hex characters"
+            )
+
         pool = self._get_pool()
         async with pool.connection() as conn:
             if len(digest) < 64:
+                # The digest is validated as hex above, so it cannot contain
+                # LIKE wildcards ('%'/'_'); the prefix match is literal.
                 cursor = await conn.execute(
                     """
                     SELECT * FROM job_versions
                     WHERE job_type_name = %s AND digest LIKE %s
-                    ORDER BY built_at DESC
-                    LIMIT 1
+                    LIMIT 2
                     """,
                     (job_type_name, digest + "%"),
                 )
+                rows = await cursor.fetchall()
+                if len(rows) > 1:
+                    raise ValueError(
+                        f"Ambiguous digest prefix {digest!r} for job type "
+                        f"{job_type_name!r}: matches multiple versions; "
+                        "provide a longer prefix or the full digest"
+                    )
+                row = rows[0] if rows else None
             else:
                 cursor = await conn.execute(
                     "SELECT * FROM job_versions WHERE job_type_name = %s AND digest = %s",
                     (job_type_name, digest),
                 )
-            row = await cursor.fetchone()
+                row = await cursor.fetchone()
 
         if not row:
             return None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -344,7 +344,7 @@ class TestJobVersions:
         )
         storage.save_version(version)
 
-        retrieved = storage.get_version_by_digest("test-job", "abcdef")
+        retrieved = storage.get_version_by_digest("test-job", "abcdef123456")
         assert retrieved is not None
         assert retrieved.version_tag == "v1.0.0"
 
@@ -633,3 +633,146 @@ class TestMarkRecordRunning:
     def test_mark_running_missing_record(self, storage):
         """Marking a nonexistent record returns False."""
         assert storage.mark_record_running("nope") is False
+
+
+class TestRecordHydrationRobustness:
+    """Tests for robust hydration of stored execution records."""
+
+    def test_resource_usage_round_trip_with_only_max_rss(self, storage):
+        """ResourceUsage survives a round-trip when only max_rss_mb is set."""
+        record = ExecutionRecord(
+            execution_id="rss-only",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            exit_code=0,
+            resource_usage=ResourceUsage(max_rss_mb=64.5),
+        )
+        storage.save_record(record)
+
+        retrieved = storage.get_record("rss-only")
+        assert retrieved is not None
+        assert retrieved.resource_usage is not None
+        assert retrieved.resource_usage.max_rss_mb == 64.5
+        assert retrieved.resource_usage.cpu_time_ms is None
+        assert retrieved.resource_usage.wall_time_ms is None
+
+    def test_resource_usage_absent_stays_none(self, storage):
+        """A record saved without resource usage still loads with None."""
+        record = ExecutionRecord(
+            execution_id="no-usage",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            exit_code=0,
+        )
+        storage.save_record(record)
+
+        retrieved = storage.get_record("no-usage")
+        assert retrieved is not None
+        assert retrieved.resource_usage is None
+
+    def test_corrupted_error_json_loads_with_fallback(self, storage):
+        """A record whose stored error payload no longer parses still loads,
+        with a loud internal_error fallback instead of a silent None."""
+        from psycopg.types.json import Jsonb
+
+        record = ExecutionRecord(
+            execution_id="corrupt-error",
+            status="failed",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            exit_code=1,
+            error=ExecutionError(type="runtime_error", message="boom"),
+        )
+        storage.save_record(record)
+
+        async def _corrupt():
+            pool = storage._inner._get_pool()
+            async with pool.connection() as conn:
+                await conn.execute(
+                    "UPDATE execution_records SET error_json = %s WHERE execution_id = %s",
+                    (Jsonb({"type": "no-such-error-type", "bogus": True}), "corrupt-error"),
+                )
+
+        storage._run(_corrupt())
+
+        retrieved = storage.get_record("corrupt-error")
+        assert retrieved is not None  # record must still load
+        assert retrieved.error is not None
+        assert retrieved.error.type == "internal_error"
+        assert "stored error payload could not be decoded" in retrieved.error.message
+
+
+class TestDigestResolutionStrictness:
+    """Tests for strict digest prefix resolution in get_version_by_digest."""
+
+    @staticmethod
+    def _make_version(digest: str, tag: str, built_at=None) -> JobVersion:
+        kwargs = {"built_at": built_at} if built_at is not None else {}
+        return JobVersion(
+            digest=digest,
+            job_type_name="digest-job",
+            version_tag=tag,
+            dockerfile_hash="",
+            requirements_hash="",
+            image_ref=f"digest-job:{tag}",
+            **kwargs,
+        )
+
+    def test_empty_digest_rejected(self, storage):
+        """An empty digest raises instead of matching every version."""
+        storage.save_version(self._make_version("a" * 64, "v1"))
+
+        with pytest.raises(ValueError, match="Invalid digest"):
+            storage.get_version_by_digest("digest-job", "")
+
+    def test_short_prefix_rejected(self, storage):
+        """Prefixes shorter than 12 hex chars are rejected."""
+        storage.save_version(self._make_version("abcdef1234567890" + "0" * 48, "v1"))
+
+        with pytest.raises(ValueError, match="Invalid digest"):
+            storage.get_version_by_digest("digest-job", "abcdef12345")  # 11 chars
+
+    def test_non_hex_digest_rejected(self, storage):
+        """Non-hex digests (including SQL LIKE wildcards) are rejected, so a
+        wildcard never matches everything."""
+        storage.save_version(self._make_version("abcdef1234567890" + "0" * 48, "v1"))
+
+        # '%' would previously act as an unescaped LIKE wildcard.
+        with pytest.raises(ValueError, match="Invalid digest"):
+            storage.get_version_by_digest("digest-job", "abc%def12345")
+
+        with pytest.raises(ValueError, match="Invalid digest"):
+            storage.get_version_by_digest("digest-job", "abcdef_2345678")
+
+    def test_valid_prefix_resolves(self, storage):
+        """A 12+ hex char unique prefix resolves to the matching version."""
+        storage.save_version(self._make_version("abcdef1234567890" + "0" * 48, "v1"))
+
+        retrieved = storage.get_version_by_digest("digest-job", "abcdef123456")
+        assert retrieved is not None
+        assert retrieved.version_tag == "v1"
+
+    def test_unmatched_prefix_returns_none(self, storage):
+        """A valid prefix that matches nothing returns None."""
+        storage.save_version(self._make_version("abcdef1234567890" + "0" * 48, "v1"))
+
+        assert storage.get_version_by_digest("digest-job", "f" * 12) is None
+
+    def test_ambiguous_prefix_raises(self, storage):
+        """A prefix matching multiple versions raises instead of silently
+        resolving to the newest one."""
+        old_time = datetime.now(timezone.utc) - timedelta(days=1)
+        new_time = datetime.now(timezone.utc)
+        shared_prefix = "deadbeef0123"
+        storage.save_version(self._make_version(shared_prefix + "a" * 52, "v1", built_at=old_time))
+        storage.save_version(self._make_version(shared_prefix + "b" * 52, "v2", built_at=new_time))
+
+        with pytest.raises(ValueError, match="Ambiguous digest prefix"):
+            storage.get_version_by_digest("digest-job", shared_prefix)
+
+        # Full digests still resolve unambiguously.
+        retrieved = storage.get_version_by_digest("digest-job", shared_prefix + "a" * 52)
+        assert retrieved is not None
+        assert retrieved.version_tag == "v1"


### PR DESCRIPTION
## Summary

Fixes three verified read-path bugs in `tako_vm/storage.py` (storage layer only; no model or queue/worker changes).

### F23a — ResourceUsage silently dropped on round-trip
`_row_to_record` only rebuilt `ResourceUsage` when `wall_time_ms` was non-null. Since all three fields are independently nullable in `models.ResourceUsage`, a record saved with only `max_rss_mb`/`cpu_time_ms` hydrated to `resource_usage=None`, silently losing stored metrics. Now rebuilt if **any** of `max_rss_mb`/`cpu_time_ms`/`wall_time_ms` is non-null.

### F23b — corrupt stored JSON degraded silently
Parse failures of `input_artifacts_json`/`artifacts_json`/`error_json`/`timing_json` were logged at WARNING and degraded to empty list/None, so a reader could not distinguish "no artifacts" from "stored payload no longer matches the model". Now:
- all parse failures log at **ERROR** with the execution_id and field name;
- a corrupt `error_json` hydrates to a loud fallback `ExecutionError(type="internal_error", message="stored error payload could not be decoded")` instead of `None`.

Behavior stays conservative — records always still load.

### F24 — digest prefix resolution was wildcard-injectable and ambiguous
`get_version_by_digest` used `digest LIKE digest || '%'` unescaped for digests under 64 chars:
- an **empty** digest matched everything and silently resolved to the newest version;
- `%`/`_` in the input acted as LIKE wildcards;
- ambiguous prefixes silently took the newest build.

Now the digest must be 12–64 lowercase hex characters (`ValueError` otherwise — this rejects wildcards by construction), and a prefix matching more than one stored version raises `ValueError` instead of guessing. Callers (`VersionManager.resolve` / `version_exists` in `tako_vm/version.py`) are not invoked on production request paths, so the stricter contract is safe; the one existing test using a 6-char prefix was updated to a 12-char prefix.

## Tests

Appended to `tests/test_storage.py` (Postgres-backed; skip locally, run in CI):
- ResourceUsage round-trip with only `max_rss_mb` set (and absent-stays-None)
- corrupted `error_json` (written via direct SQL) loads with the `internal_error` fallback
- empty / <12-char / non-hex / wildcard-containing digests raise `ValueError`
- valid unique prefix resolves; unmatched prefix returns `None`
- ambiguous prefix raises while the full digest still resolves

## Verification

- `ruff check` and `ruff format --check` pass on both files
- `py_compile` passes
- Postgres tests skip locally (no DB available); logic verified against models (`ErrorType` literal includes `internal_error`; `JobVersion.digest` is 64-char lowercase hex) and the `SyncStorageAdapter` test fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)