### PR TITLE
fix(queue): don't burn the idempotency key when the queue is full

### DIFF
--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -221,7 +221,13 @@ class WorkerPool:
         try:
             self._queue.put_nowait(job)
         except asyncio.QueueFull as exc:
+            # Release the idempotency key: a 503 tells the client to retry,
+            # and the retry must not collide with this dead record. save_record
+            # is an upsert that overwrites all columns, so re-saving with the
+            # key cleared frees it while keeping the failure visible.
             queued_record.status = "failed"
+            queued_record.idempotency_key = None
+            queued_record.idempotency_fingerprint = None
             queued_record.error = ExecutionError(
                 type="service_unavailable", message="Job queue is full, try again later"
             )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -581,3 +581,74 @@ async def test_watchdog_timeout_saves_timeout_record_and_skips_dlq(monkeypatch):
     storage.add_to_dlq.assert_not_awaited()
     saved = storage.save_record.await_args.args[0]
     assert saved.status == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_submit_queue_full_race_releases_idempotency_key():
+    """A QueueFull race must not strand the idempotency key on a failed record.
+
+    The 503 the client receives is the canonical retry signal; the retry with
+    the same key must not collide with the dead record.
+    """
+    storage = MagicMock()
+    # submit() mutates and re-saves the same record object, so snapshot the
+    # fields we care about at call time instead of inspecting await_args_list.
+    saves = []
+
+    async def capture_save(record):
+        saves.append((record.status, record.idempotency_key, record.idempotency_fingerprint))
+
+    storage.save_record = AsyncMock(side_effect=capture_save)
+    pool = WorkerPool(executor=MagicMock(), storage=storage)
+
+    # Simulate the TOCTOU race: full() pre-check passes, put_nowait raises.
+    fake_queue = MagicMock()
+    fake_queue.full.return_value = False
+    fake_queue.put_nowait.side_effect = asyncio.QueueFull
+    pool._queue = fake_queue
+
+    job_data = {
+        "code": "print('hi')",
+        "input_data": {},
+        "idempotency_key": "idem-123",
+        "idempotency_fingerprint": "f" * 64,
+    }
+
+    with pytest.raises(RuntimeError, match="queue is full"):
+        await pool.submit(job_data=job_data, client_ip="10.0.0.1")
+
+    # Two saves: the preliminary queued record, then the failed rewrite.
+    assert saves == [
+        ("queued", "idem-123", "f" * 64),
+        ("failed", None, None),
+    ]
+
+    # The final upsert keeps the failure visible for forensics.
+    failed = storage.save_record.await_args_list[1].args[0]
+    assert failed.error is not None
+    assert failed.error.type == "service_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_submit_queue_full_precheck_rejects_without_db_write():
+    """The cheap full() pre-check rejects before any record is persisted."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    pool = WorkerPool(executor=MagicMock(), storage=storage, max_queue_size=1)
+    loop = asyncio.get_running_loop()
+    pool._queue.put_nowait(
+        QueuedJob(
+            job_id="job-occupies-slot",
+            job_data={"code": "x", "input_data": {}},
+            client_ip=None,
+            future=loop.create_future(),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="queue is full"):
+        await pool.submit(
+            job_data={"code": "y", "input_data": {}, "idempotency_key": "idem-456"},
+            client_ip=None,
+        )
+
+    storage.save_record.assert_not_awaited()


### PR DESCRIPTION
## Problem (F14)

In `WorkerPool.submit()`, the `self._queue.full()` pre-check runs **before** the preliminary `queued` record is saved, so only the `put_nowait` TOCTOU race path reaches the `asyncio.QueueFull` handler. That handler rewrote the already-saved record as `status="failed"` **with the idempotency key still attached** and raised queue-full, which `app.py` maps to a 503.

A 503 is the canonical "retry me" signal — but the retry with the same idempotency key hits `get_by_idempotency_key` in `app.py` and gets the dead failed job back. The job can never run under that key, which is exactly the case idempotent retry exists for.

## Fix

In the `QueueFull` handler, clear `idempotency_key` and `idempotency_fingerprint` before re-saving. `ExecutionStorage.save_record` is an upsert that overwrites all columns (`idempotency_key = EXCLUDED.idempotency_key`), so the re-save frees the key for the client's retry while keeping the failed record visible for forensics.

- The cheap `full()` pre-check is kept (rejects before any DB write).
- Both rejection paths already raise the same `RuntimeError` → 503, so client behavior is consistent.
- No changes to `app.py`, `storage.py`, `worker.py`, or `models.py`.

## Tests

- `test_submit_queue_full_race_releases_idempotency_key`: simulates the race (`full()` → False, `put_nowait` → `QueueFull`), snapshots both `save_record` calls, asserts the rewrite has `status="failed"` with key/fingerprint cleared and a `service_unavailable` error.
- `test_submit_queue_full_precheck_rejects_without_db_write`: the pre-check path rejects with no persistence.

`tests/test_queue.py`: 19 passed. `ruff check`/`format`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)