### PR TITLE
fix(cleanup): label executor containers and make orphan cleanup actually match them

### DIFF
--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -12,6 +12,16 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Label applied to every executor container at `docker run` time. Cleanup
+# (DockerCleanup.cleanup_orphaned_containers) matches on this label, so it must
+# be applied by every launch path — base_isolation_args() does this centrally.
+CONTAINER_LABEL = "tako-vm-executor"
+
+# Label key carrying the execution/job ID, so an orphaned container can be
+# mapped back to its ExecutionRecord (e.g. `docker ps --filter
+# label=tako-vm.execution-id=<id>`).
+EXECUTION_ID_LABEL = "tako-vm.execution-id"
+
 
 def is_native_linux() -> bool:
     """
@@ -85,6 +95,7 @@ def base_isolation_args(
     *,
     runtime: str,
     enable_cap_restrictions: bool = True,
+    execution_id: Optional[str] = None,
 ) -> list[str]:
     """Leading ``docker run`` args shared by every isolated-execution path.
 
@@ -105,6 +116,9 @@ def base_isolation_args(
         enable_cap_restrictions: Drop all capabilities and re-add only SETUID/
             SETGID (needed by gosu to drop to the unprivileged sandbox user).
             Can be disabled in CI where Docker can't modify capability sets.
+        execution_id: Optional execution/job ID recorded as the
+            ``tako-vm.execution-id`` label so orphaned containers can be traced
+            back to their execution records.
 
     Returns:
         The leading argument list, ready to have path-specific flags and the
@@ -115,9 +129,14 @@ def base_isolation_args(
         "run",
         "--rm",
         f"--name={container_name}",
+        # Identify the container as ours so startup cleanup can find orphans.
+        f"--label={CONTAINER_LABEL}",
         "--init",  # Faster signal handling with tini
         "--read-only",
     ]
+
+    if execution_id:
+        args.append(f"--label={EXECUTION_ID_LABEL}={execution_id}")
 
     # Capability restrictions (can be disabled in CI environments where Docker
     # can't modify capability bounding sets)

--- a/tako_vm/execution/health.py
+++ b/tako_vm/execution/health.py
@@ -11,8 +11,11 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Optional
+
+from tako_vm.execution.docker import CONTAINER_LABEL as EXECUTOR_CONTAINER_LABEL
 
 logger = logging.getLogger(__name__)
 
@@ -168,16 +171,51 @@ class DockerCircuitBreaker:
 class DockerCleanup:
     """Utilities for cleaning up Docker resources."""
 
-    CONTAINER_LABEL = "tako-vm-executor"
-    """Label used to identify Tako VM executor containers."""
+    CONTAINER_LABEL = EXECUTOR_CONTAINER_LABEL
+    """Label used to identify Tako VM executor containers (shared with docker.py,
+    where launch paths apply it via ``base_isolation_args``)."""
+
+    @staticmethod
+    def _parse_created_at(created_at: str) -> Optional[float]:
+        """Parse a ``docker ps {{.CreatedAt}}`` value into a Unix timestamp.
+
+        Docker formats it as ``2024-01-15 10:30:00 +0000 UTC``. The trailing
+        timezone *name* is dropped before parsing because ``%Z`` only accepts
+        a few well-known names; the numeric ``%z`` offset is what matters.
+
+        Returns:
+            Unix timestamp, or None if the value cannot be parsed.
+        """
+        try:
+            fields = created_at.strip().split(" ")
+            dt = datetime.strptime(" ".join(fields[:3]), "%Y-%m-%d %H:%M:%S %z")
+            return dt.timestamp()
+        except (ValueError, IndexError):
+            return None
 
     @classmethod
     def cleanup_orphaned_containers(cls, max_age_seconds: int = 3600) -> int:
         """
         Remove orphaned Tako VM executor containers.
 
+        Containers are matched by the ``tako-vm-executor`` label, which every
+        launch path applies via ``base_isolation_args`` (worker and library
+        sandbox alike). Matching is label-only by design: name-pattern filters
+        do substring matching and could sweep up unrelated user containers.
+        (Containers launched by versions that predate the label are not
+        matched — a one-time concern, accepted to keep matching unambiguous.)
+
+        This runs at server startup, so any labeled container still *running*
+        was launched by a previous (now dead) server process — its supervising
+        subprocess is gone and nothing will ever reap it. Exited/dead labeled
+        containers are removed unconditionally; running ones are only removed
+        once older than ``max_age_seconds``, as a safety guard against killing
+        in-flight work from another live Tako VM instance sharing the same
+        Docker daemon.
+
         Args:
-            max_age_seconds: Remove containers older than this age
+            max_age_seconds: Only force-remove *running* labeled containers
+                older than this age. Non-running containers are always removed.
 
         Returns:
             Number of containers removed
@@ -194,7 +232,7 @@ class DockerCleanup:
                     "--filter",
                     f"label={cls.CONTAINER_LABEL}",
                     "--format",
-                    "{{.ID}}\t{{.CreatedAt}}\t{{.Status}}",
+                    "{{.ID}}\t{{.CreatedAt}}\t{{.State}}",
                 ],
                 capture_output=True,
                 text=True,
@@ -206,29 +244,38 @@ class DockerCleanup:
                 logger.warning(f"Failed to list containers: {result.stderr}")
                 return 0
 
-            # Also find containers with our naming pattern (job-*)
-            result_pattern = subprocess.run(
-                ["docker", "ps", "-a", "--filter", "name=job-", "--format", "{{.ID}}"],
-                capture_output=True,
-                text=True,
-                timeout=30.0,
-                check=False,
-            )
+            now = time.time()
+            containers_to_remove = []
 
-            containers_to_remove = set()
-
-            # Parse labeled containers
             for line in result.stdout.strip().split("\n"):
                 if not line:
                     continue
                 parts = line.split("\t")
-                if len(parts) >= 1:
-                    containers_to_remove.add(parts[0])
+                if len(parts) < 3:
+                    continue
+                container_id, created_at, state = parts[0], parts[1], parts[2]
 
-            # Add pattern-matched containers
-            for container_id in result_pattern.stdout.strip().split("\n"):
-                if container_id:
-                    containers_to_remove.add(container_id)
+                if state in ("running", "restarting", "paused"):
+                    # Age guard: only treat live containers as orphans once
+                    # they exceed max_age_seconds. Unparseable timestamps are
+                    # skipped (fail safe: never kill a container whose age we
+                    # cannot determine).
+                    created_ts = cls._parse_created_at(created_at)
+                    if created_ts is None:
+                        logger.warning(
+                            f"Skipping running container {container_id}: "
+                            f"unparseable CreatedAt {created_at!r}"
+                        )
+                        continue
+                    age = now - created_ts
+                    if age < max_age_seconds:
+                        logger.debug(
+                            f"Skipping running container {container_id} "
+                            f"(age {age:.0f}s < {max_age_seconds}s)"
+                        )
+                        continue
+
+                containers_to_remove.append(container_id)
 
             # Remove containers
             for container_id in containers_to_remove:
@@ -318,7 +365,9 @@ def startup_cleanup() -> dict:
     results["docker_healthy"] = breaker.check_docker_health()
 
     if results["docker_healthy"]:
-        # Clean up orphaned containers
+        # Clean up orphaned executor containers: exited ones unconditionally,
+        # running ones only past the default 1h age guard (see
+        # cleanup_orphaned_containers for the rationale).
         results["containers_removed"] = DockerCleanup.cleanup_orphaned_containers()
 
     return results

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -1046,6 +1046,7 @@ class CodeExecutor:
             container_name,
             runtime=self._runtime,
             enable_cap_restrictions=self.config.enable_cap_restrictions,
+            execution_id=job_id,
         )
 
         # Mount uv cache volume for faster repeated installs

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -501,14 +501,18 @@ class Sandbox:
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako-sandbox")
 
-        # Shared isolation base: --rm/--init/--read-only, capability drops, and
-        # the gVisor --runtime flag, resolved via the shared resolver so the
+        # Shared isolation base: --rm/--init/--read-only, capability drops, the
+        # tako-vm-executor label (so startup cleanup can find orphans), and the
+        # gVisor --runtime flag, resolved via the shared resolver so the
         # library path enforces the same posture as CodeExecutor (and fails
-        # closed in strict mode when gVisor is unavailable).
+        # closed in strict mode when gVisor is unavailable). Library-mode runs
+        # have no ExecutionRecord, so the unique container name doubles as the
+        # traceability ID.
         cmd = base_isolation_args(
             container_name,
             runtime=resolve_runtime(get_config()),
             enable_cap_restrictions=self.config.enable_cap_restrictions,
+            execution_id=container_name,
         )
 
         # Network isolation

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -8,6 +8,8 @@ import subprocess
 from unittest.mock import MagicMock, patch
 
 from tako_vm.execution.docker import (
+    CONTAINER_LABEL,
+    EXECUTION_ID_LABEL,
     base_isolation_args,
     generate_container_name,
     is_native_linux,
@@ -137,14 +139,30 @@ class TestBaseIsolationArgs:
     def test_always_on_flags_present(self):
         """The fixed isolation flags are always emitted, in order."""
         args = base_isolation_args("c1", runtime="runc")
-        assert args[:6] == [
+        assert args[:7] == [
             "docker",
             "run",
             "--rm",
             "--name=c1",
+            f"--label={CONTAINER_LABEL}",
             "--init",
             "--read-only",
         ]
+
+    def test_executor_label_always_applied(self):
+        """Every container gets the executor label so cleanup can find orphans."""
+        args = base_isolation_args("c1", runtime="runc")
+        assert f"--label={CONTAINER_LABEL}" in args
+
+    def test_execution_id_label_applied_when_given(self):
+        """The execution-id label maps a container back to its execution record."""
+        args = base_isolation_args("c1", runtime="runc", execution_id="job-42")
+        assert f"--label={EXECUTION_ID_LABEL}=job-42" in args
+
+    def test_execution_id_label_omitted_when_absent(self):
+        """No execution-id label when no execution id is provided."""
+        args = base_isolation_args("c1", runtime="runc")
+        assert not any(a.startswith(f"--label={EXECUTION_ID_LABEL}") for a in args)
 
     def test_caps_dropped_by_default(self):
         """Capabilities are dropped and only SETUID/SETGID re-added by default."""

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -1,0 +1,253 @@
+"""
+Tests for orphaned-container cleanup and the executor container label.
+
+DockerCleanup.cleanup_orphaned_containers matches containers by the
+``tako-vm-executor`` label, so these tests verify both halves of the
+contract:
+
+1. Every launch path (CodeExecutor and the library Sandbox) actually applies
+   the label at ``docker run`` time via ``base_isolation_args``.
+2. Cleanup filters by the label only (no name-pattern matching), honors the
+   ``max_age_seconds`` guard for running containers, and removes exactly the
+   matched container IDs.
+
+All tests mock subprocess.run — no Docker required.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import tako_vm.execution.health as health_module
+import tako_vm.execution.worker as worker_module
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution.docker import CONTAINER_LABEL, EXECUTION_ID_LABEL
+from tako_vm.execution.health import DockerCleanup
+from tako_vm.execution.worker import CodeExecutor
+from tako_vm.job_types import JobType
+from tako_vm.sandbox import Sandbox
+
+
+def _created_at(age_seconds: float) -> str:
+    """Render a docker ps {{.CreatedAt}} value for a container of given age."""
+    dt = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    return dt.strftime("%Y-%m-%d %H:%M:%S %z") + " UTC"
+
+
+def _patch_health_subprocess(monkeypatch, ps_stdout="", ps_returncode=0):
+    """Replace subprocess.run in the health module; returns recorded argv lists."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["docker", "ps"]:
+            return SimpleNamespace(returncode=ps_returncode, stdout=ps_stdout, stderr="boom")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(health_module.subprocess, "run", fake_run)
+    return calls
+
+
+def _removed_ids(calls):
+    """Extract container IDs from recorded `docker rm -f <id>` calls."""
+    return [cmd[3] for cmd in calls if cmd[:3] == ["docker", "rm", "-f"]]
+
+
+class TestCleanupOrphanedContainers:
+    """Tests for DockerCleanup.cleanup_orphaned_containers."""
+
+    def test_filters_by_executor_label_only(self, monkeypatch):
+        """Cleanup lists containers by label; no name-pattern filter is used."""
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout="")
+
+        DockerCleanup.cleanup_orphaned_containers()
+
+        ps_calls = [cmd for cmd in calls if cmd[:2] == ["docker", "ps"]]
+        assert len(ps_calls) == 1
+        assert "--filter" in ps_calls[0]
+        assert f"label={CONTAINER_LABEL}" in ps_calls[0]
+        # The old substring name filter matched unrelated user containers.
+        assert not any("name=job-" in arg for cmd in calls for arg in cmd)
+
+    def test_label_constant_matches_launch_paths(self):
+        """health.py and docker.py must agree on the label or cleanup is a no-op."""
+        assert DockerCleanup.CONTAINER_LABEL == CONTAINER_LABEL
+
+    def test_removes_exited_and_dead_containers(self, monkeypatch):
+        """Non-running labeled containers are removed regardless of age."""
+        stdout = "\n".join(
+            [
+                f"aaa111\t{_created_at(5)}\texited",
+                f"bbb222\t{_created_at(10)}\tdead",
+                f"ccc333\t{_created_at(20)}\tcreated",
+            ]
+        )
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout=stdout)
+
+        removed = DockerCleanup.cleanup_orphaned_containers(max_age_seconds=3600)
+
+        assert removed == 3
+        assert sorted(_removed_ids(calls)) == ["aaa111", "bbb222", "ccc333"]
+
+    def test_running_container_younger_than_max_age_is_kept(self, monkeypatch):
+        """Running containers within the age guard are never force-removed."""
+        stdout = f"aaa111\t{_created_at(60)}\trunning"
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout=stdout)
+
+        removed = DockerCleanup.cleanup_orphaned_containers(max_age_seconds=3600)
+
+        assert removed == 0
+        assert _removed_ids(calls) == []
+
+    def test_running_container_older_than_max_age_is_removed(self, monkeypatch):
+        """Running containers past max_age_seconds are treated as orphans."""
+        stdout = f"aaa111\t{_created_at(7200)}\trunning"
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout=stdout)
+
+        removed = DockerCleanup.cleanup_orphaned_containers(max_age_seconds=3600)
+
+        assert removed == 1
+        assert _removed_ids(calls) == ["aaa111"]
+
+    def test_mixed_states_only_old_running_removed(self, monkeypatch):
+        """Exited always removed; running removed only past the age guard."""
+        stdout = "\n".join(
+            [
+                f"old-run\t{_created_at(7200)}\trunning",
+                f"new-run\t{_created_at(30)}\trunning",
+                f"old-exit\t{_created_at(7200)}\texited",
+                f"new-exit\t{_created_at(30)}\texited",
+            ]
+        )
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout=stdout)
+
+        removed = DockerCleanup.cleanup_orphaned_containers(max_age_seconds=3600)
+
+        assert removed == 3
+        assert sorted(_removed_ids(calls)) == ["new-exit", "old-exit", "old-run"]
+
+    def test_unparseable_created_at_skips_running_container(self, monkeypatch):
+        """Fail safe: never kill a running container whose age is unknown."""
+        stdout = "\n".join(
+            [
+                "aaa111\tgarbage timestamp\trunning",
+                "bbb222\tgarbage timestamp\texited",
+            ]
+        )
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout=stdout)
+
+        removed = DockerCleanup.cleanup_orphaned_containers(max_age_seconds=3600)
+
+        # Running with unknown age: skipped. Exited: removed regardless.
+        assert removed == 1
+        assert _removed_ids(calls) == ["bbb222"]
+
+    def test_ps_failure_returns_zero(self, monkeypatch):
+        """A failed docker ps aborts cleanup without removing anything."""
+        calls = _patch_health_subprocess(monkeypatch, ps_stdout="", ps_returncode=1)
+
+        assert DockerCleanup.cleanup_orphaned_containers() == 0
+        assert _removed_ids(calls) == []
+
+
+class TestParseCreatedAt:
+    """Tests for DockerCleanup._parse_created_at."""
+
+    def test_parses_docker_format(self):
+        """Parses the `docker ps {{.CreatedAt}}` format (offset + zone name)."""
+        ts = DockerCleanup._parse_created_at("2024-01-15 10:30:00 +0000 UTC")
+        expected = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc).timestamp()
+        assert ts == expected
+
+    def test_honors_non_utc_offset(self):
+        """The numeric offset is respected even with an unknown zone name."""
+        ts = DockerCleanup._parse_created_at("2024-01-15 19:30:00 +0900 JST")
+        expected = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc).timestamp()
+        assert ts == expected
+
+    def test_invalid_returns_none(self):
+        """Garbage input returns None instead of raising."""
+        assert DockerCleanup._parse_created_at("not a timestamp") is None
+        assert DockerCleanup._parse_created_at("") is None
+
+
+@pytest.fixture
+def executor(tmp_path, monkeypatch):
+    monkeypatch.setattr(worker_module, "_gvisor_available", True)
+    monkeypatch.setattr(
+        worker_module,
+        "get_circuit_breaker",
+        lambda: SimpleNamespace(
+            is_available=True,
+            record_success=lambda *a, **k: None,
+            record_failure=lambda *a, **k: None,
+        ),
+    )
+    config = TakoVMConfig(security_mode="permissive", data_dir=str(tmp_path / "data"))
+    return CodeExecutor(config=config)
+
+
+@pytest.fixture
+def io_dirs(tmp_path):
+    dirs = []
+    for name in ("code", "input", "output"):
+        d = tmp_path / name
+        d.mkdir()
+        dirs.append(d)
+    return dirs
+
+
+class TestWorkerAppliesLabels:
+    """CodeExecutor must label containers so startup cleanup can find them."""
+
+    def test_run_container_command_includes_labels(self, executor, io_dirs, monkeypatch):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(list(cmd))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+
+        code_dir, input_dir, output_dir = io_dirs
+        executor._run_container(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+            startup_timeout=45,
+            job_type=JobType(name="default", requirements=[]),
+            job_id="job-label-test",
+        )
+
+        run_cmds = [cmd for cmd in captured if cmd[:2] == ["docker", "run"]]
+        assert run_cmds, "expected a docker run invocation"
+        cmd = run_cmds[0]
+        assert f"--label={CONTAINER_LABEL}" in cmd
+        assert f"--label={EXECUTION_ID_LABEL}=job-label-test" in cmd
+
+
+class TestSandboxAppliesLabels:
+    """Library-mode Sandbox must label containers identically."""
+
+    def test_build_docker_command_includes_labels(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(worker_module, "_gvisor_available", True)
+
+        code_dir = tmp_path / "code"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        for d in (code_dir, input_dir, output_dir):
+            d.mkdir()
+
+        sb = Sandbox()
+        cmd, container_name = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+        )
+
+        assert f"--label={CONTAINER_LABEL}" in cmd
+        # No ExecutionRecord in library mode; the container name is the trace ID.
+        assert f"--label={EXECUTION_ID_LABEL}={container_name}" in cmd


### PR DESCRIPTION
## Problem (F6)

`DockerCleanup.cleanup_orphaned_containers` in `tako_vm/execution/health.py` was a complete no-op with a dangerous edge:

1. It filtered by `label=tako-vm-executor`, but **no launch path ever applied that label** — neither `base_isolation_args` nor the worker/sandbox `docker run` assembly contained any `--label`.
2. Its fallback `name=job-` substring filter never matched our containers (they are named `tako-{job_id}` / `tako-sandbox-*`) but **could match unrelated user containers** named `*job-*`.
3. Its `max_age_seconds` parameter was never used — anything matched was `docker rm -f`'d, including running containers, regardless of age.

Net effect: orphaned executor containers were never reclaimed, and the only thing the function could ever remove was somebody else's container.

## Fix

- **Apply the label at launch** in `base_isolation_args` (`tako_vm/execution/docker.py`) — the single shared assembly point used by both `CodeExecutor` and the library `Sandbox`, so the label cannot drift between launch paths. The constant `CONTAINER_LABEL` now lives in `docker.py` next to where it is applied; `health.py` imports it (so matcher and applier cannot disagree).
- **Traceability label**: `--label=tako-vm.execution-id=<id>` maps a container back to its `ExecutionRecord` (worker passes `job_id`; library mode has no record, so the unique container name serves as the trace ID).
- **Label-only matching** in cleanup; the `name=job-` filter is dropped entirely. Containers launched by pre-label versions won't be matched — a one-time upgrade concern, accepted to keep matching unambiguous.
- **Honor `max_age_seconds`**: exited/dead/created labeled containers are removed unconditionally; running ones only when older than the guard. Rationale: cleanup runs at server startup, so any labeled running container predates this server process and is unowned — but the age guard protects in-flight work from another live Tako VM instance sharing the same Docker daemon. Unparseable `CreatedAt` timestamps fail safe (container skipped, warning logged).

## Tests

New `tests/test_orphan_cleanup.py` (all subprocess-mocked, no Docker):
- worker `_run_container` and sandbox `_build_docker_command` emit both labels
- cleanup lists by label only (asserts no `name=job-` filter anywhere)
- age guard: young running kept, old running removed, exited always removed, mixed-state matrix
- `CreatedAt` parsing (`+0000 UTC`, non-UTC offsets with unknown zone names, garbage → None)
- `docker rm -f` targets exactly the matched IDs; `docker ps` failure aborts without removals

Updated `tests/test_docker_utils.py` for the new flag ordering and label assertions.

`pytest tests/` (docker-free): 324 passed, 145 skipped. The single failure (`test_config.py::...::test_load_config_redacts_database_password_from_errors`) is pre-existing full-suite test pollution — it fails identically on clean `origin/main` and passes in isolation on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)