### PR TITLE
fix(ci): repair main test suite — sandbox timeout errors and config test env isolation

### DIFF
--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -433,6 +433,14 @@ class Sandbox:
                     except json.JSONDecodeError:
                         pass
 
+                # The in-container timeout (TAKO_EXECUTION_TIMEOUT, enforced by
+                # entrypoint.sh via timeout(1)) exits 124 when the code exceeds
+                # its budget, so most timeouts return here rather than through
+                # the TimeoutExpired backstop below. Surface them as timeouts.
+                error = None
+                if proc.returncode == 124:
+                    error = f"Execution timed out after {timeout}s"
+
                 return SandboxResult(
                     stdout=proc.stdout,
                     stderr=proc.stderr,
@@ -440,6 +448,7 @@ class Sandbox:
                     success=proc.returncode == 0,
                     output=output_data,
                     duration_ms=duration_ms,
+                    error=error,
                 )
 
             except subprocess.TimeoutExpired as exc:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,8 +26,15 @@ from tako_vm.config import (
 
 
 @pytest.fixture(autouse=True)
-def reset_config_fixture():
-    """Reset config before and after each test."""
+def reset_config_fixture(monkeypatch):
+    """Reset config and scrub config env overrides before and after each test.
+
+    Other test modules legitimately mutate process env (e.g. the CLI's managed
+    postgres helper sets TAKO_VM_DATABASE_URL); if those leak in, load_config's
+    env override layer silently replaces values under test.
+    """
+    for var in ("TAKO_VM_CONFIG", "TAKO_VM_DATABASE_URL", "TAKO_VM_SECURITY_MODE"):
+        monkeypatch.delenv(var, raising=False)
     reset_config()
     yield
     reset_config()


### PR DESCRIPTION
Main CI has been red since #67/#68 merged: PR-level CI ran on bases that predated sibling merges, so two interaction regressions only surfaced on main pushes.

**Sandbox timeout reporting (#68 interaction):** with in-container timeouts now enforced via TAKO_EXECUTION_TIMEOUT, timed-out code exits 124 through the normal subprocess path before the parent TimeoutExpired backstop fires — `SandboxResult.error` stayed `None`, failing `TestSandboxTimeout`. Exit 124 now surfaces `Execution timed out after {timeout}s`.

**Config test env isolation (#65/#67 interaction):** `_ensure_managed_postgres` exports `TAKO_VM_DATABASE_URL` process-wide; CLI tests leak it, and `load_config`'s env override layer then replaces the invalid URL under test in `test_load_config_redacts_database_password_from_errors` (DID NOT RAISE). Config tests now scrub `TAKO_VM_CONFIG`/`TAKO_VM_DATABASE_URL`/`TAKO_VM_SECURITY_MODE` via an autouse fixture.

Verified: `tests/test_cli.py tests/test_config.py` together (the failing order) → 106 passed; full docker-free suite → 309 passed, 145 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)