### PR TITLE
fix(storage): protect submission fields and terminal status in upsert; retry transient save failures

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -527,13 +527,18 @@ class CodeExecutor:
         input_data = job.get("input_data", {})
 
         job_type_name = job.get("job_type") or "default"
+        # created_at/queued_at are intentionally left to the model defaults
+        # (now): the executor runs at execution start and does not know the
+        # true submission timestamps. For async jobs, queue.submit() already
+        # persisted them, and storage.save_record's upsert preserves the
+        # existing row's submission-identity fields (created_at, queued_at,
+        # dequeued_at set by mark_record_running, idempotency fields, ...), so
+        # this record's values only matter for the fresh-insert (sync) path.
         record = ExecutionRecord(
             execution_id=job_id,
             status="queued",
             job_type=job_type_name,
             job_ref=f"{job_type_name}@latest",
-            created_at=datetime.now(timezone.utc),
-            queued_at=datetime.now(timezone.utc),
             code_hash=sha256_content(code),
             input_hash=sha256_json(input_data),
             client_ip=client_ip,

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -10,6 +10,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, List, Mapping, Optional, cast
 
+import psycopg
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 from psycopg_pool import AsyncConnectionPool
@@ -29,6 +30,15 @@ logger = logging.getLogger(__name__)
 
 MIGRATION_LOCK_ID = 94857231
 RowMapping = Mapping[str, Any]
+
+# Statuses from which an execution record must never transition away. Once a
+# record is terminal, later writes (e.g. a stale executor result racing a
+# cancellation, or vice versa) are refused by the save_record upsert guard.
+TERMINAL_STATUSES = ("succeeded", "failed", "timeout", "oom", "cancelled")
+
+# Backoff schedule (seconds) for retrying save_record on transient connection
+# errors. Tests may monkeypatch this to avoid real sleeps.
+_SAVE_RECORD_RETRY_DELAYS = (0.2, 0.8, 2.0)
 
 # Minimum digest prefix length accepted by get_version_by_digest. Shorter
 # prefixes are too ambiguous to resolve safely (and an empty prefix would
@@ -241,7 +251,53 @@ class ExecutionStorage:
                 await conn.execute("SELECT pg_advisory_unlock(%s)", (MIGRATION_LOCK_ID,))
 
     async def save_record(self, record: ExecutionRecord) -> None:
-        """Insert or update execution record."""
+        """
+        Insert or update execution record.
+
+        Durability behavior:
+        - Transient connection errors (psycopg.OperationalError, which includes
+          psycopg_pool.PoolTimeout) are retried with backoff so a brief DB blip
+          cannot lose the record of code that already ran. Non-transient errors
+          (e.g. IntegrityError) are raised immediately.
+        - The upsert refuses to modify a record that is already in a terminal
+          status (see TERMINAL_STATUSES); such writes are logged and dropped.
+        """
+        attempts = len(_SAVE_RECORD_RETRY_DELAYS) + 1
+        for attempt in range(attempts):
+            try:
+                rowcount = await self._save_record_once(record)
+                break
+            except psycopg.OperationalError as e:
+                # Connection-level failure (includes psycopg_pool.PoolTimeout,
+                # which subclasses OperationalError). Retry with backoff;
+                # IntegrityError and friends derive from DatabaseError instead
+                # and propagate immediately.
+                if attempt >= attempts - 1:
+                    raise
+                delay = _SAVE_RECORD_RETRY_DELAYS[attempt]
+                logger.warning(
+                    "Transient error saving execution record %s (attempt %d/%d), "
+                    "retrying in %.1fs: %s",
+                    record.execution_id,
+                    attempt + 1,
+                    attempts,
+                    delay,
+                    e,
+                )
+                await asyncio.sleep(delay)
+
+        if rowcount == 0:
+            # The ON CONFLICT ... WHERE guard skipped the update: the existing
+            # row is already terminal and must not be regressed (e.g. a
+            # cancel/complete race).
+            logger.warning(
+                "Refused to overwrite terminal execution record %s with status %s",
+                record.execution_id,
+                record.status,
+            )
+
+    async def _save_record_once(self, record: ExecutionRecord) -> int:
+        """Execute the upsert once; return affected rowcount (0 = guard skip)."""
         resource_usage = record.resource_usage
         artifacts_json = [a.model_dump() for a in record.artifacts]
         input_artifacts_json = [a.model_dump() for a in record.input_artifacts]
@@ -249,10 +305,34 @@ class ExecutionStorage:
         result_json = record.result_json
         timing_json = record.timing.model_dump() if record.timing else None
 
+        terminal_list = ", ".join(f"'{s}'" for s in TERMINAL_STATUSES)
+
+        # Upsert column policy:
+        # - Submission-identity fields (created_at, queued_at, code_hash,
+        #   input_hash, params_hash, input_artifacts_hash, client_ip,
+        #   idempotency_key, idempotency_fingerprint, parent_execution_id,
+        #   relationship) describe WHEN/HOW the job was submitted. They are
+        #   written by queue.submit() and must survive later writes from the
+        #   executor, which rebuilds its record at execution start and does not
+        #   know the true submission timestamps. We keep the existing row's
+        #   value (COALESCE(existing, new) for nullables; plain existing for
+        #   NOT NULL created_at/queued_at, where COALESCE degenerates to the
+        #   existing value anyway).
+        # - dequeued_at is set once by mark_record_running(); COALESCE keeps it.
+        # - worker_id is also set by mark_record_running(); prefer the new
+        #   value when the writer knows it, otherwise keep the existing one.
+        # - Execution-outcome fields (status, started_at, ended_at,
+        #   duration_ms, attempt, exit_code, stdout/stderr, result/timing/
+        #   artifacts/error JSON, resource usage) take EXCLUDED: later writes
+        #   know more about the outcome. input_artifacts_json also takes
+        #   EXCLUDED because the executor enriches it with replay artifacts
+        #   that the preliminary queued record does not have.
+        # - The WHERE guard makes the whole update a no-op when the existing
+        #   row is already terminal, so terminal status can never regress.
         pool = self._get_pool()
         async with pool.connection() as conn:
-            await conn.execute(
-                """
+            cursor = await conn.execute(
+                f"""
                 INSERT INTO execution_records (
                     execution_id, status, job_type, job_ref,
                     created_at, queued_at, dequeued_at, started_at, ended_at, duration_ms,
@@ -274,21 +354,28 @@ class ExecutionStorage:
                     status = EXCLUDED.status,
                     job_type = EXCLUDED.job_type,
                     job_ref = EXCLUDED.job_ref,
-                    created_at = EXCLUDED.created_at,
-                    queued_at = EXCLUDED.queued_at,
-                    dequeued_at = EXCLUDED.dequeued_at,
+                    created_at = execution_records.created_at,
+                    queued_at = COALESCE(execution_records.queued_at, EXCLUDED.queued_at),
+                    dequeued_at = COALESCE(execution_records.dequeued_at, EXCLUDED.dequeued_at),
                     started_at = EXCLUDED.started_at,
                     ended_at = EXCLUDED.ended_at,
                     duration_ms = EXCLUDED.duration_ms,
                     attempt = EXCLUDED.attempt,
                     max_attempts = EXCLUDED.max_attempts,
-                    worker_id = EXCLUDED.worker_id,
-                    idempotency_key = EXCLUDED.idempotency_key,
-                    idempotency_fingerprint = EXCLUDED.idempotency_fingerprint,
-                    code_hash = EXCLUDED.code_hash,
-                    input_hash = EXCLUDED.input_hash,
-                    params_hash = EXCLUDED.params_hash,
-                    input_artifacts_hash = EXCLUDED.input_artifacts_hash,
+                    worker_id = COALESCE(EXCLUDED.worker_id, execution_records.worker_id),
+                    idempotency_key =
+                        COALESCE(execution_records.idempotency_key, EXCLUDED.idempotency_key),
+                    idempotency_fingerprint = COALESCE(
+                        execution_records.idempotency_fingerprint,
+                        EXCLUDED.idempotency_fingerprint
+                    ),
+                    code_hash = COALESCE(execution_records.code_hash, EXCLUDED.code_hash),
+                    input_hash = COALESCE(execution_records.input_hash, EXCLUDED.input_hash),
+                    params_hash = COALESCE(execution_records.params_hash, EXCLUDED.params_hash),
+                    input_artifacts_hash = COALESCE(
+                        execution_records.input_artifacts_hash,
+                        EXCLUDED.input_artifacts_hash
+                    ),
                     input_artifacts_json = EXCLUDED.input_artifacts_json,
                     exit_code = EXCLUDED.exit_code,
                     stdout = EXCLUDED.stdout,
@@ -302,9 +389,14 @@ class ExecutionStorage:
                     timing_json = EXCLUDED.timing_json,
                     artifacts_json = EXCLUDED.artifacts_json,
                     error_json = EXCLUDED.error_json,
-                    client_ip = EXCLUDED.client_ip,
-                    parent_execution_id = EXCLUDED.parent_execution_id,
-                    relationship = EXCLUDED.relationship
+                    client_ip = COALESCE(execution_records.client_ip, EXCLUDED.client_ip),
+                    parent_execution_id = COALESCE(
+                        execution_records.parent_execution_id,
+                        EXCLUDED.parent_execution_id
+                    ),
+                    relationship =
+                        COALESCE(execution_records.relationship, EXCLUDED.relationship)
+                WHERE execution_records.status NOT IN ({terminal_list})
                 """,
                 (
                     record.execution_id,
@@ -344,6 +436,7 @@ class ExecutionStorage:
                     record.relationship,
                 ),
             )
+            return cursor.rowcount
 
     async def get_record(self, execution_id: str) -> Optional[ExecutionRecord]:
         """Retrieve execution record by ID."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -776,3 +776,206 @@ class TestDigestResolutionStrictness:
         retrieved = storage.get_version_by_digest("digest-job", shared_prefix + "a" * 52)
         assert retrieved is not None
         assert retrieved.version_tag == "v1"
+
+
+class TestSaveRecordUpsertIntegrity:
+    """save_record upsert must preserve submission fields and terminal status."""
+
+    @staticmethod
+    def _make_record(execution_id: str, status: str, **kwargs) -> ExecutionRecord:
+        kwargs.setdefault("code_hash", "a" * 64)
+        kwargs.setdefault("input_hash", "b" * 64)
+        return ExecutionRecord(execution_id=execution_id, status=status, **kwargs)
+
+    def test_resave_preserves_submission_fields(self, storage):
+        """A later save with fresh timestamps/hashes keeps the original
+        submission-identity fields while still updating outcome fields."""
+        original_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+        storage.save_record(
+            self._make_record(
+                "upsert-submission",
+                "queued",
+                created_at=original_time,
+                queued_at=original_time,
+                client_ip="10.0.0.1",
+                idempotency_key="idem-upsert-1",
+                idempotency_fingerprint="f" * 64,
+                parent_execution_id="parent-1",
+            )
+        )
+
+        # Simulates the executor rebuilding a record at execution start with
+        # now() timestamps and freshly computed hashes.
+        storage.save_record(
+            self._make_record(
+                "upsert-submission",
+                "succeeded",
+                created_at=datetime.now(timezone.utc),
+                queued_at=datetime.now(timezone.utc),
+                code_hash="c" * 64,
+                input_hash="d" * 64,
+                stdout="done",
+                exit_code=0,
+            )
+        )
+
+        retrieved = storage.get_record("upsert-submission")
+        # Outcome fields updated
+        assert retrieved.status == "succeeded"
+        assert retrieved.stdout == "done"
+        assert retrieved.exit_code == 0
+        # Submission-identity fields preserved from the original row
+        assert retrieved.created_at == original_time
+        assert retrieved.queued_at == original_time
+        assert retrieved.code_hash == "a" * 64
+        assert retrieved.input_hash == "b" * 64
+        assert retrieved.client_ip == "10.0.0.1"
+        assert retrieved.idempotency_key == "idem-upsert-1"
+        assert retrieved.idempotency_fingerprint == "f" * 64
+        assert retrieved.parent_execution_id == "parent-1"
+
+    def test_dequeued_at_and_worker_id_survive_final_save(self, storage):
+        """dequeued_at/worker_id written by mark_record_running survive the
+        executor's final save, which does not know them."""
+        storage.save_record(self._make_record("upsert-dequeue", "queued"))
+        assert storage.mark_record_running("upsert-dequeue", worker_id="worker-7")
+        intermediate = storage.get_record("upsert-dequeue")
+        assert intermediate.dequeued_at is not None
+
+        storage.save_record(self._make_record("upsert-dequeue", "succeeded", stdout="ok"))
+
+        retrieved = storage.get_record("upsert-dequeue")
+        assert retrieved.status == "succeeded"
+        assert retrieved.stdout == "ok"
+        assert retrieved.dequeued_at == intermediate.dequeued_at
+        assert retrieved.worker_id == "worker-7"
+
+    def test_terminal_record_not_overwritten(self, storage, caplog):
+        """A terminal (succeeded) record is not regressed by a stale write
+        (e.g. a cancel/complete race); save_record logs and returns."""
+        import logging
+
+        storage.save_record(self._make_record("upsert-terminal", "succeeded", stdout="ok"))
+
+        with caplog.at_level(logging.WARNING, logger="tako_vm.storage"):
+            storage.save_record(self._make_record("upsert-terminal", "cancelled"))
+
+        retrieved = storage.get_record("upsert-terminal")
+        assert retrieved.status == "succeeded"
+        assert retrieved.stdout == "ok"
+        assert any("Refused to overwrite terminal" in m for m in caplog.messages)
+
+    def test_non_terminal_to_terminal_transition_allowed(self, storage):
+        """queued/running records can still transition to a terminal status."""
+        storage.save_record(self._make_record("upsert-transition", "queued"))
+        storage.save_record(self._make_record("upsert-transition", "running"))
+        storage.save_record(self._make_record("upsert-transition", "failed", stderr="boom"))
+
+        retrieved = storage.get_record("upsert-transition")
+        assert retrieved.status == "failed"
+        assert retrieved.stderr == "boom"
+
+
+class TestSaveRecordRetry:
+    """save_record retries transient connection errors with backoff."""
+
+    @staticmethod
+    def _fake_pool(attempts: dict, failures: int, exc_factory):
+        """Pool whose connection() raises for the first `failures` attempts."""
+
+        class FakeCursor:
+            rowcount = 1
+
+        class FakeConn:
+            async def execute(self, *args, **kwargs):
+                return FakeCursor()
+
+        class FakeConnCtx:
+            async def __aenter__(self):
+                attempts["n"] += 1
+                if attempts["n"] <= failures:
+                    raise exc_factory()
+                return FakeConn()
+
+            async def __aexit__(self, *exc_info):
+                return False
+
+        class FakePool:
+            def connection(self):
+                return FakeConnCtx()
+
+        return FakePool()
+
+    @staticmethod
+    def _record() -> ExecutionRecord:
+        return ExecutionRecord(
+            execution_id="retry-test",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+        )
+
+    def test_transient_error_retried_then_succeeds(self, monkeypatch, caplog):
+        """Two OperationalErrors then success: record saved, two warnings."""
+        import logging
+
+        import psycopg
+
+        from tako_vm import storage as storage_module
+
+        store = ExecutionStorage("postgresql://unused")
+        attempts = {"n": 0}
+        monkeypatch.setattr(
+            store,
+            "_get_pool",
+            lambda: self._fake_pool(
+                attempts, 2, lambda: psycopg.OperationalError("connection refused")
+            ),
+        )
+        monkeypatch.setattr(storage_module, "_SAVE_RECORD_RETRY_DELAYS", (0, 0, 0))
+
+        with caplog.at_level(logging.WARNING, logger="tako_vm.storage"):
+            asyncio.run(store.save_record(self._record()))
+
+        assert attempts["n"] == 3
+        retry_warnings = [m for m in caplog.messages if "Transient error saving" in m]
+        assert len(retry_warnings) == 2
+
+    def test_persistent_transient_error_raises(self, monkeypatch):
+        """OperationalError on every attempt eventually propagates."""
+        import psycopg
+
+        from tako_vm import storage as storage_module
+
+        store = ExecutionStorage("postgresql://unused")
+        attempts = {"n": 0}
+        monkeypatch.setattr(
+            store,
+            "_get_pool",
+            lambda: self._fake_pool(
+                attempts, 100, lambda: psycopg.OperationalError("connection refused")
+            ),
+        )
+        monkeypatch.setattr(storage_module, "_SAVE_RECORD_RETRY_DELAYS", (0, 0, 0))
+
+        with pytest.raises(psycopg.OperationalError):
+            asyncio.run(store.save_record(self._record()))
+
+        assert attempts["n"] == len(storage_module._SAVE_RECORD_RETRY_DELAYS) + 1
+
+    def test_non_transient_error_not_retried(self, monkeypatch):
+        """IntegrityError (non-connection) propagates immediately, no retry."""
+        import psycopg
+
+        store = ExecutionStorage("postgresql://unused")
+        attempts = {"n": 0}
+        monkeypatch.setattr(
+            store,
+            "_get_pool",
+            lambda: self._fake_pool(attempts, 100, lambda: psycopg.IntegrityError("duplicate key")),
+        )
+
+        with pytest.raises(psycopg.IntegrityError):
+            asyncio.run(store.save_record(self._record()))
+
+        assert attempts["n"] == 1


### PR DESCRIPTION
## Summary

Fixes three verified durability bugs in execution-record persistence (F10b, F10a, F9).

### F10b — upsert clobbered submission timestamps
`CodeExecutor.execute_job_with_record` rebuilds its `ExecutionRecord` at execution start with fresh `created_at`/`queued_at`, and `save_record`'s `ON CONFLICT DO UPDATE` blindly took `EXCLUDED` values — overwriting the true submission timestamps written by `queue.submit()`. Consequences: `created_at` changed between polls, queue wait time was unrecoverable, and `/executions` ordering reflected execution order instead of submission order.

**Fix:** the upsert now follows an explicit column policy (documented inline):
- **Submission-identity fields** keep the existing row's value: `created_at` (plain existing), and `COALESCE(existing, EXCLUDED)` for `queued_at`, `code_hash`, `input_hash`, `params_hash`, `input_artifacts_hash`, `client_ip`, `idempotency_key`, `idempotency_fingerprint`, `parent_execution_id`, `relationship`.
- `dequeued_at` uses `COALESCE(existing, EXCLUDED)` and `worker_id` uses `COALESCE(EXCLUDED, existing)` so values set by `mark_record_running()` survive the executor's final save.
- **Execution-outcome fields** (`status`, `started_at`, `ended_at`, `duration_ms`, `exit_code`, stdout/stderr, result/timing/artifacts/error JSON, resource usage) still take `EXCLUDED`.

The executor no longer fabricates `created_at`/`queued_at` (model defaults apply; they only matter on the fresh-insert sync path).

### F10a — terminal status could regress
A stale write could regress a terminal record (e.g. `succeeded` → `cancelled` via a cancel/complete race). The `DO UPDATE` now carries `WHERE execution_records.status NOT IN ('succeeded','failed','timeout','oom','cancelled')`, making the update a no-op for terminal rows. `save_record` detects the skipped update via `rowcount == 0` and logs a warning. Targeted UPDATEs (`reconcile_stale_records`, `mark_record_running`) have their own WHERE clauses and are unaffected.

### F9 — no retry on transient DB errors
After code already ran, a brief connection blip could lose the record entirely. `save_record` now retries up to 3 times with 0.2/0.8/2s backoff on `psycopg.OperationalError` (which `psycopg_pool.PoolTimeout` subclasses), logging each retry at warning. Non-transient errors (e.g. `IntegrityError`, used by the idempotency unique index) propagate immediately with no retry.

## Tests

Appended to `tests/test_storage.py`:
- re-save with fresh timestamps/hashes preserves submission-identity fields while updating status/stdout/exit_code
- `dequeued_at`/`worker_id` from `mark_record_running` survive the final save
- terminal (`succeeded`) record is not overwritten by a later `cancelled` save; warning logged
- non-terminal → terminal transition still works
- retry: two `OperationalError`s then success → saved with 2 warnings; persistent failure raises after all attempts; `IntegrityError` not retried (mock-based, no postgres needed)

## Verification

- `ruff check` / `ruff format`: clean
- `py_compile` on all touched files: clean
- Mock-based retry tests + `tests/test_models.py`, `tests/test_security.py`, `tests/test_worker_errors.py`: 85 passed locally
- Postgres-backed tests rely on the CI postgres:16 service (no local postgres available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)