### PR TITLE
fix(security): container-id sanitizer boundary and error classification ordering

### DIFF
--- a/tako_vm/security.py
+++ b/tako_vm/security.py
@@ -28,10 +28,26 @@ SANITIZE_PATTERNS: List[Tuple[str, str]] = [
     (r"172\.\d+\.\d+\.\d+", "172.***.***"),
     (r"10\.\d+\.\d+\.\d+", "10.***.***"),
     (r"192\.168\.\d+\.\d+", "192.168.***.***"),
-    # Docker container IDs
-    (r"[a-f0-9]{64}", "<container-id>"),
-    (r"[a-f0-9]{12}(?![a-f0-9])", "<container-id>"),
+    # Docker container IDs. Boundaries on both sides ensure we never rewrite a
+    # fragment of a longer hex run (git SHA-1s, sha256 digests, UUID hex).
+    (r"(?<![a-f0-9])[a-f0-9]{64}(?![a-f0-9])", "<container-id>"),
+    # Short (12-char) container IDs. The (?=[0-9]*[a-f]) lookahead requires at
+    # least one a-f letter so plain 12-digit numbers (timestamps, account IDs)
+    # are left intact. Theoretical false negative: an all-digit short container
+    # ID (~0.4% of IDs) will not be redacted.
+    (r"(?<![a-f0-9])(?=[0-9]*[a-f])[a-f0-9]{12}(?![a-f0-9])", "<container-id>"),
 ]
+
+# Known kernel/shell/docker phrasings for a SIGKILL-ed process. Deliberately
+# narrower than a bare "killed" substring so ordinary program output that
+# happens to contain the word "killed" is not misclassified.
+_KILLED_PATTERN = re.compile(
+    r"\boom-?kill(?:ed|er)\b"  # docker "OOMKilled" state / kernel "oom-killer"
+    r"|\bprocess killed\b"
+    r"|^\s*killed\b"  # shell prints "Killed" at the start of a line
+    r"|\bline \d+:\s*\d+ killed\b",  # bash job control: "sh: line 1: 42 Killed ..."
+    re.MULTILINE,
+)
 
 # Default limits
 DEFAULT_MAX_STDOUT_BYTES = 65536  # 64KB
@@ -207,8 +223,9 @@ def classify_error(exit_code: int, stderr: str, timed_out: bool = False) -> Tupl
     if "cannot allocate memory" in stderr_lower:
         return "oom", "Cannot allocate memory"
 
-    # Process termination
-    if "killed" in stderr_lower:
+    # Process termination. Match only known kernel/shell/docker phrasings, not
+    # the bare word "killed", which can appear in ordinary program output.
+    if _KILLED_PATTERN.search(stderr_lower):
         return "killed", "Process was killed by system"
 
     # Permission errors
@@ -224,19 +241,6 @@ def classify_error(exit_code: int, stderr: str, timed_out: bool = False) -> Tupl
 
     if "indentationerror" in stderr_lower:
         return "syntax_error", sanitize_error(stderr[:200] if stderr else "Indentation error")
-
-    # Dependency installation errors (uv/pip failures)
-    if "no matching distribution" in stderr_lower or "could not find" in stderr_lower:
-        return "dependency_error", "Failed to install required package (not found)"
-
-    if "error: externally-managed-environment" in stderr_lower:
-        return "dependency_error", "Package installation failed (environment issue)"
-
-    if "failed to download" in stderr_lower or "failed to fetch" in stderr_lower:
-        return "dependency_error", "Failed to download package (network issue)"
-
-    if "resolving dependencies" in stderr_lower and "conflict" in stderr_lower:
-        return "dependency_error", "Package dependency conflict"
 
     # Import errors
     if "importerror" in stderr_lower or "modulenotfounderror" in stderr_lower:
@@ -315,6 +319,24 @@ def classify_error(exit_code: int, stderr: str, timed_out: bool = False) -> Tupl
 
     if "timeouterror" in stderr_lower:
         return "network_timeout", "Network request timed out"
+
+    # Dependency installation errors (uv/pip failures). Checked after the
+    # Python-exception-name patterns above: these generic installer phrasings
+    # ("could not find ...", "failed to download ...") can also appear inside
+    # the message text of an ordinary runtime exception (e.g.
+    # "FileNotFoundError: could not find config file"), and the named
+    # exception is the more specific signal.
+    if "no matching distribution" in stderr_lower or "could not find a version" in stderr_lower:
+        return "dependency_error", "Failed to install required package (not found)"
+
+    if "error: externally-managed-environment" in stderr_lower:
+        return "dependency_error", "Package installation failed (environment issue)"
+
+    if "failed to download" in stderr_lower or "failed to fetch" in stderr_lower:
+        return "dependency_error", "Failed to download package (network issue)"
+
+    if "resolving dependencies" in stderr_lower and "conflict" in stderr_lower:
+        return "dependency_error", "Package dependency conflict"
 
     # Docker/container specific
     if "docker" in stderr_lower and "not found" in stderr_lower:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -10,10 +10,90 @@ from tako_vm.constants import UV_CACHE_VOLUME
 from tako_vm.execution import CodeExecutor
 from tako_vm.job_types import JobType
 from tako_vm.security import (
+    classify_error,
+    sanitize_error,
     validate_docker_run_args,
     validate_execution_id,
     validate_pip_requirement,
 )
+
+
+class TestSanitizeError:
+    def test_replaces_standalone_short_container_id(self):
+        result = sanitize_error("Error in container 4e5021d210f6: exited")
+        assert result == "Error in container <container-id>: exited"
+
+    def test_replaces_full_container_id(self):
+        full_id = "a" * 32 + "1" * 32
+        result = sanitize_error(f"container {full_id} failed")
+        assert result == "container <container-id> failed"
+
+    def test_leaves_40_char_sha_intact(self):
+        sha = "2c796c3f410f0396ba541855b8421d210f6a9e7b"
+        assert sanitize_error(f"commit {sha} not found") == f"commit {sha} not found"
+
+    def test_leaves_13_char_hex_intact(self):
+        token = "4e5021d210f6a"
+        assert sanitize_error(f"token {token} invalid") == f"token {token} invalid"
+
+    def test_leaves_32_char_uuid_hex_intact(self):
+        uuid_hex = "550e8400e29b41d4a716446655440000"
+        assert sanitize_error(f"id {uuid_hex} missing") == f"id {uuid_hex} missing"
+
+    def test_leaves_plain_12_digit_number_intact(self):
+        assert (
+            sanitize_error("timestamp 170000000000 is stale") == "timestamp 170000000000 is stale"
+        )
+
+    def test_empty_input(self):
+        assert sanitize_error("") == ""
+
+
+class TestClassifyError:
+    def test_filenotfounderror_with_could_not_find_is_not_dependency_error(self):
+        error_type, message = classify_error(1, "FileNotFoundError: could not find config file")
+        assert error_type == "file_not_found"
+        assert "config file" in message
+
+    def test_genuine_pip_resolution_failure_is_dependency_error(self):
+        error_type, _ = classify_error(
+            1, "ERROR: Could not find a version that satisfies the requirement nopkg"
+        )
+        assert error_type == "dependency_error"
+
+    def test_no_matching_distribution_is_dependency_error(self):
+        error_type, _ = classify_error(1, "ERROR: No matching distribution found for nopkg")
+        assert error_type == "dependency_error"
+
+    def test_user_output_containing_killed_is_not_killed(self):
+        error_type, _ = classify_error(1, "ValueError: the job was killed by the user")
+        assert error_type == "value_error"
+
+    def test_shell_killed_line_is_killed(self):
+        error_type, _ = classify_error(
+            1, "sh: line 1:    42 Killed                  python3 code.py"
+        )
+        assert error_type == "killed"
+
+    def test_bare_killed_line_is_killed(self):
+        error_type, _ = classify_error(1, "Killed\n")
+        assert error_type == "killed"
+
+    def test_oom_killed_is_killed(self):
+        error_type, _ = classify_error(1, "container was OOMKilled")
+        assert error_type == "killed"
+
+    def test_sigkill_exit_code_is_oom(self):
+        error_type, _ = classify_error(137, "")
+        assert error_type == "oom"
+
+    def test_timeout_flag_wins(self):
+        error_type, _ = classify_error(1, "MemoryError", timed_out=True)
+        assert error_type == "timeout"
+
+    def test_generic_nonzero_exit_is_runtime_error(self):
+        error_type, _ = classify_error(2, "something unexpected happened")
+        assert error_type == "runtime_error"
 
 
 class TestValidateExecutionId:


### PR DESCRIPTION
## Summary

Fixes two verified bugs in `tako_vm/security.py` (F13e, F13b). Touches only `tako_vm/security.py` and `tests/test_security.py`.

### F13e — `sanitize_error` container-id regex corrupted longer hex runs

The 12-char pattern `[a-f0-9]{12}(?![a-f0-9])` had a right lookahead but no left boundary, so:

- Any longer hex run (git SHA-1, sha256 digest, 32-char UUID hex) had its **last 12 chars** rewritten to `<container-id>` (a 13-char token became `a<container-id>`).
- Any plain 12-digit number (timestamps, account IDs) was redacted outright.

Fix: both container-id patterns (64-char and 12-char) now require non-hex on both sides (`(?<![a-f0-9])` ... `(?![a-f0-9])`). The short-id pattern additionally requires at least one `a-f` letter via `(?=[0-9]*[a-f])` so standalone 12-digit numbers are never touched.

**Documented trade-off:** an all-digit 12-char short container ID (~0.4% of IDs, since each hex char is a digit with p=10/16) is no longer redacted. We chose this over corrupting common 12-digit numbers in error messages. Full 64-char IDs are unaffected.

### F13b — `classify_error` ordering misclassified runtime errors as dependency errors

`"could not find"` (dependency_error) was checked before `filenotfounderror`, so `FileNotFoundError: could not find config file` was reported as "Failed to install required package (not found)". Fixes:

- Dependency-installer phrase checks moved **after** the Python exception-name checks (the named exception is the more specific signal; uv/pip installer output never contains Python exception names).
- `"could not find"` tightened to the pip resolver phrasing `"could not find a version"` (still paired with `"no matching distribution"`), so runtime exceptions whose message contains "could not find ..." no longer match.
- The bare `"killed"` substring check (which fired on *any* stderr containing the word, e.g. `ValueError: the job was killed by the user`) is tightened to known kernel/shell/docker phrasings: `OOMKilled`/`oom-killer`, `process killed`, a bare `Killed` line, and the bash job-control line (`sh: line 1: 42 Killed ...`).

### Known limitation (out of scope, not fixed here)

`classify_error` fundamentally reads **attacker-controlled stderr**: sandboxed code can print `MemoryError` and be classified `oom`, etc. A structural fix (trusting only exit codes / docker state) is out of scope for this PR; only the deterministic misclassification bugs are fixed. **Downstream consumers must not treat `error_type` as a security signal.**

Note: the truncation-flag fix (F13d) in `worker.py` is handled in a separate in-flight PR; this PR deliberately does not touch `worker.py`.

## Tests

New tests in `tests/test_security.py`:
- `sanitize_error`: 40-char SHA / 13-char hex / 32-char UUID hex / 12-digit number left intact; genuine 12-char and 64-char container IDs still redacted.
- `classify_error`: `FileNotFoundError: could not find config file` → `file_not_found`; genuine pip resolution failures still `dependency_error`; user output containing "killed" no longer `killed`; shell/OOM kill phrasings still `killed`; exit-code/timeout precedence preserved.

`uv run --extra all --extra dev pytest tests/test_security.py -q` → 58 passed. Also ran `tests/test_worker_errors.py` and `tests/test_models.py` (41 passed). ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)