### PR TITLE
fix(ci): actually run postgres-backed tests in CI and fail loudly when the DB is unreachable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           TAKO_VM_ENABLE_SECCOMP: "false"  # Custom seccomp profiles block container init in GitHub Actions
           TAKO_VM_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tako_vm_test
         run: |
-          pytest tests/ -v --timeout=120 \
+          pytest tests/ -v -ra --timeout=120 \
             --cov=tako_vm \
             --cov-report=xml \
             --cov-report=term-missing \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,22 @@ def is_gvisor_available() -> bool:
         return False
 
 
+# Capture the test database URL once at import time, BEFORE any test runs.
+# Some tests exercise code that mutates os.environ["TAKO_VM_DATABASE_URL"]
+# directly (e.g. the CLI dev helpers point it at the managed postgres on
+# port 55432). Reading the env lazily inside fixtures let that pollution
+# redirect every later storage test at a dead DSN, silently skipping the
+# whole storage suite in CI.
+TEST_DATABASE_URL = os.environ.get(
+    "TAKO_VM_DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/tako_vm_test"
+)
+
+
+def is_running_in_ci() -> bool:
+    """Detect CI environments (GitHub Actions sets both of these)."""
+    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
+
+
 # Check Docker availability once at module load
 DOCKER_AVAILABLE = is_docker_available()
 EXECUTOR_IMAGE_AVAILABLE = is_executor_image_available()
@@ -213,9 +229,7 @@ def temp_data_dir():
         original_db_url = os.environ.get("TAKO_VM_DATABASE_URL")
         schema_created = False
 
-        raw_db_url = os.environ.get(
-            "TAKO_VM_DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/tako_vm_test"
-        )
+        raw_db_url = TEST_DATABASE_URL
         schema = f"test_{uuid.uuid4().hex}"
 
         raw_parts = urlsplit(raw_db_url)
@@ -247,6 +261,13 @@ def temp_data_dir():
                     )
                     schema_created = True
         except psycopg.Error as exc:
+            if is_running_in_ci():
+                pytest.fail(
+                    f"PostgreSQL is required in CI but connecting to {base_db_url} failed: "
+                    f"{exc}. Check the postgres service container and TAKO_VM_DATABASE_URL "
+                    "in .github/workflows/test.yml. Storage tests must never silently skip "
+                    "in CI."
+                )
             pytest.skip(f"PostgreSQL test database unavailable: {exc}")
 
         test_db_url = with_schema(base_db_url, schema)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -967,6 +967,22 @@ class TestCLISubprocessExtended:
 class TestCLIDevHelpers:
     """Tests for dev helper functionality."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_database_url_env(self):
+        """Restore TAKO_VM_DATABASE_URL after each test.
+
+        dev_up() and run_server() mutate os.environ["TAKO_VM_DATABASE_URL"]
+        directly (pointing it at the managed postgres on port 55432). Without
+        restoration that leaks into every later test in the process and caused
+        the entire storage suite to silently skip in CI.
+        """
+        original = os.environ.get("TAKO_VM_DATABASE_URL")
+        yield
+        if original is None:
+            os.environ.pop("TAKO_VM_DATABASE_URL", None)
+        else:
+            os.environ["TAKO_VM_DATABASE_URL"] = original
+
     def test_dev_up_without_server(self, capsys):
         """dev_up starts local postgres without launching server."""
         from tako_vm.cli import MANAGED_POSTGRES_URL, dev_up

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -12,8 +12,11 @@ import tako_vm.storage as storage_module
 from tako_vm.models import ExecutionRecord, sha256_content, sha256_json
 from tako_vm.storage import ExecutionStorage
 
+# Never skip in CI: temp_data_dir provides the database URL there and fails
+# loudly if postgres is unreachable, so DB coverage cannot silently vanish.
 pytestmark = pytest.mark.skipif(
-    "TAKO_VM_DATABASE_URL" not in os.environ,
+    "TAKO_VM_DATABASE_URL" not in os.environ
+    and not (os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")),
     reason="Set TAKO_VM_DATABASE_URL to run PostgreSQL integration tests",
 )
 


### PR DESCRIPTION
## Problem

Every CI run was silently **skipping all postgres-backed tests** — 44+ tests across `tests/test_storage.py` and all of `tests/test_postgres_integration.py` — even though the workflow's postgres:16 service was healthy and `TAKO_VM_DATABASE_URL` was correctly exported into the test step. The entire storage layer (reconcile_stale_records, upsert integrity, hydration robustness, digest strictness, etc.) has had zero CI coverage; recent storage PRs merged with their DB tests skipped.

## Root cause

`tests/test_cli.py::TestCLIDevHelpers` (`test_dev_up_without_server`, `test_run_server_auto_starts_local_postgres`) invoke `dev_up()` / `run_server()`, which mutate `os.environ["TAKO_VM_DATABASE_URL"]` to the managed-postgres DSN (`postgresql://postgres:postgres@localhost:55432/tako_vm`) and never restore it. `test_cli.py` runs alphabetically before `test_postgres_integration.py` and `test_storage.py`, so the `temp_data_dir` fixture — which read the env var lazily at fixture time — connected to dead port 55432, hit `psycopg.Error`, and `pytest.skip`'d every storage test. (`tests/test_config.py` had already worked around this exact leak locally for itself; see its `reset_config_fixture` docstring.)

## Fix

- **tests/test_cli.py** — autouse fixture in `TestCLIDevHelpers` snapshots/restores `TAKO_VM_DATABASE_URL`, so env mutation by the code under test cannot leak into later tests.
- **tests/conftest.py** — capture `TEST_DATABASE_URL` once at import time (before any test can pollute the process env) and use it in `temp_data_dir`, making storage tests immune to pollution regardless of test order.
- **Anti-regression** — when `CI`/`GITHUB_ACTIONS` is set, `temp_data_dir` now `pytest.fail()`s with an actionable message if postgres is unreachable, instead of skipping. DB coverage can never silently vanish from CI again. Local dev without postgres still skips gracefully.
- **tests/test_postgres_integration.py** — the module-level skipif no longer applies in CI (the fixture supplies the URL and fails loudly there).
- **.github/workflows/test.yml** — add `-ra` so skip reasons appear in CI logs (the original bug would have been immediately visible with this).

## Verification

Against a throwaway local postgres (`initdb` + `pg_ctl` on port 5499):
- `tests/test_storage.py` + `tests/test_postgres_integration.py`: **53 passed, 0 skipped**
- Pollution-order repro (`test_cli.py` then storage tests): **104 passed, 0 skipped** (previously the storage half skipped)
- `CI=true` with unreachable DB: storage test **errors loudly** instead of skipping; without `CI` it skips gracefully
- Full suite: 398 passed, 98 skipped (docker-dependent only; no docker locally)

CI on this PR is the real proof — the storage tests should now show PASSED instead of SKIPPED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)