### PR TITLE
feat(traceability): persist correlation_id on execution records and fix contextvar bleed

### DIFF
--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -369,6 +369,9 @@ class ExecutionRecord(BaseModel):
     client_ip: Optional[str] = Field(default=None, max_length=45)  # IPv6 max length
     """Client IP address."""
 
+    correlation_id: Optional[str] = Field(default=None, max_length=64)
+    """Correlation ID (X-Correlation-ID) of the submitting request, for request tracing."""
+
     # Lineage tracking
     parent_execution_id: Optional[str] = Field(default=None, max_length=64)
     """ID of parent execution (for reruns/forks)."""

--- a/tako_vm/server/correlation.py
+++ b/tako_vm/server/correlation.py
@@ -43,6 +43,17 @@ def set_correlation_id(correlation_id: str) -> None:
     correlation_id_var.set(correlation_id)
 
 
+def clear_correlation_id() -> None:
+    """
+    Clear the correlation ID from context.
+
+    Call this at the start of work that is not tied to an HTTP request (e.g.
+    each queue worker iteration) so logs and DLQ entries never inherit a
+    previous request's correlation ID.
+    """
+    correlation_id_var.set(None)
+
+
 def generate_correlation_id() -> str:
     """
     Generate a new correlation ID.

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -20,7 +20,11 @@ from tako_vm.models import (
     sha256_content,
     sha256_json,
 )
-from tako_vm.server.correlation import get_correlation_id, set_correlation_id
+from tako_vm.server.correlation import (
+    clear_correlation_id,
+    get_correlation_id,
+    set_correlation_id,
+)
 from tako_vm.storage import ExecutionStorage
 
 if TYPE_CHECKING:
@@ -208,6 +212,7 @@ class WorkerPool:
             code_hash=sha256_content(job_data.get("code", "")),
             input_hash=sha256_json(job_data.get("input_data", {})),
             client_ip=client_ip,
+            correlation_id=job_data.get("correlation_id"),
             idempotency_key=job_data.get("idempotency_key"),
             idempotency_fingerprint=job_data.get("idempotency_fingerprint"),
             parent_execution_id=job_data.get("parent_execution_id"),
@@ -402,6 +407,7 @@ class WorkerPool:
             code_hash=sha256_content(job.job_data.get("code", "")),
             input_hash=sha256_json(job.job_data.get("input_data", {})),
             client_ip=job.client_ip,
+            correlation_id=job.job_data.get("correlation_id"),
             error=ExecutionError(type="cancelled", message=message),
             idempotency_key=job.job_data.get("idempotency_key"),
             idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
@@ -473,6 +479,11 @@ class WorkerPool:
                     job = await asyncio.wait_for(self._queue.get(), timeout=self.queue_wait_timeout)
                 except asyncio.TimeoutError:
                     continue
+
+                # Reset correlation context before any per-job work (including
+                # the cancelled-skip path below) so logs and DLQ entries never
+                # inherit the previous job's correlation ID.
+                clear_correlation_id()
 
                 # Skip if already cancelled
                 if job.cancelled or (job.future and job.future.cancelled()):
@@ -567,6 +578,7 @@ class WorkerPool:
                         code_hash=sha256_content(job.job_data.get("code", "")),
                         input_hash=sha256_json(job.job_data.get("input_data", {})),
                         client_ip=job.client_ip,
+                        correlation_id=job.job_data.get("correlation_id"),
                         error=ExecutionError(type=error_type, message=error_msg),
                         # Propagate idempotency and lineage fields
                         idempotency_key=job.job_data.get("idempotency_key"),
@@ -622,6 +634,7 @@ class WorkerPool:
                             code_hash=sha256_content(job.job_data.get("code", "")),
                             input_hash=sha256_json(job.job_data.get("input_data", {})),
                             client_ip=job.client_ip,
+                            correlation_id=job.job_data.get("correlation_id"),
                             error=ExecutionError(
                                 type="internal_error", message=sanitize_error(str(e))
                             ),
@@ -755,6 +768,7 @@ class WorkerPool:
             code_hash=sha256_content(job.job_data.get("code", "")),
             input_hash=sha256_json(job.job_data.get("input_data", {})),
             client_ip=job.client_ip,
+            correlation_id=job.job_data.get("correlation_id"),
             error=ExecutionError(
                 type="execution_timeout",
                 message=(

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -150,7 +150,13 @@ MIGRATIONS: list[tuple[str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_dlq_error_type ON dead_letter_queue(error_type);
         CREATE INDEX IF NOT EXISTS idx_dlq_job_id ON dead_letter_queue(job_id);
         """,
-    )
+    ),
+    (
+        "0002_correlation_id",
+        """
+        ALTER TABLE execution_records ADD COLUMN IF NOT EXISTS correlation_id TEXT
+        """,
+    ),
 ]
 
 
@@ -310,8 +316,9 @@ class ExecutionStorage:
         # Upsert column policy:
         # - Submission-identity fields (created_at, queued_at, code_hash,
         #   input_hash, params_hash, input_artifacts_hash, client_ip,
-        #   idempotency_key, idempotency_fingerprint, parent_execution_id,
-        #   relationship) describe WHEN/HOW the job was submitted. They are
+        #   correlation_id, idempotency_key, idempotency_fingerprint,
+        #   parent_execution_id, relationship) describe WHEN/HOW the job was
+        #   submitted. They are
         #   written by queue.submit() and must survive later writes from the
         #   executor, which rebuilds its record at execution start and does not
         #   know the true submission timestamps. We keep the existing row's
@@ -343,12 +350,12 @@ class ExecutionStorage:
                     max_rss_mb, cpu_time_ms, wall_time_ms,
                     timing_json,
                     artifacts_json, error_json,
-                    client_ip, parent_execution_id, relationship
+                    client_ip, correlation_id, parent_execution_id, relationship
                 ) VALUES (
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s, %s, %s
+                    %s, %s, %s, %s, %s, %s
                 )
                 ON CONFLICT (execution_id) DO UPDATE SET
                     status = EXCLUDED.status,
@@ -390,6 +397,10 @@ class ExecutionStorage:
                     artifacts_json = EXCLUDED.artifacts_json,
                     error_json = EXCLUDED.error_json,
                     client_ip = COALESCE(execution_records.client_ip, EXCLUDED.client_ip),
+                    correlation_id = COALESCE(
+                        execution_records.correlation_id,
+                        EXCLUDED.correlation_id
+                    ),
                     parent_execution_id = COALESCE(
                         execution_records.parent_execution_id,
                         EXCLUDED.parent_execution_id
@@ -432,6 +443,7 @@ class ExecutionStorage:
                     Jsonb(artifacts_json),
                     Jsonb(error_json) if error_json is not None else None,
                     record.client_ip,
+                    record.correlation_id,
                     record.parent_execution_id,
                     record.relationship,
                 ),
@@ -675,6 +687,7 @@ class ExecutionStorage:
             artifacts=artifacts,
             error=error,
             client_ip=row.get("client_ip"),
+            correlation_id=row.get("correlation_id"),
             parent_execution_id=row.get("parent_execution_id"),
             relationship=row.get("relationship"),
         )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -652,3 +652,135 @@ async def test_submit_queue_full_precheck_rejects_without_db_write():
         )
 
     storage.save_record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_persists_correlation_id_on_preliminary_record():
+    """submit() must persist job_data's correlation_id on the queued record."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage)
+
+    job_id = await pool.submit(
+        {
+            "code": "print('hi')",
+            "input_data": {},
+            "correlation_id": "corr-submit-123",
+        }
+    )
+
+    storage.save_record.assert_awaited_once()
+    saved = storage.save_record.await_args.args[0]
+    assert saved.execution_id == job_id
+    assert saved.status == "queued"
+    assert saved.correlation_id == "corr-submit-123"
+
+
+@pytest.mark.asyncio
+async def test_worker_loop_clears_correlation_id_between_jobs():
+    """A job without a correlation_id must not inherit the previous job's."""
+    from tako_vm.server.correlation import get_correlation_id
+
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    storage.mark_record_running = AsyncMock()
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage, queue_wait_timeout=0.05)
+
+    seen: dict[str, object] = {}
+
+    async def fake_execute(job):
+        seen[job.job_id] = get_correlation_id()
+        return make_record(job.job_id)
+
+    pool._execute_job = fake_execute
+
+    loop = asyncio.get_running_loop()
+    job_a = QueuedJob(
+        job_id="job-with-corr",
+        job_data={"code": "print('a')", "input_data": {}, "correlation_id": "corr-a"},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    job_b = QueuedJob(
+        job_id="job-without-corr",
+        job_data={"code": "print('b')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    for job in (job_a, job_b):
+        pool._active_jobs[job.job_id] = job
+        pool._queue.put_nowait(job)
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        await asyncio.wait_for(job_a.future, timeout=2.0)
+        await asyncio.wait_for(job_b.future, timeout=2.0)
+    finally:
+        pool._shutdown = True
+        await asyncio.wait_for(worker, timeout=2.0)
+
+    assert seen["job-with-corr"] == "corr-a"
+    assert seen["job-without-corr"] is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_skip_path_does_not_inherit_previous_correlation_id():
+    """The pre-execution cancelled-skip path runs before the correlation_id is
+    set for the job, so it must see a cleared context (not the previous job's
+    id), and the cancelled record itself must carry the job's own (absent)
+    correlation_id."""
+    from tako_vm.server.correlation import get_correlation_id
+
+    storage = MagicMock()
+    storage.mark_record_running = AsyncMock()
+
+    save_contexts: list[tuple[str, object]] = []
+
+    async def capture_save(record):
+        save_contexts.append((record.execution_id, get_correlation_id()))
+
+    storage.save_record = AsyncMock(side_effect=capture_save)
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage, queue_wait_timeout=0.05)
+
+    async def fake_execute(job):
+        return make_record(job.job_id)
+
+    pool._execute_job = fake_execute
+
+    loop = asyncio.get_running_loop()
+    job_a = QueuedJob(
+        job_id="job-corr-first",
+        job_data={"code": "print('a')", "input_data": {}, "correlation_id": "corr-a"},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    job_b = QueuedJob(
+        job_id="job-cancelled-skip",
+        job_data={"code": "print('b')", "input_data": {}},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    job_b.cancelled = True
+    for job in (job_a, job_b):
+        pool._active_jobs[job.job_id] = job
+        pool._queue.put_nowait(job)
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        await asyncio.wait_for(job_a.future, timeout=2.0)
+        record_b = await asyncio.wait_for(job_b.future, timeout=2.0)
+    finally:
+        pool._shutdown = True
+        await asyncio.wait_for(worker, timeout=2.0)
+
+    assert record_b.status == "cancelled"
+    assert record_b.correlation_id is None
+
+    contexts = dict(save_contexts)
+    # Job A's terminal save happens while its correlation id is set.
+    assert contexts["job-corr-first"] == "corr-a"
+    # Job B's cancelled-skip save must NOT see job A's correlation id.
+    assert contexts["job-cancelled-skip"] is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -979,3 +979,66 @@ class TestSaveRecordRetry:
             asyncio.run(store.save_record(self._record()))
 
         assert attempts["n"] == 1
+
+
+class TestCorrelationIdPersistence:
+    """correlation_id round-trips through save/load and survives upserts (F11)."""
+
+    def test_correlation_id_round_trip(self, storage):
+        """correlation_id persists through save and load."""
+        record = ExecutionRecord(
+            execution_id="corr-round-trip",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            correlation_id="req-abc-123",
+        )
+
+        storage.save_record(record)
+        retrieved = storage.get_record("corr-round-trip")
+
+        assert retrieved is not None
+        assert retrieved.correlation_id == "req-abc-123"
+
+    def test_correlation_id_defaults_to_none(self, storage):
+        """Records saved without a correlation_id hydrate with None."""
+        record = ExecutionRecord(
+            execution_id="corr-none",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+        )
+
+        storage.save_record(record)
+        retrieved = storage.get_record("corr-none")
+
+        assert retrieved is not None
+        assert retrieved.correlation_id is None
+
+    def test_correlation_id_survives_executor_rewrite(self, storage):
+        """Submission-identity policy: the executor's later write (which does
+        not know the correlation_id) must not erase the value persisted by the
+        preliminary queued record."""
+        queued = ExecutionRecord(
+            execution_id="corr-upsert",
+            status="queued",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            correlation_id="req-keep-me",
+        )
+        storage.save_record(queued)
+
+        final = ExecutionRecord(
+            execution_id="corr-upsert",
+            status="succeeded",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            correlation_id=None,
+            exit_code=0,
+        )
+        storage.save_record(final)
+
+        retrieved = storage.get_record("corr-upsert")
+        assert retrieved is not None
+        assert retrieved.status == "succeeded"
+        assert retrieved.correlation_id == "req-keep-me"


### PR DESCRIPTION
## Summary

Fixes two verified traceability bugs:

**F11 (partial) — correlation_id never persisted on execution records.** The server generates/propagates `X-Correlation-ID` per request and `app.py` already places it in `job_data` at submit time, but `ExecutionRecord` had no `correlation_id` field — only `DeadLetterEntry` did. Successful/failed/timeout/cancelled executions therefore could not be joined to HTTP request traces; only DLQ'd internal errors could.

**F25 — correlation contextvar bleed in the worker loop.** The loop set the contextvar from `job_data` but never reset it, and the cancelled-skip path ran *before* the set — so logs and DLQ entries from jobs without a correlation id (and from the skip path) carried the **previous** job's correlation id.

## Changes

- `tako_vm/models.py`: add `correlation_id: Optional[str]` (max_length=64, matching `DeadLetterEntry`) to `ExecutionRecord`, placed next to `client_ip`.
- `tako_vm/storage.py`:
  - New migration `0002_correlation_id`: `ALTER TABLE execution_records ADD COLUMN IF NOT EXISTS correlation_id TEXT` (follows the existing `(name, sql)` migration framework).
  - `save_record` upsert: column added to INSERT and to `ON CONFLICT` as a **submission-identity** field per the documented policy — `COALESCE(execution_records.correlation_id, EXCLUDED.correlation_id)` — so the executor's later write (which rebuilds the record without knowing the correlation id) cannot erase it. Policy comment block updated.
  - `_row_to_record`: hydrate `correlation_id`.
- `tako_vm/server/queue.py`: thread `job_data.get("correlation_id")` into **every** record the pool constructs: the preliminary queued record in `submit()`, `_build_cancelled_record` (covers user cancel, pre-execution skip, and shutdown drain), the watchdog timeout record, and both internal-error fallback records. Also: clear the correlation contextvar at the **top** of every dequeue iteration, before the cancelled-skip check, so no path can inherit the previous job's id.
- `tako_vm/server/correlation.py`: add `clear_correlation_id()`.

No changes to `worker.py`, `app.py`, `sandbox.py`, or the SDK. `app.py` already puts `correlation_id` into `job_data` (verified, line ~988), so no threading change was needed there. Records produced by the executor lack the field, but the COALESCE upsert preserves the value written by the preliminary queued record — so the final row always carries it.

## Tests

- `tests/test_storage.py` (postgres-backed, appended at EOF): round-trip persistence, None default, and upsert-survival (executor rewrite without correlation_id must not erase it).
- `tests/test_queue.py` (appended at EOF): `submit()` persists `correlation_id` on the preliminary record (AsyncMock storage); worker-loop hygiene — job A with correlation id then job B without → `get_correlation_id()` is None during B; cancelled-skip path after a correlated job sees a cleared context and its record carries its own (absent) correlation id.

## Verification

- `ruff check` / `ruff format --check`: clean.
- `uv run --extra all --extra dev pytest tests/test_queue.py tests/test_models.py -q`: **56 passed**.
- `tests/test_storage.py`: 3 passed, 47 skipped locally — **the new postgres-backed storage tests could not run locally** (no PostgreSQL/Docker available in this environment; the suite's fixture skips cleanly). They follow the existing `storage` fixture pattern exactly and should run in CI once the postgres CI gap (tracked separately) is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)