### PR TITLE
fix(worker): idempotent retries (unique container per attempt, clean output dir) and truncation flags

### DIFF
--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -36,21 +36,40 @@ def is_native_linux() -> bool:
     return platform.system() == "Linux"
 
 
-def generate_container_name(prefix: str, job_id: Optional[str] = None) -> str:
+def generate_container_name(prefix: str, job_id: Optional[str] = None, attempt: int = 0) -> str:
     """
     Generate a unique container name for tracking.
 
     Uses job_id if provided, otherwise generates a UUID-based name
     to avoid collisions under high concurrency.
 
+    Retry attempts (attempt > 0) get a ``-r{attempt}`` suffix so a retry can
+    never collide with a previous attempt's container that ``--rm`` has not
+    removed yet (exactly the daemon-hiccup scenario that triggers a retry —
+    a name collision would fail the retry with docker exit 125 "name already
+    in use"). Attempt 0 keeps the plain deterministic ``{prefix}-{job_id}``
+    name because external kill paths (queue.py cancel()/watchdog) compute
+    ``generate_container_name("tako", job_id)`` and must still match the
+    first attempt's container.
+
+    Known limitation: those cancel/watchdog paths can only kill the
+    attempt-0 name, so a container from a retry attempt is not reachable by
+    them. Retries are short-lived and rare; killing by the
+    ``tako-vm.execution-id`` label (which every attempt carries) instead of
+    by name is noted as future work.
+
     Args:
         prefix: Container name prefix (e.g., "tako", "tako-sandbox")
         job_id: Optional job ID to include in name
+        attempt: Retry attempt index (0 = first attempt, no suffix)
 
     Returns:
-        Unique container name like "tako-abc123" or "tako-a1b2c3d4"
+        Unique container name like "tako-abc123", "tako-abc123-r1",
+        or "tako-a1b2c3d4"
     """
     if job_id:
+        if attempt > 0:
+            return f"{prefix}-{job_id}-r{attempt}"
         return f"{prefix}-{job_id}"
     return f"{prefix}-{uuid.uuid4().hex[:12]}"
 
@@ -87,6 +106,42 @@ def kill_container(container_name: str) -> bool:
     except Exception as e:
         # Ignore errors - container may not exist or already be stopped
         logger.debug("Failed to kill container %s: %s", container_name, e)
+        return False
+
+
+def remove_container(container_name: str) -> bool:
+    """
+    Force-remove a container by name (best-effort).
+
+    ``docker rm -f`` kills the container if it is running and removes it in
+    one step. Used before a retry attempt to clean up the previous attempt's
+    container so it cannot linger (``--rm`` removal can lag behind a daemon
+    hiccup — the very condition that triggers retries).
+
+    Silently ignores errors (the container has usually already been removed
+    by ``--rm``).
+
+    Args:
+        container_name: Name of the container to remove
+
+    Returns:
+        True if Docker reported the container was removed, False otherwise
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "rm", "-f", container_name],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode == 0:
+            logger.debug("Removed container %s", container_name)
+            return True
+        logger.debug("Container %s did not exist", container_name)
+        return False
+    except Exception as e:
+        # Ignore errors - container may not exist or daemon may be unreachable
+        logger.debug("Failed to remove container %s: %s", container_name, e)
         return False
 
 

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -6,6 +6,7 @@ Provides both legacy dict-based results and new ExecutionRecord-based results.
 
 import json
 import logging
+import os
 import shutil
 import subprocess
 import tempfile
@@ -22,6 +23,7 @@ from tako_vm.execution.docker import (
     generate_container_name,
     is_native_linux,
     kill_container,
+    remove_container,
 )
 from tako_vm.execution.health import get_circuit_breaker
 from tako_vm.execution.retry import RetryConfig, RetryContext, is_transient_error
@@ -155,6 +157,34 @@ def prune_old_run_dirs(data_dir: Path, ttl_days: int) -> int:
         except OSError as e:
             logger.warning("Failed to prune old run dir %s: %s", entry, e)
     return removed
+
+
+def _clear_output_dir(output_dir: Path) -> None:
+    """Remove the contents of the output dir between retry attempts.
+
+    A failed attempt may have left a partial ``result.json``, ``.tako_phase``
+    file, or artifacts behind; without clearing, those leftovers would be
+    reported as the next attempt's results. The directory itself is preserved
+    (it is bind-mounted by path and carries the 0o777 mode the container user
+    needs) — only its entries are removed. Symlinks are unlinked, never
+    followed: untrusted code may have planted a symlink at any name here.
+
+    Fail-soft: per-entry errors are logged and skipped.
+    """
+    try:
+        with os.scandir(output_dir) as entries:
+            for entry in entries:
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        shutil.rmtree(entry.path, ignore_errors=True)
+                    else:
+                        # Regular files and symlinks: unlink removes the link
+                        # itself without following it.
+                        os.unlink(entry.path)
+                except OSError as e:
+                    logger.warning("Failed to clear stale output entry %s: %s", entry.path, e)
+    except OSError as e:
+        logger.warning("Failed to clear output dir %s: %s", output_dir, e)
 
 
 def check_gvisor_available() -> bool:
@@ -611,8 +641,24 @@ class CodeExecutor:
                     base_delay=self.config.retry_base_delay,
                 )
             )
+            # Surface retry behavior in the audit record: max_attempts is the
+            # configured ceiling; attempt is updated to the index of each
+            # attempt actually run (0 = no retries occurred).
+            record.max_attempts = self.config.max_retry_attempts
 
             while retry_ctx.should_retry():
+                attempt = retry_ctx.attempt
+                record.attempt = attempt
+                if attempt > 0:
+                    # Make retries idempotent. The previous attempt's
+                    # container may still exist (`--rm` removal can lag the
+                    # very daemon hiccup that triggered the retry), and its
+                    # partial output (result.json, .tako_phase, artifacts)
+                    # may still be in output_dir — remove both so the retry
+                    # cannot collide on a container name or report stale
+                    # results from the failed attempt.
+                    remove_container(generate_container_name("tako", job_id, attempt=attempt - 1))
+                    _clear_output_dir(output_dir)
                 try:
                     result = self._run_container(
                         code_dir=code_dir,
@@ -623,6 +669,7 @@ class CodeExecutor:
                         job_type=job_type,
                         extra_requirements=job.get("requirements"),
                         job_id=job_id,
+                        attempt=attempt,
                     )
 
                     # Host-level timeout: the job already consumed its full
@@ -678,9 +725,22 @@ class CodeExecutor:
             record.duration_ms = wall_time_ms
             record.exit_code = result.get("exit_code")
 
-            # Cap and sanitize outputs
-            record.stdout = cap_output(result.get("stdout", ""), self.config.max_stdout_bytes)
-            record.stderr = cap_output(result.get("stderr", ""), self.config.max_stderr_bytes)
+            # Cap and sanitize outputs. cap_output truncates in-band (appends
+            # a notice), so also surface truncation on the record flags — the
+            # API must not report truncated output as complete. The flag
+            # mirrors cap_output's own truncation condition (UTF-8 encoded
+            # size vs the cap), which is robust against the notice text
+            # legitimately appearing in user output.
+            raw_stdout = result.get("stdout", "")
+            raw_stderr = result.get("stderr", "")
+            record.stdout = cap_output(raw_stdout, self.config.max_stdout_bytes)
+            record.stderr = cap_output(raw_stderr, self.config.max_stderr_bytes)
+            record.stdout_truncated = (
+                len(raw_stdout.encode("utf-8", errors="replace")) > self.config.max_stdout_bytes
+            )
+            record.stderr_truncated = (
+                len(raw_stderr.encode("utf-8", errors="replace")) > self.config.max_stderr_bytes
+            )
 
             # Resource usage
             record.resource_usage = ResourceUsage(wall_time_ms=wall_time_ms)
@@ -939,6 +999,7 @@ class CodeExecutor:
         job_type: JobType,
         extra_requirements: Optional[List[str]] = None,
         job_id: Optional[str] = None,
+        attempt: int = 0,
     ) -> Dict[str, Any]:
         """
         Run Docker container with security restrictions.
@@ -951,6 +1012,10 @@ class CodeExecutor:
             startup_timeout: Startup timeout in seconds
             job_type: Job type configuration for container settings
             extra_requirements: Additional requirements to install (merged with job_type)
+            job_id: Job/execution ID used for the container name and label
+            attempt: Retry attempt index; attempts > 0 get a suffixed
+                container name so they cannot collide with a previous
+                attempt's not-yet-removed container
 
         Returns:
             Dictionary with execution results
@@ -1044,8 +1109,10 @@ class CodeExecutor:
                 "For true network isolation, use pre-built images via 'tako-vm build'."
             )
 
-        # Generate container name for tracking (allows cleanup on timeout)
-        container_name = generate_container_name("tako", job_id)
+        # Generate container name for tracking (allows cleanup on timeout).
+        # Retry attempts get a unique suffixed name; see
+        # generate_container_name for the queue.py cancel/watchdog caveat.
+        container_name = generate_container_name("tako", job_id, attempt=attempt)
 
         cmd = base_isolation_args(
             container_name,

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -14,6 +14,7 @@ from tako_vm.execution.docker import (
     generate_container_name,
     is_native_linux,
     kill_container,
+    remove_container,
 )
 
 
@@ -64,6 +65,20 @@ class TestGenerateContainerName:
         name = generate_container_name("my-app", job_id="job1")
         assert name == "my-app-job1"
 
+    def test_attempt_zero_keeps_plain_name(self):
+        """Attempt 0 keeps the deterministic name so cancel/watchdog kill paths match."""
+        assert generate_container_name("tako", job_id="abc123", attempt=0) == "tako-abc123"
+
+    def test_retry_attempts_get_unique_suffix(self):
+        """Attempts > 0 get a -r{attempt} suffix so retries never collide with attempt 0."""
+        assert generate_container_name("tako", job_id="abc123", attempt=1) == "tako-abc123-r1"
+        assert generate_container_name("tako", job_id="abc123", attempt=2) == "tako-abc123-r2"
+
+    def test_attempt_names_are_distinct_per_attempt(self):
+        """Every attempt index yields a distinct container name."""
+        names = {generate_container_name("tako", job_id="j", attempt=a) for a in range(4)}
+        assert len(names) == 4
+
 
 class TestKillContainer:
     """Tests for kill_container() function."""
@@ -102,6 +117,45 @@ class TestKillContainer:
         mock_run.side_effect = Exception("Unexpected error")
 
         assert kill_container("error-container") is False
+
+
+class TestRemoveContainer:
+    """Tests for remove_container() function."""
+
+    @patch("subprocess.run")
+    def test_remove_container_calls_docker_rm_force(self, mock_run):
+        """remove_container force-removes by name via docker rm -f."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert remove_container("tako-test-123") is True
+
+        mock_run.assert_called_once_with(
+            ["docker", "rm", "-f", "tako-test-123"],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    def test_remove_container_returns_false_when_missing(self, mock_run):
+        """A nonexistent container (nonzero exit) is reported as not removed."""
+        mock_run.return_value = MagicMock(returncode=1)
+
+        assert remove_container("already-gone") is False
+
+    @patch("subprocess.run")
+    def test_remove_container_ignores_timeout(self, mock_run):
+        """remove_container silently ignores subprocess timeouts."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
+
+        assert remove_container("tako-test-123") is False
+
+    @patch("subprocess.run")
+    def test_remove_container_handles_exception(self, mock_run):
+        """remove_container handles unexpected exceptions."""
+        mock_run.side_effect = Exception("Unexpected error")
+
+        assert remove_container("error-container") is False
 
 
 class TestContainerNameValidation:

--- a/tests/test_worker_errors.py
+++ b/tests/test_worker_errors.py
@@ -1,7 +1,7 @@
 """
 Error plumbing tests for CodeExecutor._run_container / execute_job_with_record.
 
-Covers two bugs:
+Covers:
 
 1. Docker infrastructure failures (daemon down, `docker run` exit 125) were
    recorded as circuit breaker *successes*, returned without an "error" key
@@ -12,10 +12,19 @@ Covers two bugs:
    "timeout" and the partial stdout/stderr captured before the kill was
    discarded.
 
+3. Retry idempotency: a retry reused the exact container name of the failed
+   attempt (colliding with a not-yet-removed `--rm` container) and inherited
+   the failed attempt's leftover output dir contents; record.attempt /
+   record.max_attempts never reflected that retries happened.
+
+4. Truncation flags: cap_output truncated stdout/stderr in-band but
+   record.stdout_truncated / stderr_truncated were never set.
+
 All tests mock subprocess.run — no Docker required.
 """
 
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -110,6 +119,51 @@ def _patch_subprocess(monkeypatch, side_effect):
     return calls
 
 
+def _output_mount_dir(cmd):
+    """Extract the host source dir of the /output bind mount from a docker run cmd."""
+    for arg in cmd:
+        if arg.startswith("--mount=type=bind,") and arg.endswith(",target=/output"):
+            return Path(arg.split("source=", 1)[1].split(",", 1)[0])
+    raise AssertionError("docker run command has no /output bind mount")
+
+
+def _patch_docker_cli(monkeypatch, run_results, on_run=None):
+    """Fake subprocess.run that distinguishes `docker run` from `docker rm`.
+
+    `docker run` invocations consume `run_results` in order (calling `on_run`
+    with (attempt_index, cmd) first, e.g. to seed stale files into the mounted
+    output dir); `docker rm` invocations are recorded and succeed. Any other
+    docker command fails the test.
+
+    Returns (run_cmds, rm_cmds) lists, appended to as calls happen.
+    """
+    run_cmds = []
+    rm_cmds = []
+    results = iter(run_results)
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["docker", "run"]:
+            if on_run:
+                on_run(len(run_cmds), cmd)
+            run_cmds.append(cmd)
+            return next(results)
+        if cmd[:2] == ["docker", "rm"]:
+            rm_cmds.append(cmd)
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        raise AssertionError(f"unexpected docker command: {cmd}")
+
+    monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
+    return run_cmds, rm_cmds
+
+
+def _infra_failure():
+    return SimpleNamespace(returncode=125, stdout="", stderr=DAEMON_DOWN_STDERR)
+
+
+def _success(stdout="ok", stderr=""):
+    return SimpleNamespace(returncode=0, stdout=stdout, stderr=stderr)
+
+
 class TestDockerInfraFailure:
     """`docker run` failing (exit 125 / daemon unreachable) is an infra failure."""
 
@@ -152,17 +206,14 @@ class TestDockerInfraFailure:
     def test_daemon_down_retries_and_record_is_service_unavailable(
         self, executor, breaker, monkeypatch
     ):
-        calls = _patch_subprocess(
-            monkeypatch,
-            lambda: SimpleNamespace(returncode=125, stdout="", stderr=DAEMON_DOWN_STDERR),
-        )
+        run_cmds, _ = _patch_docker_cli(monkeypatch, [_infra_failure(), _infra_failure()])
 
         record = executor.execute_job_with_record(
             "job-infra-1", {"code": "print('hi')", "input_data": {}}
         )
 
         # Retry loop fired: both configured attempts hit Docker
-        assert calls["count"] == 2
+        assert len(run_cmds) == 2
         assert len(breaker.failures) == 2
         assert breaker.successes == 0
 
@@ -171,6 +222,10 @@ class TestDockerInfraFailure:
         assert record.error is not None
         assert record.error.type == "service_unavailable"
         assert "Docker infrastructure failure" in record.error.message
+
+        # The audit record shows that retries happened
+        assert record.attempt == 1
+        assert record.max_attempts == 2
 
 
 class TestHostTimeout:
@@ -255,3 +310,132 @@ class TestUserCodeFailure:
         assert record.status == "succeeded"
         assert breaker.successes == 1
         assert breaker.failures == []
+
+
+class TestRetryIdempotency:
+    """Retries must not collide on container names or report stale outputs."""
+
+    def test_retry_uses_unique_container_name_and_removes_previous(
+        self, executor, breaker, monkeypatch
+    ):
+        """Attempt 2 gets a -r1 name and the attempt-1 container is force-removed first."""
+        run_cmds, rm_cmds = _patch_docker_cli(monkeypatch, [_infra_failure(), _success()])
+
+        record = executor.execute_job_with_record(
+            "job-retry-name", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert len(run_cmds) == 2
+        names = [next(a for a in cmd if a.startswith("--name=")) for cmd in run_cmds]
+        # Attempt 0 keeps the deterministic name (cancel/watchdog paths match
+        # it); the retry gets a unique suffix so a lingering --rm container
+        # from attempt 0 cannot cause a "name already in use" failure.
+        assert names == ["--name=tako-job-retry-name", "--name=tako-job-retry-name-r1"]
+        # Best-effort cleanup of the previous attempt's container fired
+        assert ["docker", "rm", "-f", "tako-job-retry-name"] in rm_cmds
+
+    def test_stale_output_cleared_between_attempts(self, executor, breaker, monkeypatch):
+        """Leftovers from a failed attempt must not be reported as retry results."""
+        seen_on_retry = {}
+
+        def on_run(attempt_idx, cmd):
+            out_dir = _output_mount_dir(cmd)
+            if attempt_idx == 0:
+                # Simulate a failed attempt that left partial output behind
+                (out_dir / "result.json").write_text('{"stale": true}')
+                (out_dir / ".tako_phase").write_text("phase=failed\nfailed_phase=startup\n")
+                (out_dir / "stale-artifact.txt").write_text("leftover")
+            else:
+                seen_on_retry["entries"] = sorted(p.name for p in out_dir.iterdir())
+
+        _patch_docker_cli(monkeypatch, [_infra_failure(), _success()], on_run=on_run)
+
+        record = executor.execute_job_with_record(
+            "job-retry-clean", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert seen_on_retry["entries"] == [], "output dir must be empty when a retry starts"
+        # Nothing stale leaked into the record
+        assert record.result_json is None
+        assert record.artifacts == []
+        assert record.timing is None
+
+    def test_attempt_and_max_attempts_recorded_on_retry(self, executor, breaker, monkeypatch):
+        """A successful retry is visible in the audit record."""
+        _patch_docker_cli(monkeypatch, [_infra_failure(), _success()])
+
+        record = executor.execute_job_with_record(
+            "job-retry-attempt", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert record.attempt == 1
+        assert record.max_attempts == 2
+
+    def test_attempt_zero_when_no_retry_needed(self, executor, breaker, monkeypatch):
+        """A first-attempt success records attempt 0 with the configured ceiling."""
+        run_cmds, rm_cmds = _patch_docker_cli(monkeypatch, [_success()])
+
+        record = executor.execute_job_with_record(
+            "job-no-retry", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert record.attempt == 0
+        assert record.max_attempts == 2
+        assert len(run_cmds) == 1
+        assert rm_cmds == [], "no retry means no defensive container removal"
+
+
+class TestTruncationFlags:
+    """cap_output truncation must be surfaced via record.stdout/stderr_truncated."""
+
+    def test_stdout_truncation_sets_flag(self, executor, breaker, monkeypatch):
+        big_stdout = "x" * (executor.config.max_stdout_bytes + 1000)
+        _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(returncode=0, stdout=big_stdout, stderr=""),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-trunc-out", {"code": "print('x')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert record.stdout_truncated is True
+        assert record.stderr_truncated is False
+        assert len(record.stdout.encode("utf-8")) <= executor.config.max_stdout_bytes
+        assert "[TRUNCATED" in record.stdout
+
+    def test_stderr_truncation_sets_flag(self, executor, breaker, monkeypatch):
+        big_stderr = "e" * (executor.config.max_stderr_bytes + 1000)
+        _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(returncode=0, stdout="ok", stderr=big_stderr),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-trunc-err", {"code": "print('x')", "input_data": {}}
+        )
+
+        assert record.stdout_truncated is False
+        assert record.stderr_truncated is True
+        assert len(record.stderr.encode("utf-8")) <= executor.config.max_stderr_bytes
+        assert "[TRUNCATED" in record.stderr
+
+    def test_flags_false_when_output_within_limits(self, executor, breaker, monkeypatch):
+        _patch_subprocess(
+            monkeypatch,
+            lambda: SimpleNamespace(returncode=0, stdout="small out", stderr="small err"),
+        )
+
+        record = executor.execute_job_with_record(
+            "job-no-trunc", {"code": "print('x')", "input_data": {}}
+        )
+
+        assert record.stdout_truncated is False
+        assert record.stderr_truncated is False
+        assert record.stdout == "small out"
+        assert record.stderr == "small err"


### PR DESCRIPTION
## Summary

Fixes two verified bugs (F16 + F13d) in the executor retry loop (`execute_job_with_record`).

### F16 — retries were not idempotent

- **Container name reuse**: every retry attempt reused the deterministic `tako-{job_id}` container name. If the previous attempt's `--rm` container lingered (exactly the daemon-hiccup scenario that triggers retries), the retry failed with docker exit 125 "name already in use" — recorded as an infra failure but burning the attempt. Retries now use a unique `tako-{job_id}-r{attempt}` name. **Attempt 0 keeps the plain name** so the `queue.py` cancel()/watchdog kill paths (which compute `generate_container_name("tako", job_id)`) still match the first attempt's container. Documented limitation: those paths can only reach the attempt-0 name; killing by the `tako-vm.execution-id` label (carried by every attempt) is noted in the code as future work.
- **Defensive cleanup**: before each retry, the previous attempt's container is force-removed best-effort via a new `remove_container()` helper (`docker rm -f`), so failed attempts can't leak containers.
- **Dirty output dir**: `result.json`, `.tako_phase`, and artifacts left behind by a failed attempt could be reported as the next attempt's results. The output dir contents are now cleared at the start of each retry — the dir itself (bind-mounted by path, 0o777) is preserved, entries are removed via `os.scandir` without following symlinks.
- **Attempt tracking**: `record.attempt` stayed 0 and `record.max_attempts` stayed 1 regardless of retries. The record now carries the final attempt index actually run and the configured `max_retry_attempts` ceiling.

### F13d — truncation flags never set

`cap_output` truncates stdout/stderr in-band (appending a notice), but `record.stdout_truncated` / `record.stderr_truncated` were never set — the API reported truncated output as complete. The flags are now set by mirroring `cap_output`'s own truncation condition (UTF-8 encoded size vs the configured cap), which is robust even if the notice text legitimately appears in user output.

## Tests

All mocked `subprocess.run`, no Docker required:

- retry produces `--name=tako-{id}` then `--name=tako-{id}-r1`, and `docker rm -f` of the previous name fires
- output dir is empty at the start of a retry; stale `result.json`/phase file/artifacts seeded by attempt 1 do not leak into the record
- `record.attempt` / `record.max_attempts` reflect retries (success-after-retry, exhausted, and no-retry cases)
- truncation flags set when stdout/stderr exceed `max_stdout_bytes`/`max_stderr_bytes`, `False` otherwise
- new `generate_container_name(attempt=...)` and `remove_container()` unit tests

`uv run --extra all --extra dev pytest tests/test_worker_errors.py tests/test_docker_utils.py tests/test_runtime.py -q` → **63 passed**; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)