### PR TITLE
fix(dlq): redact sensitive payloads from dead-letter entries and make DLQ TTL configurable

### DIFF
--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -421,6 +421,16 @@ class TakoVMConfig(BaseModel):
 
     # Retention
     execution_record_ttl_days: int = Field(default=30, ge=1, le=3650)
+    dlq_ttl_days: int = Field(
+        default=30,
+        ge=1,
+        le=365,
+        description=(
+            "Days to retain dead-letter-queue entries. Defaults to 30 to match "
+            "execution record retention: DLQ entries are forensic records of "
+            "internal failures and should not expire sooner than ordinary records."
+        ),
+    )
 
     # Docker
     docker_image: str = Field(default="code-executor:latest")

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -464,7 +464,18 @@ class JobVersion(BaseModel):
 
 
 class DeadLetterEntry(BaseModel):
-    """Entry in the dead letter queue for failed jobs."""
+    """Entry in the dead letter queue for failed jobs.
+
+    Redaction policy: DLQ entries are forensic records, not replay payloads.
+    ``job_data`` must never contain raw code, input_data values, or
+    idempotency keys -- AI-agent callers routinely embed credentials in
+    input_data, and persisting them as readable JSONB would contradict
+    ExecutionRecord's hash-only posture. Build ``job_data`` with
+    :meth:`build_job_summary`, which keeps fingerprints (sha256 hashes),
+    sizes, and non-secret diagnostic metadata (job_type, timeouts,
+    requirements package list, correlation/lineage IDs) and records only the
+    PRESENCE of an idempotency key.
+    """
 
     model_config = {"extra": "forbid"}
 
@@ -475,7 +486,45 @@ class DeadLetterEntry(BaseModel):
     """Original job ID."""
 
     job_data: Dict[str, Any]
-    """Original job data (code, input_data, etc.)."""
+    """Redacted forensic summary of the original job (see build_job_summary).
+
+    Historic entries (written before redaction was introduced) may still
+    contain raw fields; new entries never do.
+    """
+
+    @classmethod
+    def build_job_summary(cls, job_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a redacted forensic summary from a raw job payload.
+
+        Drops raw ``code``, ``input_data``, and the ``idempotency_key`` value
+        entirely; keeps sha256 fingerprints, byte sizes, and non-secret
+        diagnostic metadata so internal failures remain debuggable.
+        """
+        code = job_data.get("code", "") or ""
+        input_data = job_data.get("input_data", {})
+        canonical_input = json.dumps(
+            input_data, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+        summary: Dict[str, Any] = {
+            "job_type": job_data.get("job_type") or "default",
+            "code_hash": sha256_content(code),
+            "input_hash": sha256_json(input_data),
+            "code_size_bytes": len(code.encode("utf-8")),
+            "input_size_bytes": len(canonical_input.encode("utf-8")),
+            "has_idempotency_key": job_data.get("idempotency_key") is not None,
+        }
+        # Non-secret diagnostic metadata, included only when present.
+        for key in (
+            "timeout",
+            "startup_timeout",
+            "requirements",
+            "correlation_id",
+            "parent_execution_id",
+        ):
+            value = job_data.get(key)
+            if value is not None:
+                summary[key] = value
+        return summary
 
     error_type: ErrorType
     """Type of error that caused failure."""

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -173,7 +173,7 @@ async def _periodic_cleanup(
     record_ttl_days: int,
     data_dir: Path,
     workspace_max_age_seconds: int,
-    dlq_ttl_days: int = 7,
+    dlq_ttl_days: int,
 ):
     """Background task for periodic database + on-disk cleanup."""
     cleanup_interval = 3600  # Run every hour
@@ -259,6 +259,7 @@ async def lifespan(app: FastAPI):
             state.config.execution_record_ttl_days,
             state.config.data_dir,
             workspace_max_age,
+            state.config.dlq_ttl_days,
         )
     )
 

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -590,9 +590,11 @@ class WorkerPool:
 
                     # Add to dead letter queue for internal errors (P3 fix)
                     try:
+                        # Redact: DLQ persists a forensic summary (hashes,
+                        # sizes, metadata), never raw code/input_data/keys.
                         dlq_entry = DeadLetterEntry(
                             job_id=job.job_id,
-                            job_data=job.job_data,
+                            job_data=DeadLetterEntry.build_job_summary(job.job_data),
                             error_type=error_type,
                             error_message=error_msg,
                             retry_count=0,

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -845,7 +845,12 @@ class ExecutionStorage:
         )
 
     async def add_to_dlq(self, entry: DeadLetterEntry) -> int:
-        """Add a failed job to the dead letter queue."""
+        """Add a failed job to the dead letter queue.
+
+        ``entry.job_data`` is persisted verbatim as JSONB, so callers must
+        pass a redacted forensic summary (DeadLetterEntry.build_job_summary),
+        never raw code/input_data/idempotency keys.
+        """
         pool = self._get_pool()
         async with pool.connection() as conn:
             cursor = await conn.execute(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -677,3 +677,23 @@ max_workers: 16
             assert found == Path(config_path)
         finally:
             Path(config_path).unlink()
+
+
+class TestDLQTTLConfig:
+    """Tests for dlq_ttl_days retention config."""
+
+    def test_dlq_ttl_days_default_matches_record_retention(self):
+        """DLQ TTL defaults to 30 days, same as execution record retention."""
+        config = TakoVMConfig()
+        assert config.dlq_ttl_days == 30
+        assert config.dlq_ttl_days == config.execution_record_ttl_days
+
+    def test_dlq_ttl_days_bounds(self):
+        """dlq_ttl_days accepts 1-365 and rejects values outside that range."""
+        assert TakoVMConfig(dlq_ttl_days=1).dlq_ttl_days == 1
+        assert TakoVMConfig(dlq_ttl_days=365).dlq_ttl_days == 365
+
+        with pytest.raises(ValueError):
+            TakoVMConfig(dlq_ttl_days=0)
+        with pytest.raises(ValueError):
+            TakoVMConfig(dlq_ttl_days=366)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -416,3 +416,70 @@ class TestDeadLetterEntry:
         for error_type in valid_types:
             entry = DeadLetterEntry(job_id="job", job_data={}, error_type=error_type)
             assert entry.error_type == error_type
+
+
+class TestDeadLetterJobSummary:
+    """Tests for DeadLetterEntry.build_job_summary redaction policy."""
+
+    def test_summary_keeps_fingerprints_and_metadata(self):
+        """Summary carries hashes, sizes, and non-secret diagnostics."""
+        code = "print('hello')"
+        input_data = {"key": "value"}
+        job_data = {
+            "code": code,
+            "input_data": input_data,
+            "job_type": "svg-processing",
+            "timeout": 45,
+            "startup_timeout": 120,
+            "requirements": ["numpy", "pillow==10.0.0"],
+            "correlation_id": "corr-1",
+            "parent_execution_id": "parent-1",
+            "idempotency_key": "idem-secret",
+        }
+
+        summary = DeadLetterEntry.build_job_summary(job_data)
+
+        assert summary["job_type"] == "svg-processing"
+        assert summary["code_hash"] == sha256_content(code)
+        assert summary["input_hash"] == sha256_json(input_data)
+        assert summary["code_size_bytes"] == len(code.encode("utf-8"))
+        assert summary["input_size_bytes"] == len(b'{"key":"value"}')
+        assert summary["timeout"] == 45
+        assert summary["startup_timeout"] == 120
+        assert summary["requirements"] == ["numpy", "pillow==10.0.0"]
+        assert summary["correlation_id"] == "corr-1"
+        assert summary["parent_execution_id"] == "parent-1"
+        assert summary["has_idempotency_key"] is True
+
+    def test_summary_drops_raw_payloads(self):
+        """Raw code, input_data values, and idempotency keys never appear."""
+        job_data = {
+            "code": "import os; os.environ['SECRET']",
+            "input_data": {"api_key": "sk-live-supersecret"},
+            "idempotency_key": "idem-key-abc",
+        }
+
+        summary = DeadLetterEntry.build_job_summary(job_data)
+
+        assert "code" not in summary
+        assert "input_data" not in summary
+        assert "idempotency_key" not in summary
+        serialized = str(summary)
+        assert "sk-live-supersecret" not in serialized
+        assert "idem-key-abc" not in serialized
+        assert "import os" not in serialized
+
+    def test_summary_minimal_job(self):
+        """Summary of an empty job has stable defaults and omits absent fields."""
+        summary = DeadLetterEntry.build_job_summary({})
+
+        assert summary["job_type"] == "default"
+        assert summary["code_hash"] == sha256_content("")
+        assert summary["input_hash"] == sha256_json({})
+        assert summary["code_size_bytes"] == 0
+        assert summary["has_idempotency_key"] is False
+        assert "timeout" not in summary
+        assert "startup_timeout" not in summary
+        assert "requirements" not in summary
+        assert "correlation_id" not in summary
+        assert "parent_execution_id" not in summary

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -784,3 +784,83 @@ async def test_cancelled_skip_path_does_not_inherit_previous_correlation_id():
     assert contexts["job-corr-first"] == "corr-a"
     # Job B's cancelled-skip save must NOT see job A's correlation id.
     assert contexts["job-cancelled-skip"] is None
+
+
+@pytest.mark.asyncio
+async def test_internal_error_dlq_entry_is_redacted():
+    """Internal-error DLQ entries must hold a redacted forensic summary.
+
+    The persisted entry keeps fingerprints/sizes/metadata but never the raw
+    code string, input_data values, or the idempotency key itself.
+    """
+    from tako_vm.models import sha256_content, sha256_json
+
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    storage.mark_record_running = AsyncMock()
+    storage.add_to_dlq = AsyncMock()
+
+    pool = WorkerPool(executor=MagicMock(), storage=storage, queue_wait_timeout=0.05)
+
+    async def boom(job):
+        raise RuntimeError("executor exploded")
+
+    pool._execute_job = boom
+
+    secret_code = "import os; print(os.environ['AWS_SECRET_ACCESS_KEY'])"
+    secret_input = {"api_key": "sk-live-supersecret", "nested": {"token": "tok-12345"}}
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="job-redact",
+        job_data={
+            "code": secret_code,
+            "input_data": secret_input,
+            "idempotency_key": "idem-key-abc-123",
+            "job_type": "default",
+            "timeout": 30,
+            "startup_timeout": 60,
+            "requirements": ["numpy", "pandas"],
+            "correlation_id": "corr-redact",
+            "parent_execution_id": "parent-1",
+        },
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    pool._active_jobs[job.job_id] = job
+    pool._queue.put_nowait(job)
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        record = await asyncio.wait_for(job.future, timeout=5.0)
+    finally:
+        pool._shutdown = True
+        await asyncio.wait_for(worker, timeout=5.0)
+
+    assert record.status == "failed"
+    storage.add_to_dlq.assert_awaited_once()
+    entry = storage.add_to_dlq.await_args.args[0]
+    summary = entry.job_data
+
+    # Forensic fingerprints, sizes, flags, and metadata are retained.
+    assert summary["code_hash"] == sha256_content(secret_code)
+    assert summary["input_hash"] == sha256_json(secret_input)
+    assert summary["code_size_bytes"] == len(secret_code.encode("utf-8"))
+    assert summary["input_size_bytes"] > 0
+    assert summary["has_idempotency_key"] is True
+    assert summary["job_type"] == "default"
+    assert summary["timeout"] == 30
+    assert summary["startup_timeout"] == 60
+    assert summary["requirements"] == ["numpy", "pandas"]
+    assert summary["correlation_id"] == "corr-redact"
+    assert summary["parent_execution_id"] == "parent-1"
+
+    # Raw payloads and the key itself never reach storage.
+    assert "code" not in summary
+    assert "input_data" not in summary
+    assert "idempotency_key" not in summary
+    serialized = entry.model_dump_json()
+    assert secret_code not in serialized
+    assert "sk-live-supersecret" not in serialized
+    assert "tok-12345" not in serialized
+    assert "idem-key-abc-123" not in serialized


### PR DESCRIPTION
## Problem

Two verified issues (F18) in the dead-letter queue:

1. **DLQ stored raw sensitive payloads.** `DeadLetterEntry.job_data` persisted the FULL original job payload — raw code, `input_data`, and idempotency keys — as readable JSONB, and `GET /dlq` served it back verbatim. This contradicts `ExecutionRecord`'s deliberate hash-only posture ("input fingerprints, not raw data for security"). AI agents commonly embed credentials in `input_data`; those sat readable in the database.

2. **DLQ TTL was hardcoded to 7 days.** `_periodic_cleanup` had `dlq_ttl_days: int = 7` as a never-overridden default, not exposed in config — so forensic records of *internal* failures expired after 7 days while ordinary execution records live 30 (`execution_record_ttl_days`).

## Fix

- New `DeadLetterEntry.build_job_summary()` classmethod (`tako_vm/models.py`) builds a redacted forensic summary, applied at the enqueue point in the worker loop (`tako_vm/server/queue.py`). Retained: `job_type`, `timeout`/`startup_timeout`, `requirements` list (package names are not secrets and matter for diagnosing install failures), `correlation_id`, `parent_execution_id`, `code_hash` / `input_hash` (sha256, same helpers `submit()` uses), `code_size_bytes` / `input_size_bytes`, and `has_idempotency_key` (presence flag only). Dropped entirely: raw `code`, `input_data`, the idempotency key value. Policy documented on the model and on `storage.add_to_dlq`.
- Added `dlq_ttl_days: int = Field(default=30, ge=1, le=365)` to `TakoVMConfig` (default 30 to match record retention) and wired it through the `_periodic_cleanup` call in the app lifespan; the hardcoded `= 7` default is removed.

## Compatibility notes

- Checked all `job_data` consumers: `POST /jobs/{id}/rerun` and `/fork` replay from **ExecutionRecord** artifacts via `_get_replay_data()`, not from DLQ entries — there is no rerun-from-DLQ feature, so redaction breaks no replay path. `GET /dlq` now returns the redacted summary (intended behavior change). DLQ entries written before this change retain their original raw payloads until TTL expiry; the model docstring notes this.

## Tests

- `tests/test_models.py`: `build_job_summary` keeps fingerprints/sizes/metadata, drops raw payloads, handles minimal jobs.
- `tests/test_queue.py`: end-to-end through `_worker_loop` — an internal error produces a DLQ entry whose serialized form contains hashes/sizes/flags but NOT the raw code string, input_data values, or the idempotency key.
- `tests/test_config.py`: `dlq_ttl_days` default (30, matches record retention) and 1–365 bounds.

`pytest tests/test_queue.py tests/test_config.py tests/test_models.py -q`: 117 passed. `ruff check` / `ruff format`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)