### PR TITLE
fix(worker): verify OOM via docker inspect and move phase file out of sandbox-writable dir

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 set -e
 
-# Phase tracking file - Tako VM reads this to know which phase timed out
+# Phase tracking file - Tako VM reads this to know which phase timed out.
+#
+# Prefer the root-only /tako-meta control mount: /output is world-writable
+# (0777) and the sandbox user (uid 1000) could unlink and re-create
+# /output/.tako_phase to forge phase/timing data that feeds the server's
+# status determination. /tako-meta is mounted 0755 owned by the server uid,
+# so only this entrypoint (container root) can write it. Fall back to the
+# legacy /output location when /tako-meta is absent (old server that does
+# not mount it) or not writable by container root (server running as a
+# non-root host user; --cap-drop=ALL strips CAP_DAC_OVERRIDE, so root is
+# subject to normal permission checks on the bind mount). The writability
+# probe runs as root, before any privilege drop.
 PHASE_FILE="/output/.tako_phase"
+if [ -d /tako-meta ] && touch /tako-meta/.tako_phase 2>/dev/null; then
+    PHASE_FILE="/tako-meta/.tako_phase"
+fi
 
 # Helper to get current time in milliseconds
 get_time_ms() {

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -114,12 +114,13 @@ def remove_container(container_name: str) -> bool:
     Force-remove a container by name (best-effort).
 
     ``docker rm -f`` kills the container if it is running and removes it in
-    one step. Used before a retry attempt to clean up the previous attempt's
-    container so it cannot linger (``--rm`` removal can lag behind a daemon
-    hiccup — the very condition that triggers retries).
+    one step. Used by the worker after every run (its containers are started
+    without ``--rm`` so a 137 exit can be inspected for ``State.OOMKilled``)
+    and before a retry attempt to clean up the previous attempt's container
+    so it cannot linger (removal can lag behind a daemon hiccup — the very
+    condition that triggers retries).
 
-    Silently ignores errors (the container has usually already been removed
-    by ``--rm``).
+    Silently ignores errors (the container may already be gone).
 
     Args:
         container_name: Name of the container to remove
@@ -145,12 +146,55 @@ def remove_container(container_name: str) -> bool:
         return False
 
 
+def inspect_oom_killed(container_name: str) -> Optional[bool]:
+    """Check whether a container's process was OOM-killed via ``docker inspect``.
+
+    ``State.OOMKilled`` is the only authoritative signal that exit code 137
+    came from the kernel/cgroup OOM killer rather than some other SIGKILL
+    (``docker kill`` from a cancel path, a pids-limit kill, or user code
+    calling ``sys.exit(137)``). Requires the container to still exist, i.e.
+    the run must not use ``--rm`` (see ``base_isolation_args(auto_remove=
+    False)``); the caller is responsible for removing the container afterward.
+
+    Args:
+        container_name: Name of the container to inspect
+
+    Returns:
+        True/False from ``State.OOMKilled``, or None if the inspect failed
+        (container already gone, daemon unreachable, timeout, unparseable
+        output). Callers should treat None as "unknown" and fall back to
+        their previous heuristic so a flaky inspect never loses a true OOM.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.OOMKilled}}", container_name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.debug("docker inspect of %s failed (exit %s)", container_name, result.returncode)
+            return None
+        value = (result.stdout or "").strip().lower()
+        if value == "true":
+            return True
+        if value == "false":
+            return False
+        logger.debug("Unexpected OOMKilled value for %s: %r", container_name, result.stdout)
+        return None
+    except Exception as e:
+        logger.debug("Failed to inspect container %s: %s", container_name, e)
+        return None
+
+
 def base_isolation_args(
     container_name: str,
     *,
     runtime: str,
     enable_cap_restrictions: bool = True,
     execution_id: Optional[str] = None,
+    auto_remove: bool = True,
 ) -> list[str]:
     """Leading ``docker run`` args shared by every isolated-execution path.
 
@@ -174,6 +218,11 @@ def base_isolation_args(
         execution_id: Optional execution/job ID recorded as the
             ``tako-vm.execution-id`` label so orphaned containers can be traced
             back to their execution records.
+        auto_remove: Pass ``--rm`` so the daemon removes the container on
+            exit. Callers that need to ``docker inspect`` the exited container
+            (e.g. to read ``State.OOMKilled`` and distinguish a real OOM from
+            any other SIGKILL) must set this to False and remove the container
+            themselves (``remove_container``) once inspection is done.
 
     Returns:
         The leading argument list, ready to have path-specific flags and the
@@ -182,7 +231,10 @@ def base_isolation_args(
     args = [
         "docker",
         "run",
-        "--rm",
+    ]
+    if auto_remove:
+        args.append("--rm")
+    args += [
         f"--name={container_name}",
         # Identify the container as ours so startup cleanup can find orphans.
         f"--label={CONTAINER_LABEL}",

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -21,6 +21,7 @@ from tako_vm.constants import MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
 from tako_vm.execution.docker import (
     base_isolation_args,
     generate_container_name,
+    inspect_oom_killed,
     is_native_linux,
     kill_container,
     remove_container,
@@ -187,6 +188,50 @@ def _clear_output_dir(output_dir: Path) -> None:
         logger.warning("Failed to clear output dir %s: %s", output_dir, e)
 
 
+# Fixed uid of the in-container sandbox user (``useradd -u 1000 sandbox`` in
+# Dockerfile.executor); user code always runs as this uid via gosu.
+_SANDBOX_UID = 1000
+
+
+def _make_meta_dir(meta_dir: Path) -> Optional[Path]:
+    """Create the control-metadata dir mounted read-write at ``/tako-meta``.
+
+    The entrypoint writes ``.tako_phase`` (phase/timing data that feeds status
+    determination) here instead of the 0777 ``/output`` mount, because the
+    sandbox user (uid 1000) can unlink and re-create anything in ``/output``
+    and thereby forge timing/phase data. Mode 0755 means only the directory's
+    owner (the host server process uid) can write. The container runs with
+    ``--cap-drop=ALL`` (no CAP_DAC_OVERRIDE), so writes inside the container
+    are subject to plain permission checks against that host owner uid:
+
+    - Server running as root (the supported production deployment,
+      ``Dockerfile.server``): the dir is uid-0-owned, container root (the
+      entrypoint) can write, the sandbox user (uid 1000) cannot. Secure.
+    - Server running as a non-root host user: container root cannot write
+      either; the entrypoint detects this and falls back to the legacy
+      ``/output`` location (and ``parse_phase_file`` falls back with it) —
+      no worse than the previous behavior.
+    - Server running as host uid 1000 exactly: the dir would be owned by the
+      sandbox user inside the container, which as owner could chmod and write
+      it — the "trusted" location would be forgeable. Returns None so the
+      mount is skipped entirely and the legacy behavior applies.
+
+    Returns:
+        The created directory, or None when a trusted meta dir cannot be
+        provided (host uid collides with the sandbox uid).
+    """
+    if hasattr(os, "geteuid") and os.geteuid() == _SANDBOX_UID:
+        logger.debug(
+            "Server uid collides with in-container sandbox uid %s; "
+            "skipping /tako-meta mount (phase file stays in /output)",
+            _SANDBOX_UID,
+        )
+        return None
+    meta_dir.mkdir()
+    meta_dir.chmod(0o755)
+    return meta_dir
+
+
 def check_gvisor_available() -> bool:
     """
     Check if gVisor (runsc) runtime is available.
@@ -234,7 +279,9 @@ DEFAULT_JOB_TYPE = JobType(
 )
 
 
-def parse_phase_file(output_dir: Path) -> Optional[ExecutionTiming]:
+def parse_phase_file(
+    output_dir: Path, meta_dir: Optional[Path] = None
+) -> Optional[ExecutionTiming]:
     """
     Parse the phase tracking file written by entrypoint.sh.
 
@@ -246,18 +293,37 @@ def parse_phase_file(output_dir: Path) -> Optional[ExecutionTiming]:
     - total_ms: total container runtime
     - failed_phase: which phase failed (if phase=failed)
 
+    Trust model: the entrypoint prefers writing the phase file to the
+    root-only ``/tako-meta`` control mount (``meta_dir`` on the host), which
+    sandboxed user code (uid 1000) cannot write to. When the meta copy exists
+    it is authoritative and a (possibly forged) ``/output/.tako_phase`` is
+    ignored. The ``output_dir`` fallback only applies when no meta copy was
+    written — a stale executor image that predates ``/tako-meta``, or a host
+    setup where container root could not write the mount — and that fallback
+    copy lives in the 0777 output dir, so it remains untrusted legacy data.
+
     Args:
-        output_dir: Path to output directory containing .tako_phase file
+        output_dir: Path to output directory (legacy/fallback location)
+        meta_dir: Path to the root-only control metadata directory mounted at
+            /tako-meta (preferred location), or None if not mounted
 
     Returns:
         ExecutionTiming with parsed timing info, or None if file not found
     """
-    phase_file = output_dir / ".tako_phase"
-    # Untrusted code could point .tako_phase at a host file; never follow it.
-    if phase_file.is_symlink():
-        logger.warning("Phase file is a symlink, ignoring")
-        return None
-    if not phase_file.exists():
+    phase_file = None
+    candidates = []
+    if meta_dir is not None:
+        candidates.append(meta_dir / ".tako_phase")
+    candidates.append(output_dir / ".tako_phase")
+    for candidate in candidates:
+        # Untrusted code could point .tako_phase at a host file; never follow it.
+        if candidate.is_symlink():
+            logger.warning("Phase file %s is a symlink, ignoring", candidate)
+            continue
+        if candidate.exists():
+            phase_file = candidate
+            break
+    if phase_file is None:
         return None
 
     try:
@@ -482,6 +548,10 @@ class CodeExecutor:
             input_dir.mkdir()
             output_dir.mkdir()
             output_dir.chmod(0o777)  # Writable by container user (uid 1000)
+            # Control metadata (.tako_phase) mount: writable by container
+            # root only, NOT by the sandbox user — see _make_meta_dir.
+            # None when a trusted dir cannot be provided (mount is skipped).
+            meta_dir = _make_meta_dir(workspace / "meta")
 
             # Write generated code to file
             code_file = code_dir / "main.py"
@@ -503,6 +573,7 @@ class CodeExecutor:
                 job_type=job_type,
                 extra_requirements=job.get("requirements"),
                 job_id=job_id,
+                meta_dir=meta_dir,
             )
 
             # Add job type info to result
@@ -610,6 +681,10 @@ class CodeExecutor:
             input_dir.mkdir()
             output_dir.mkdir()
             output_dir.chmod(0o777)  # Writable by container user (uid 1000)
+            # Control metadata (.tako_phase) mount: writable by container
+            # root only, NOT by the sandbox user — see _make_meta_dir.
+            # None when a trusted dir cannot be provided (mount is skipped).
+            meta_dir = _make_meta_dir(workspace / "meta")
 
             # Write generated code to file
             code_file = code_dir / "main.py"
@@ -651,14 +726,17 @@ class CodeExecutor:
                 record.attempt = attempt
                 if attempt > 0:
                     # Make retries idempotent. The previous attempt's
-                    # container may still exist (`--rm` removal can lag the
-                    # very daemon hiccup that triggered the retry), and its
-                    # partial output (result.json, .tako_phase, artifacts)
-                    # may still be in output_dir — remove both so the retry
+                    # container may still exist (its removal is best-effort
+                    # and can fail during the very daemon hiccup that
+                    # triggered the retry), and its partial output
+                    # (result.json, .tako_phase, artifacts) may still be in
+                    # output_dir/meta_dir — remove all of these so the retry
                     # cannot collide on a container name or report stale
                     # results from the failed attempt.
                     remove_container(generate_container_name("tako", job_id, attempt=attempt - 1))
                     _clear_output_dir(output_dir)
+                    if meta_dir is not None:
+                        _clear_output_dir(meta_dir)
                 try:
                     result = self._run_container(
                         code_dir=code_dir,
@@ -670,6 +748,7 @@ class CodeExecutor:
                         extra_requirements=job.get("requirements"),
                         job_id=job_id,
                         attempt=attempt,
+                        meta_dir=meta_dir,
                     )
 
                     # Host-level timeout: the job already consumed its full
@@ -759,8 +838,10 @@ class CodeExecutor:
                 except json.JSONDecodeError:
                     pass
 
-            # Parse phase timing file (written by entrypoint.sh)
-            timing = parse_phase_file(output_dir)
+            # Parse phase timing file (written by entrypoint.sh). The
+            # root-only meta_dir copy is preferred; the /output copy is a
+            # legacy fallback that sandboxed code can forge.
+            timing = parse_phase_file(output_dir, meta_dir)
             record.timing = timing
 
             # Determine which phase timed out (if applicable)
@@ -802,13 +883,32 @@ class CodeExecutor:
                         phase=timing.phase_at_exit if timing else None,
                     )
             elif result.get("exit_code") == 137:
-                record.status = "oom"
+                # Exit 137 means SIGKILL, but not necessarily the OOM killer:
+                # `docker kill` (cancel path), a pids-limit kill, or user code
+                # calling sys.exit(137) all look identical. _run_container
+                # inspects State.OOMKilled before removing the container:
+                # True -> genuine OOM; False -> killed but NOT by the memory
+                # limit; None (inspect failed) -> fall back to the historical
+                # behavior of reporting OOM so a flaky inspect never loses a
+                # true OOM.
                 phase = timing.phase_at_exit if timing else None
-                record.error = ExecutionError(
-                    type="oom",
-                    message="Execution exceeded memory limit",
-                    phase=phase,
-                )
+                if result.get("oom_killed") is False:
+                    record.status = "failed"
+                    record.error = ExecutionError(
+                        type="killed",
+                        message=(
+                            "Process was killed (SIGKILL) but not by the memory "
+                            "limit (no OOM kill recorded for the container)"
+                        ),
+                        phase=phase,
+                    )
+                else:
+                    record.status = "oom"
+                    record.error = ExecutionError(
+                        type="oom",
+                        message="Execution exceeded memory limit",
+                        phase=phase,
+                    )
             elif result.get("success"):
                 record.status = "succeeded"
             else:
@@ -1000,9 +1100,17 @@ class CodeExecutor:
         extra_requirements: Optional[List[str]] = None,
         job_id: Optional[str] = None,
         attempt: int = 0,
+        meta_dir: Optional[Path] = None,
     ) -> Dict[str, Any]:
         """
         Run Docker container with security restrictions.
+
+        The container is started WITHOUT ``--rm`` so that on exit code 137 the
+        exited container can be inspected for ``State.OOMKilled`` (the only
+        authoritative OOM signal — ``--rm`` would race the inspect). Every
+        exit path from this method removes the container via a best-effort
+        ``docker rm -f`` in a ``finally`` block; the labeled orphan cleanup at
+        startup remains as a backstop only.
 
         Args:
             code_dir: Path to directory containing code (will be mounted read-only)
@@ -1016,9 +1124,15 @@ class CodeExecutor:
             attempt: Retry attempt index; attempts > 0 get a suffixed
                 container name so they cannot collide with a previous
                 attempt's not-yet-removed container
+            meta_dir: Host dir mounted at /tako-meta for control metadata
+                (.tako_phase) writable by container root but not the sandbox
+                user, or None to skip the mount (entrypoint then falls back
+                to the legacy /output location)
 
         Returns:
-            Dictionary with execution results
+            Dictionary with execution results. On exit code 137 it includes
+            ``oom_killed``: True/False from docker inspect, or None if the
+            inspect failed (callers should treat None as "assume OOM").
         """
         # Check circuit breaker before attempting Docker operation
         circuit_breaker = get_circuit_breaker()
@@ -1114,11 +1228,16 @@ class CodeExecutor:
         # generate_container_name for the queue.py cancel/watchdog caveat.
         container_name = generate_container_name("tako", job_id, attempt=attempt)
 
+        # auto_remove=False: keep the exited container so a 137 exit can be
+        # checked against `docker inspect .State.OOMKilled` (with --rm the
+        # daemon removes the container before it can be inspected). The
+        # finally block below guarantees removal on every exit path.
         cmd = base_isolation_args(
             container_name,
             runtime=self._runtime,
             enable_cap_restrictions=self.config.enable_cap_restrictions,
             execution_id=job_id,
+            auto_remove=False,
         )
 
         # Mount uv cache volume for faster repeated installs
@@ -1164,6 +1283,12 @@ class CodeExecutor:
             ]
         )
 
+        # Control-metadata mount: the entrypoint (running as container root)
+        # writes .tako_phase here instead of the sandbox-writable /output, so
+        # user code cannot forge phase/timing data. See _make_meta_dir.
+        if meta_dir is not None:
+            cmd.append(f"--mount=type=bind,source={meta_dir.absolute()},target=/tako-meta")
+
         # Add seccomp profile if enabled and exists (native Linux only)
         # Docker Desktop (macOS/Windows) has issues with custom seccomp profiles
         # Some CI environments (GitHub Actions) may also have issues with custom seccomp
@@ -1192,16 +1317,17 @@ class CodeExecutor:
         # Add image name
         cmd.append(image_name)
 
+        container_timeout = startup_timeout + timeout + 5
+        if not validate_docker_run_args(cmd):
+            return {
+                "success": False,
+                "error": "Unsafe Docker command rejected",
+                "stdout": "",
+                "stderr": "Docker command arguments failed validation",
+                "exit_code": -1,
+            }
+
         try:
-            container_timeout = startup_timeout + timeout + 5
-            if not validate_docker_run_args(cmd):
-                return {
-                    "success": False,
-                    "error": "Unsafe Docker command rejected",
-                    "stdout": "",
-                    "stderr": "Docker command arguments failed validation",
-                    "exit_code": -1,
-                }
             result = subprocess.run(
                 cmd, timeout=container_timeout, capture_output=True, text=True, check=False
             )
@@ -1240,11 +1366,22 @@ class CodeExecutor:
             # non-zero exit from user code) means Docker itself is healthy.
             circuit_breaker.record_success()
 
+            # Exit 137 is SIGKILL — could be the OOM killer, but also `docker
+            # kill` (cancel path), a pids-limit kill, or user sys.exit(137).
+            # Only the exited container's State.OOMKilled distinguishes them;
+            # inspect before the finally block removes the container. Note:
+            # in-container timeout kills are already remapped to 124 by the
+            # entrypoint, so a 137 seen here is a genuine SIGKILL.
+            oom_killed: Optional[bool] = None
+            if result.returncode == 137:
+                oom_killed = inspect_oom_killed(container_name)
+
             return {
                 "success": result.returncode == 0,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
                 "exit_code": result.returncode,
+                "oom_killed": oom_killed,
             }
 
         except subprocess.TimeoutExpired as e:
@@ -1289,6 +1426,15 @@ class CodeExecutor:
                 "stderr": "",
                 "exit_code": -1,
             }
+        finally:
+            # The container is started without --rm (so a 137 exit can be
+            # inspected for State.OOMKilled above), which makes this method
+            # responsible for removal on EVERY exit path: success, user-code
+            # failure, infra failure, host timeout (kill_container above only
+            # kills, it does not remove), and unexpected exceptions. Removal
+            # is best-effort (`docker rm -f`, errors swallowed); the labeled
+            # orphan cleanup at startup is the backstop if it fails.
+            remove_container(container_name)
 
 
 if __name__ == "__main__":

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -12,6 +12,7 @@ from tako_vm.execution.docker import (
     EXECUTION_ID_LABEL,
     base_isolation_args,
     generate_container_name,
+    inspect_oom_killed,
     is_native_linux,
     kill_container,
     remove_container,
@@ -158,6 +159,62 @@ class TestRemoveContainer:
         assert remove_container("error-container") is False
 
 
+class TestInspectOomKilled:
+    """Tests for inspect_oom_killed() — the authoritative OOM signal."""
+
+    @patch("subprocess.run")
+    def test_inspect_calls_docker_with_oomkilled_format(self, mock_run):
+        """inspect_oom_killed asks docker inspect for State.OOMKilled with a short timeout."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="true\n")
+
+        assert inspect_oom_killed("tako-test-123") is True
+
+        mock_run.assert_called_once_with(
+            ["docker", "inspect", "--format", "{{.State.OOMKilled}}", "tako-test-123"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    def test_returns_false_when_not_oom_killed(self, mock_run):
+        """A SIGKILL that was not the OOM killer reports OOMKilled=false."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="false\n")
+
+        assert inspect_oom_killed("tako-test-123") is False
+
+    @patch("subprocess.run")
+    def test_returns_none_when_container_missing(self, mock_run):
+        """A failed inspect (container already gone) returns None, not False."""
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="Error: No such object: tako-test-123"
+        )
+
+        assert inspect_oom_killed("tako-test-123") is None
+
+    @patch("subprocess.run")
+    def test_returns_none_on_unparseable_output(self, mock_run):
+        """Unexpected inspect output is treated as unknown (None)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="<no value>\n")
+
+        assert inspect_oom_killed("tako-test-123") is None
+
+    @patch("subprocess.run")
+    def test_returns_none_on_timeout(self, mock_run):
+        """A hung docker inspect returns None instead of raising."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
+
+        assert inspect_oom_killed("tako-test-123") is None
+
+    @patch("subprocess.run")
+    def test_returns_none_on_unexpected_exception(self, mock_run):
+        """Any unexpected failure is swallowed and reported as unknown."""
+        mock_run.side_effect = Exception("boom")
+
+        assert inspect_oom_killed("tako-test-123") is None
+
+
 class TestContainerNameValidation:
     """Tests for container name format validation."""
 
@@ -237,3 +294,21 @@ class TestBaseIsolationArgs:
     def test_runc_is_implicit(self):
         """runc is docker's default and is not passed explicitly."""
         assert not any(a.startswith("--runtime") for a in base_isolation_args("c1", runtime="runc"))
+
+    def test_auto_remove_default_includes_rm(self):
+        """By default the container is auto-removed on exit (--rm)."""
+        assert "--rm" in base_isolation_args("c1", runtime="runc")
+
+    def test_auto_remove_false_omits_rm(self):
+        """auto_remove=False omits --rm so the exited container can be inspected."""
+        args = base_isolation_args("c1", runtime="runc", auto_remove=False)
+        assert "--rm" not in args
+        # The rest of the isolation posture is unchanged
+        assert args[:6] == [
+            "docker",
+            "run",
+            "--name=c1",
+            f"--label={CONTAINER_LABEL}",
+            "--init",
+            "--read-only",
+        ]

--- a/tests/test_worker_errors.py
+++ b/tests/test_worker_errors.py
@@ -20,6 +20,16 @@ Covers:
 4. Truncation flags: cap_output truncated stdout/stderr in-band but
    record.stdout_truncated / stderr_truncated were never set.
 
+5. OOM detection: exit code 137 was unconditionally reported as "oom", but
+   137 is just SIGKILL — `docker kill` (cancel), pids-limit kills, and user
+   sys.exit(137) looked identical, and the authoritative State.OOMKilled flag
+   was unreadable because `--rm` removed the container before inspection.
+
+6. Phase-file trust: .tako_phase lived in the 0777 /output mount, so the
+   sandbox user could unlink/re-create it and forge the timing/phase data
+   that feeds status determination. It now lives in the root-only /tako-meta
+   mount when available.
+
 All tests mock subprocess.run — no Docker required.
 """
 
@@ -31,7 +41,7 @@ import pytest
 
 import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
-from tako_vm.execution.worker import CodeExecutor
+from tako_vm.execution.worker import CodeExecutor, parse_phase_file
 from tako_vm.job_types import JobType
 
 DAEMON_DOWN_STDERR = (
@@ -105,10 +115,22 @@ def _run_container(executor, io_dirs):
 
 
 def _patch_subprocess(monkeypatch, side_effect):
-    """Replace subprocess.run in the worker module; returns the call counter."""
+    """Replace subprocess.run in the worker module; returns the call counter.
+
+    Only `docker run` invocations consume `side_effect` and increment the
+    counter: cleanup `docker rm -f` (every run now removes its own container,
+    since --rm was dropped to allow OOM inspection) and `docker inspect`
+    calls are answered with a benign failure so they stay invisible to tests
+    that only care about how often the container ran.
+    """
     calls = {"count": 0}
 
-    def fake_run(*args, **kwargs):
+    def fake_run(cmd, *args, **kwargs):
+        prefix = list(cmd[:2])
+        if prefix == ["docker", "rm"]:
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        if prefix == ["docker", "inspect"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="No such object")
         calls["count"] += 1
         result = side_effect()
         if isinstance(result, BaseException):
@@ -119,41 +141,67 @@ def _patch_subprocess(monkeypatch, side_effect):
     return calls
 
 
+def _mount_source_dir(cmd, target):
+    """Extract the host source dir of a bind mount from a docker run cmd."""
+    for arg in cmd:
+        if arg.startswith("--mount=type=bind,") and arg.endswith(f",target={target}"):
+            return Path(arg.split("source=", 1)[1].split(",", 1)[0])
+    raise AssertionError(f"docker run command has no {target} bind mount")
+
+
 def _output_mount_dir(cmd):
     """Extract the host source dir of the /output bind mount from a docker run cmd."""
-    for arg in cmd:
-        if arg.startswith("--mount=type=bind,") and arg.endswith(",target=/output"):
-            return Path(arg.split("source=", 1)[1].split(",", 1)[0])
-    raise AssertionError("docker run command has no /output bind mount")
+    return _mount_source_dir(cmd, "/output")
 
 
-def _patch_docker_cli(monkeypatch, run_results, on_run=None):
-    """Fake subprocess.run that distinguishes `docker run` from `docker rm`.
+def _meta_mount_dir(cmd):
+    """Extract the host source dir of the /tako-meta bind mount from a docker run cmd."""
+    return _mount_source_dir(cmd, "/tako-meta")
+
+
+def _patch_docker_cli(monkeypatch, run_results, on_run=None, inspect_result=None):
+    """Fake subprocess.run that dispatches on the docker subcommand.
 
     `docker run` invocations consume `run_results` in order (calling `on_run`
     with (attempt_index, cmd) first, e.g. to seed stale files into the mounted
-    output dir); `docker rm` invocations are recorded and succeed. Any other
-    docker command fails the test.
+    output dir); an item that is an exception is raised instead of returned.
+    `docker rm` / `docker kill` invocations are recorded and succeed.
+    `docker inspect` invocations are recorded and return `inspect_result`
+    (default: a "no such object" failure). Any other docker command fails
+    the test.
 
-    Returns (run_cmds, rm_cmds) lists, appended to as calls happen.
+    Returns a SimpleNamespace with `run`, `rm`, `kill`, `inspect` command
+    lists plus `all` (every command, in call order).
     """
-    run_cmds = []
-    rm_cmds = []
+    cli = SimpleNamespace(run=[], rm=[], kill=[], inspect=[], all=[])
     results = iter(run_results)
 
     def fake_run(cmd, *args, **kwargs):
-        if cmd[:2] == ["docker", "run"]:
+        cli.all.append(cmd)
+        prefix = list(cmd[:2])
+        if prefix == ["docker", "run"]:
             if on_run:
-                on_run(len(run_cmds), cmd)
-            run_cmds.append(cmd)
-            return next(results)
-        if cmd[:2] == ["docker", "rm"]:
-            rm_cmds.append(cmd)
+                on_run(len(cli.run), cmd)
+            cli.run.append(cmd)
+            result = next(results)
+            if isinstance(result, BaseException):
+                raise result
+            return result
+        if prefix == ["docker", "rm"]:
+            cli.rm.append(cmd)
             return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        if prefix == ["docker", "kill"]:
+            cli.kill.append(cmd)
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        if prefix == ["docker", "inspect"]:
+            cli.inspect.append(cmd)
+            if inspect_result is not None:
+                return inspect_result
+            return SimpleNamespace(returncode=1, stdout="", stderr="No such object")
         raise AssertionError(f"unexpected docker command: {cmd}")
 
     monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
-    return run_cmds, rm_cmds
+    return cli
 
 
 def _infra_failure():
@@ -162,6 +210,15 @@ def _infra_failure():
 
 def _success(stdout="ok", stderr=""):
     return SimpleNamespace(returncode=0, stdout=stdout, stderr=stderr)
+
+
+def _exit_137(stderr=""):
+    return SimpleNamespace(returncode=137, stdout="", stderr=stderr)
+
+
+def _inspect_says(value):
+    """A successful `docker inspect --format {{.State.OOMKilled}}` result."""
+    return SimpleNamespace(returncode=0, stdout=f"{value}\n", stderr="")
 
 
 class TestDockerInfraFailure:
@@ -206,14 +263,14 @@ class TestDockerInfraFailure:
     def test_daemon_down_retries_and_record_is_service_unavailable(
         self, executor, breaker, monkeypatch
     ):
-        run_cmds, _ = _patch_docker_cli(monkeypatch, [_infra_failure(), _infra_failure()])
+        cli = _patch_docker_cli(monkeypatch, [_infra_failure(), _infra_failure()])
 
         record = executor.execute_job_with_record(
             "job-infra-1", {"code": "print('hi')", "input_data": {}}
         )
 
         # Retry loop fired: both configured attempts hit Docker
-        assert len(run_cmds) == 2
+        assert len(cli.run) == 2
         assert len(breaker.failures) == 2
         assert breaker.successes == 0
 
@@ -319,21 +376,23 @@ class TestRetryIdempotency:
         self, executor, breaker, monkeypatch
     ):
         """Attempt 2 gets a -r1 name and the attempt-1 container is force-removed first."""
-        run_cmds, rm_cmds = _patch_docker_cli(monkeypatch, [_infra_failure(), _success()])
+        cli = _patch_docker_cli(monkeypatch, [_infra_failure(), _success()])
 
         record = executor.execute_job_with_record(
             "job-retry-name", {"code": "print('hi')", "input_data": {}}
         )
 
         assert record.status == "succeeded"
-        assert len(run_cmds) == 2
-        names = [next(a for a in cmd if a.startswith("--name=")) for cmd in run_cmds]
+        assert len(cli.run) == 2
+        names = [next(a for a in cmd if a.startswith("--name=")) for cmd in cli.run]
         # Attempt 0 keeps the deterministic name (cancel/watchdog paths match
-        # it); the retry gets a unique suffix so a lingering --rm container
-        # from attempt 0 cannot cause a "name already in use" failure.
+        # it); the retry gets a unique suffix so a lingering container from
+        # attempt 0 cannot cause a "name already in use" failure.
         assert names == ["--name=tako-job-retry-name", "--name=tako-job-retry-name-r1"]
         # Best-effort cleanup of the previous attempt's container fired
-        assert ["docker", "rm", "-f", "tako-job-retry-name"] in rm_cmds
+        assert ["docker", "rm", "-f", "tako-job-retry-name"] in cli.rm
+        # The retry's own container is removed too (no --rm anymore)
+        assert ["docker", "rm", "-f", "tako-job-retry-name-r1"] in cli.rm
 
     def test_stale_output_cleared_between_attempts(self, executor, breaker, monkeypatch):
         """Leftovers from a failed attempt must not be reported as retry results."""
@@ -376,7 +435,7 @@ class TestRetryIdempotency:
 
     def test_attempt_zero_when_no_retry_needed(self, executor, breaker, monkeypatch):
         """A first-attempt success records attempt 0 with the configured ceiling."""
-        run_cmds, rm_cmds = _patch_docker_cli(monkeypatch, [_success()])
+        cli = _patch_docker_cli(monkeypatch, [_success()])
 
         record = executor.execute_job_with_record(
             "job-no-retry", {"code": "print('hi')", "input_data": {}}
@@ -385,8 +444,10 @@ class TestRetryIdempotency:
         assert record.status == "succeeded"
         assert record.attempt == 0
         assert record.max_attempts == 2
-        assert len(run_cmds) == 1
-        assert rm_cmds == [], "no retry means no defensive container removal"
+        assert len(cli.run) == 1
+        # No --rm anymore: the run's own container is removed exactly once,
+        # and no defensive pre-retry removal happened.
+        assert cli.rm == [["docker", "rm", "-f", "tako-job-no-retry"]]
 
 
 class TestTruncationFlags:
@@ -439,3 +500,333 @@ class TestTruncationFlags:
         assert record.stderr_truncated is False
         assert record.stdout == "small out"
         assert record.stderr == "small err"
+
+
+class TestOomDetection:
+    """Exit 137 must be verified against State.OOMKilled, not assumed to be OOM."""
+
+    def test_exit_137_with_oomkilled_true_is_oom(self, executor, breaker, monkeypatch):
+        """A genuine OOM kill (inspect says OOMKilled=true) reports status='oom'."""
+        cli = _patch_docker_cli(monkeypatch, [_exit_137()], inspect_result=_inspect_says("true"))
+
+        record = executor.execute_job_with_record(
+            "job-oom-true", {"code": "x = 'a' * 10**12", "input_data": {}}
+        )
+
+        assert record.status == "oom"
+        assert record.error is not None
+        assert record.error.type == "oom"
+        assert "memory" in record.error.message.lower()
+        # The right container was inspected
+        assert cli.inspect == [
+            ["docker", "inspect", "--format", "{{.State.OOMKilled}}", "tako-job-oom-true"]
+        ]
+
+    def test_exit_137_with_oomkilled_false_is_failed_killed(self, executor, breaker, monkeypatch):
+        """A non-OOM SIGKILL (docker kill, pids-limit, sys.exit(137)) is NOT 'oom'."""
+        cli = _patch_docker_cli(monkeypatch, [_exit_137()], inspect_result=_inspect_says("false"))
+
+        record = executor.execute_job_with_record(
+            "job-oom-false", {"code": "import sys; sys.exit(137)", "input_data": {}}
+        )
+
+        assert record.status == "failed"
+        assert record.error is not None
+        assert record.error.type == "killed"
+        assert "SIGKILL" in record.error.message
+        # The message must distinguish this from an OOM kill
+        assert "not by the memory limit" in record.error.message
+        assert len(cli.inspect) == 1
+
+    def test_exit_137_with_inspect_failure_falls_back_to_oom(self, executor, breaker, monkeypatch):
+        """A flaky/failed inspect (None) must not lose a true OOM: fall back to 'oom'."""
+        # Default inspect_result is a "No such object" failure -> None
+        _patch_docker_cli(monkeypatch, [_exit_137()])
+
+        record = executor.execute_job_with_record(
+            "job-oom-unknown", {"code": "x = 'a' * 10**12", "input_data": {}}
+        )
+
+        assert record.status == "oom"
+        assert record.error is not None
+        assert record.error.type == "oom"
+
+    def test_inspect_happens_before_container_removal(self, executor, breaker, monkeypatch):
+        """The container must still exist when inspected (rm -f comes after)."""
+        cli = _patch_docker_cli(monkeypatch, [_exit_137()], inspect_result=_inspect_says("true"))
+
+        executor.execute_job_with_record("job-oom-order", {"code": "x", "input_data": {}})
+
+        inspect_idx = next(i for i, c in enumerate(cli.all) if c[:2] == ["docker", "inspect"])
+        rm_idx = next(i for i, c in enumerate(cli.all) if c[:3] == ["docker", "rm", "-f"])
+        assert inspect_idx < rm_idx, "inspect must run before the container is removed"
+
+    def test_no_inspect_on_other_exit_codes(self, executor, breaker, monkeypatch):
+        """The inspect is kept cheap: only exit 137 triggers it."""
+        cli = _patch_docker_cli(
+            monkeypatch,
+            [SimpleNamespace(returncode=1, stdout="", stderr="ValueError: boom")],
+        )
+
+        record = executor.execute_job_with_record(
+            "job-no-inspect", {"code": "raise ValueError('boom')", "input_data": {}}
+        )
+
+        assert record.status == "failed"
+        assert cli.inspect == []
+
+    def test_no_inspect_on_success(self, executor, breaker, monkeypatch):
+        cli = _patch_docker_cli(monkeypatch, [_success()])
+
+        record = executor.execute_job_with_record(
+            "job-ok-no-inspect", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert cli.inspect == []
+
+
+class TestContainerRemoval:
+    """Without --rm, every exit path from _run_container must remove the container."""
+
+    def test_docker_run_has_no_rm_flag(self, executor, breaker, monkeypatch):
+        """--rm would delete the container before State.OOMKilled can be read."""
+        cli = _patch_docker_cli(monkeypatch, [_success()])
+
+        executor.execute_job_with_record("job-norm", {"code": "print('hi')", "input_data": {}})
+
+        assert "--rm" not in cli.run[0]
+
+    def test_container_removed_on_success(self, executor, breaker, monkeypatch):
+        cli = _patch_docker_cli(monkeypatch, [_success()])
+
+        record = executor.execute_job_with_record(
+            "job-rm-ok", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert ["docker", "rm", "-f", "tako-job-rm-ok"] in cli.rm
+
+    def test_container_removed_on_user_failure(self, executor, breaker, monkeypatch):
+        cli = _patch_docker_cli(
+            monkeypatch,
+            [SimpleNamespace(returncode=1, stdout="", stderr="ValueError: boom")],
+        )
+
+        record = executor.execute_job_with_record(
+            "job-rm-fail", {"code": "raise ValueError('boom')", "input_data": {}}
+        )
+
+        assert record.status == "failed"
+        assert ["docker", "rm", "-f", "tako-job-rm-fail"] in cli.rm
+
+    def test_container_removed_on_infra_failure(self, executor, breaker, monkeypatch):
+        cli = _patch_docker_cli(monkeypatch, [_infra_failure(), _infra_failure()])
+
+        record = executor.execute_job_with_record(
+            "job-rm-infra", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "failed"
+        # Both attempts' containers were removed (best-effort)
+        assert ["docker", "rm", "-f", "tako-job-rm-infra"] in cli.rm
+        assert ["docker", "rm", "-f", "tako-job-rm-infra-r1"] in cli.rm
+
+    def test_container_killed_and_removed_on_host_timeout(self, executor, breaker, monkeypatch):
+        """Host-level timeout still kills the running container AND removes it."""
+        cli = _patch_docker_cli(
+            monkeypatch,
+            [subprocess.TimeoutExpired(["docker", "run"], 80, output=b"partial", stderr=None)],
+        )
+
+        record = executor.execute_job_with_record(
+            "job-rm-timeout", {"code": "while True: pass", "input_data": {}, "timeout": 30}
+        )
+
+        assert record.status == "timeout"
+        assert ["docker", "kill", "tako-job-rm-timeout"] in cli.kill
+        assert ["docker", "rm", "-f", "tako-job-rm-timeout"] in cli.rm
+
+
+class TestPhaseFileTrust:
+    """.tako_phase must come from the root-only /tako-meta mount, not 0777 /output."""
+
+    META_PHASE = (
+        "container_start_ms=0\n"
+        "phase=startup\n"
+        "dep_install_started=false\n"
+        "dep_install_ms=0\n"
+        "startup_ms=11\n"
+        "phase=execution\n"
+        "execution_ms=222\n"
+        "phase=completed\n"
+        "total_ms=233\n"
+    )
+    FORGED_PHASE = (
+        "phase=completed\nstartup_ms=1\ndep_install_ms=0\nexecution_ms=99999\ntotal_ms=99999\n"
+    )
+
+    @pytest.fixture(autouse=True)
+    def run_as_root(self, monkeypatch):
+        """Pretend the server runs as root so the meta dir is created/mounted."""
+        monkeypatch.setattr(worker_module.os, "geteuid", lambda: 0, raising=False)
+
+    def test_meta_dir_mounted_separately_from_output(self, executor, breaker, monkeypatch):
+        seen = {}
+
+        def on_run(attempt_idx, cmd):
+            seen["meta"] = _meta_mount_dir(cmd)
+            seen["output"] = _output_mount_dir(cmd)
+
+        _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+
+        executor.execute_job_with_record("job-meta-mount", {"code": "x", "input_data": {}})
+
+        assert seen["meta"] != seen["output"]
+        assert seen["meta"].name == "meta"
+
+    def test_meta_dir_is_not_world_writable(self, executor, breaker, monkeypatch):
+        """0755: the in-container sandbox user (uid 1000) must not be able to write."""
+        seen = {}
+
+        def on_run(attempt_idx, cmd):
+            seen["mode"] = _meta_mount_dir(cmd).stat().st_mode & 0o777
+
+        _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+
+        executor.execute_job_with_record("job-meta-mode", {"code": "x", "input_data": {}})
+
+        assert seen["mode"] == 0o755
+
+    def test_phase_file_read_from_meta_dir_when_present(self, executor, breaker, monkeypatch):
+        """A forged /output/.tako_phase is ignored when the meta copy exists."""
+
+        def on_run(attempt_idx, cmd):
+            # Entrypoint (container root) writes the real phase data to /tako-meta
+            (_meta_mount_dir(cmd) / ".tako_phase").write_text(self.META_PHASE)
+            # Sandboxed user code forges a copy in the 0777 /output mount
+            (_output_mount_dir(cmd) / ".tako_phase").write_text(self.FORGED_PHASE)
+
+        _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+
+        record = executor.execute_job_with_record("job-meta-trust", {"code": "x", "input_data": {}})
+
+        assert record.timing is not None
+        assert record.timing.execution_ms == 222, "timing must come from the meta copy"
+        assert record.timing.startup_ms == 11
+
+    def test_phase_file_falls_back_to_output_dir(self, executor, breaker, monkeypatch):
+        """Old executor images write only /output/.tako_phase; it must still parse."""
+
+        def on_run(attempt_idx, cmd):
+            (_output_mount_dir(cmd) / ".tako_phase").write_text(self.META_PHASE)
+
+        _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+
+        record = executor.execute_job_with_record(
+            "job-meta-fallback", {"code": "x", "input_data": {}}
+        )
+
+        assert record.timing is not None
+        assert record.timing.execution_ms == 222
+
+    def test_no_meta_mount_when_host_uid_is_sandbox_uid(self, executor, breaker, monkeypatch):
+        """Host uid 1000 == container sandbox uid: a 'trusted' meta dir would be
+        sandbox-owned (forgeable), so the mount must be skipped entirely."""
+        monkeypatch.setattr(worker_module.os, "geteuid", lambda: 1000, raising=False)
+
+        def on_run(attempt_idx, cmd):
+            (_output_mount_dir(cmd) / ".tako_phase").write_text(self.META_PHASE)
+
+        cli = _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+
+        record = executor.execute_job_with_record(
+            "job-meta-collision", {"code": "x", "input_data": {}}
+        )
+
+        assert not any("target=/tako-meta" in arg for arg in cli.run[0])
+        # Legacy behavior still works
+        assert record.status == "succeeded"
+        assert record.timing is not None
+
+    def test_parse_phase_file_prefers_meta_dir(self, tmp_path):
+        output_dir = tmp_path / "output"
+        meta_dir = tmp_path / "meta"
+        output_dir.mkdir()
+        meta_dir.mkdir()
+        (meta_dir / ".tako_phase").write_text(self.META_PHASE)
+        (output_dir / ".tako_phase").write_text(self.FORGED_PHASE)
+
+        timing = parse_phase_file(output_dir, meta_dir)
+
+        assert timing is not None
+        assert timing.execution_ms == 222
+
+    def test_parse_phase_file_output_fallback_when_meta_empty(self, tmp_path):
+        output_dir = tmp_path / "output"
+        meta_dir = tmp_path / "meta"
+        output_dir.mkdir()
+        meta_dir.mkdir()
+        (output_dir / ".tako_phase").write_text(self.META_PHASE)
+
+        timing = parse_phase_file(output_dir, meta_dir)
+
+        assert timing is not None
+        assert timing.execution_ms == 222
+
+    def test_parse_phase_file_without_meta_dir(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        (output_dir / ".tako_phase").write_text(self.META_PHASE)
+
+        timing = parse_phase_file(output_dir, None)
+
+        assert timing is not None
+        assert timing.execution_ms == 222
+
+    def test_parse_phase_file_ignores_symlinked_output_phase(self, tmp_path):
+        """A symlink planted at /output/.tako_phase is never followed."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        target = tmp_path / "host-secret"
+        target.write_text("phase=completed\nexecution_ms=1\n")
+        (output_dir / ".tako_phase").symlink_to(target)
+
+        assert parse_phase_file(output_dir, None) is None
+
+    def test_stale_meta_phase_cleared_between_retry_attempts(self, executor, breaker, monkeypatch):
+        """A failed attempt's meta phase file must not leak into the retry's record."""
+        seen_on_retry = {}
+
+        def on_run(attempt_idx, cmd):
+            meta = _meta_mount_dir(cmd)
+            if attempt_idx == 0:
+                (meta / ".tako_phase").write_text("phase=failed\nfailed_phase=startup\n")
+            else:
+                seen_on_retry["entries"] = sorted(p.name for p in meta.iterdir())
+
+        _patch_docker_cli(monkeypatch, [_infra_failure(), _success()], on_run=on_run)
+
+        record = executor.execute_job_with_record("job-meta-retry", {"code": "x", "input_data": {}})
+
+        assert record.status == "succeeded"
+        assert seen_on_retry["entries"] == [], "meta dir must be empty when a retry starts"
+        assert record.timing is None
+
+
+class TestEntrypointScript:
+    """The entrypoint must stay valid bash and keep the dual-location phase file."""
+
+    ENTRYPOINT = Path(__file__).resolve().parent.parent / "docker" / "entrypoint.sh"
+
+    def test_bash_syntax_is_valid(self):
+        result = subprocess.run(
+            ["bash", "-n", str(self.ENTRYPOINT)], capture_output=True, text=True, check=False
+        )
+        assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+    def test_prefers_tako_meta_with_output_fallback(self):
+        """Old hosts (no /tako-meta mount) must keep working: /output is the fallback."""
+        content = self.ENTRYPOINT.read_text(encoding="utf-8")
+        assert 'PHASE_FILE="/output/.tako_phase"' in content
+        assert 'PHASE_FILE="/tako-meta/.tako_phase"' in content


### PR DESCRIPTION
## Summary

Fixes two verified execution-status integrity bugs in the worker.

### F13c — OOM status was just "exit code 137"

Exit 137 is any SIGKILL: `docker kill` from the queue cancel path, pids-limit kills, and user code calling `sys.exit(137)` were all misreported as `status="oom"`. The authoritative signal — `docker inspect State.OOMKilled` — was unreadable because `--rm` removed the container before it could be inspected.

- `base_isolation_args()` gains `auto_remove` (default `True`, so the library `Sandbox` path is byte-for-byte unchanged); the worker passes `auto_remove=False`.
- New `docker.inspect_oom_killed()` reads `State.OOMKilled` with a short timeout and returns `None` on any failure.
- `_run_container` inspects only on exit 137 (kept cheap) and now removes the container via a best-effort `docker rm -f` in a `finally` on **every** exit path (success, user failure, infra failure, host timeout — which previously only killed — and unexpected exceptions). The labeled orphan cleanup at startup remains a backstop only.
- Status logic:
  - 137 + `OOMKilled=true` → `oom` (unchanged message)
  - 137 + `OOMKilled=false` → `failed` with `type="killed"` and a message stating the process was killed (SIGKILL) but **not** by the memory limit
  - inspect failure (`None`) → keep reporting `oom`, so a flaky inspect never loses a true OOM
- Composes with the entrypoint's existing remap of in-container `timeout --kill-after` deaths (137→124): a 137 seen on the host is a genuine SIGKILL, never an internal timeout.

### F13a — `.tako_phase` was forgeable by sandboxed code

The phase/timing file lived in `/output`, which is chmod `0777` for the container user, so uid-1000 user code could unlink and re-create it with arbitrary content — forging the data that feeds timeout-phase attribution, `internal_timeout`, and error phase.

- The worker mounts a second control-metadata dir at `/tako-meta` (host dir mode `0755`, owned by the server uid). With `--cap-drop=ALL` the container has no `CAP_DAC_OVERRIDE`, so only container root (the entrypoint, pre-gosu) can write it; the sandbox user cannot.
- `entrypoint.sh` prefers `/tako-meta/.tako_phase` when the mount exists and is root-writable (probed with `touch` as root), falling back to the legacy `/output` location — old/new images and old/new hosts compose in every combination.
- `parse_phase_file` prefers the meta copy and ignores a (possibly forged) `/output` copy whenever the meta copy exists; retries clear the meta dir alongside the output dir.
- Hardening edge case: a server running as host uid 1000 exactly would make the "trusted" dir sandbox-owned inside the container (the owner could even chmod it), so the mount is skipped entirely in that case — graceful degrade to legacy behavior, no false trust.
- No `Dockerfile.executor` change needed; the entrypoint change covers it.

## Tests

All mocked-subprocess, no Docker required (`tests/test_worker_errors.py`, `tests/test_docker_utils.py`):

- 137 + inspect true → `oom`; 137 + inspect false → `failed`/`killed` with distinguishing message; inspect failure → `oom` fallback
- inspect targets the right container and runs **before** `docker rm -f`
- inspect only fires on exit 137
- container removed on success / user failure / infra failure (both retry attempts) / host timeout; `--rm` absent from run args
- meta mount present and distinct from `/output`; meta dir mode `0755`; forged `/output/.tako_phase` ignored when meta copy exists; `/output` fallback when meta absent; uid-1000 collision skips the mount; stale meta phase cleared between retries; symlinked phase file never followed
- `bash -n docker/entrypoint.sh` plus dual-location assertions
- `inspect_oom_killed` unit tests (true/false/missing/garbage/timeout/exception)

`ruff check` / `ruff format` clean. Full suite: **394 passed, 145 skipped** (skips are Docker/Postgres integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)