### PR TITLE
fix(worker): execute pre-built job-type images and refuse contract-less base images

### DIFF
--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -22,6 +22,12 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from tako_vm.execution.docker import (
+    DEFAULT_EXECUTOR_IMAGE,
+    EXECUTOR_ENTRYPOINT,
+    image_has_executor_entrypoint,
+    reset_image_caches,
+)
 from tako_vm.job_types import JobType, JobTypeRegistry
 from tako_vm.security import (
     validate_docker_image,
@@ -56,6 +62,20 @@ class ContainerBuilder:
         """
         Generate Dockerfile content for a job type.
 
+        The generated image derives from the executor base image (or an
+        executor-derived ``base_image``) so it keeps the executor entrypoint
+        contract (``ENTRYPOINT ["/entrypoint.sh"]``): the entrypoint enforces
+        the in-container startup/execution timeouts, installs any per-job
+        extra requirements, writes the phase/timing file, and runs
+        ``/code/main.py`` itself as the sandbox user via gosu. The worker
+        (``CodeExecutor._resolve_image``) refuses to run images that lack
+        this contract, because docker would otherwise execute the image's
+        default CMD instead of the user's code.
+
+        Note: ``python_version`` no longer selects the default base image —
+        the executor base image pins the Python version. To use a different
+        Python, point ``base_image`` at a custom executor-derived image.
+
         Args:
             job_type: Job type configuration
 
@@ -71,7 +91,10 @@ class ContainerBuilder:
                 f"Invalid python_version '{job_type.python_version}' for job type {job_type.name}"
             )
 
-        # Determine and validate base image
+        # Determine and validate base image. The default is the executor base
+        # image so the built image inherits /entrypoint.sh; a custom
+        # base_image must itself be executor-derived or the worker will refuse
+        # the built image at run time.
         if job_type.base_image:
             if not validate_docker_image(job_type.base_image):
                 raise BuildError(
@@ -79,7 +102,7 @@ class ContainerBuilder:
                 )
             base_image = job_type.base_image
         else:
-            base_image = f"python:{job_type.python_version}-slim"
+            base_image = DEFAULT_EXECUTOR_IMAGE
 
         # Build requirements install command with validation
         requirements_cmd = ""
@@ -115,9 +138,12 @@ class ContainerBuilder:
                 env_lines += f'ENV {key}="{escaped_value}"\n'
 
         dockerfile = f"""# Auto-generated Dockerfile for job type: {job_type.name}
+# Derives from the executor base image so the built image keeps the executor
+# entrypoint contract (ENTRYPOINT /entrypoint.sh, inherited from the base).
 FROM {base_image}
 
-# Install uv for fast dependency installation
+# Install uv for fast dependency installation (already present on the
+# executor base; kept so custom executor-derived bases get it too)
 COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /usr/local/bin/uv
 
 # Install custom libraries if present
@@ -127,7 +153,8 @@ RUN if [ -n "$(ls -A /tmp/custom_libs/*.whl 2>/dev/null)" ]; then \\
     fi && \\
     rm -rf /tmp/custom_libs
 
-# Install job type requirements
+# Install job type requirements at BUILD time. The worker skips runtime
+# installation of job_type.requirements when running this image.
 {requirements_cmd}
 
 # Copy shared code if present
@@ -137,22 +164,21 @@ ENV PYTHONPATH="/app/shared_code:$PYTHONPATH"
 # Environment variables
 {env_lines}
 
-# Create non-root user for security
-RUN useradd -m -u 1000 sandbox && \\
-    mkdir -p /code /input /output /tmp && \\
-    chown sandbox:sandbox /output /tmp
-
-# Set permissions
-RUN chmod 755 /code /input && \\
+# Ensure the sandbox user and the mount-point dirs exist (no-ops on the
+# executor base, which already provides them)
+RUN id -u sandbox >/dev/null 2>&1 || useradd -m -u 1000 sandbox
+RUN mkdir -p /code /input /output /tmp && \\
+    chown sandbox:sandbox /output /tmp && \\
+    chmod 755 /code /input && \\
     chmod 777 /output /tmp
 
 WORKDIR /app
 
-# Run as non-root user
-USER sandbox
-
-# Entry point
-CMD ["python", "-u", "/code/main.py"]
+# Deliberately NO USER/CMD/ENTRYPOINT overrides: the container must start as
+# container root so the inherited /entrypoint.sh can install per-job extra
+# requirements and write the phase file, then drop to the sandbox user (gosu)
+# to run /code/main.py. A `USER sandbox` or CMD here would break or mask that
+# contract (the worker would refuse the image, or the wrong process would run).
 """
         return dockerfile
 
@@ -220,6 +246,23 @@ CMD ["python", "-u", "/code/main.py"]
             try:
                 subprocess.run(cmd, capture_output=not quiet, text=True, check=True)
                 logger.info("Successfully built image: %s", job_type.image_name)
+                # The tag now points at new content: drop any cached inspect
+                # results so the worker re-verifies the rebuilt image.
+                reset_image_caches()
+                # Verify the executor entrypoint contract survived the build.
+                # This only fails for a custom non-executor base_image; warn
+                # loudly because the worker will refuse to run such an image.
+                if image_has_executor_entrypoint(job_type.image_name) is not True:
+                    logger.warning(
+                        "Built image %s does NOT carry the executor entrypoint contract "
+                        "(ENTRYPOINT %s) — the worker will refuse to run it. base_image "
+                        "'%s' for job type '%s' must derive from the executor image "
+                        "(docker/Dockerfile.executor).",
+                        job_type.image_name,
+                        EXECUTOR_ENTRYPOINT,
+                        job_type.base_image,
+                        job_type.name,
+                    )
                 return True
             except subprocess.CalledProcessError as e:
                 error_msg = e.stderr if e.stderr else str(e)

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -4,13 +4,128 @@ Docker utilities for container management.
 Shared utilities for Docker operations across worker and sandbox.
 """
 
+import json
 import logging
 import platform
 import subprocess
+import time
 import uuid
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Default executor base image. Built from docker/Dockerfile.executor; carries
+# uv, gosu, the sandbox user, and the /entrypoint.sh contract (see
+# EXECUTOR_ENTRYPOINT).
+DEFAULT_EXECUTOR_IMAGE = "code-executor:latest"
+
+# The entrypoint every runnable Tako image must carry
+# (`ENTRYPOINT ["/entrypoint.sh"]` in docker/Dockerfile.executor). The
+# entrypoint is what enforces the in-container startup/execution timeouts,
+# installs runtime requirements, writes the phase/timing file, and runs
+# /code/main.py itself (as the sandbox user via gosu). An image without it
+# would run its default CMD instead of the user's code — for python:slim the
+# REPL exits 0 on EOF, recording a bogus "succeeded" for code that never ran.
+EXECUTOR_ENTRYPOINT = "/entrypoint.sh"
+
+# How long positive image-inspect results are cached (seconds). Only positive
+# results are cached: a missing image can be built/pulled at any moment, and
+# caching the miss would keep a freshly built job-type image unused.
+_IMAGE_CACHE_TTL_SECONDS = 60.0
+
+# image name -> monotonic expiry timestamp. Plain dicts: worst case under
+# concurrent workers is a duplicate `docker image inspect`, which is harmless.
+_image_exists_cache: dict[str, float] = {}
+_executor_entrypoint_cache: dict[str, float] = {}
+
+
+def reset_image_caches() -> None:
+    """Clear the image-inspect caches (for tests and after image rebuilds)."""
+    _image_exists_cache.clear()
+    _executor_entrypoint_cache.clear()
+
+
+def image_exists(image_name: str) -> bool:
+    """Check whether a Docker image exists locally (cached).
+
+    Positive results are cached for a short TTL so per-run lookups (e.g. "does
+    this job type have a pre-built image?") don't cost a daemon round-trip on
+    every execution. Negative results are never cached — see
+    ``_IMAGE_CACHE_TTL_SECONDS``.
+
+    Args:
+        image_name: Image reference to look up (e.g. "tako-vm-foo:latest")
+
+    Returns:
+        True if the image exists on the local daemon, False otherwise
+        (including when the daemon is unreachable or the inspect times out).
+    """
+    now = time.monotonic()
+    expiry = _image_exists_cache.get(image_name)
+    if expiry is not None and now < expiry:
+        return True
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", image_name],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception as e:
+        logger.debug("Failed to inspect image %s: %s", image_name, e)
+        return False
+    if result.returncode == 0:
+        _image_exists_cache[image_name] = now + _IMAGE_CACHE_TTL_SECONDS
+        return True
+    return False
+
+
+def image_has_executor_entrypoint(image_name: str) -> Optional[bool]:
+    """Check whether an image's ENTRYPOINT is exactly ``["/entrypoint.sh"]``.
+
+    This is the cheap, reliable test for "was this image derived from the
+    executor base image" — i.e. does it honor the contract the worker depends
+    on (in-container timeouts, dependency install, phase file, and running
+    /code/main.py itself). Positive results are cached with a short TTL,
+    mirroring ``image_exists``.
+
+    Args:
+        image_name: Image reference to inspect
+
+    Returns:
+        True if the entrypoint matches the executor contract, False if the
+        image exists but has a different/absent entrypoint, or None if the
+        inspect failed (image not present locally, daemon unreachable,
+        timeout, unparseable output). Callers must not treat None as a pass.
+    """
+    now = time.monotonic()
+    expiry = _executor_entrypoint_cache.get(image_name)
+    if expiry is not None and now < expiry:
+        return True
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", "--format", "{{json .Config.Entrypoint}}", image_name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception as e:
+        logger.debug("Failed to inspect entrypoint of image %s: %s", image_name, e)
+        return None
+    if result.returncode != 0:
+        logger.debug("docker image inspect of %s failed (exit %s)", image_name, result.returncode)
+        return None
+    try:
+        entrypoint = json.loads((result.stdout or "").strip())
+    except json.JSONDecodeError:
+        logger.debug("Unparseable entrypoint for image %s: %r", image_name, result.stdout)
+        return None
+    if entrypoint == [EXECUTOR_ENTRYPOINT]:
+        _executor_entrypoint_cache[image_name] = now + _IMAGE_CACHE_TTL_SECONDS
+        return True
+    return False
+
 
 # Label applied to every executor container at `docker run` time. Cleanup
 # (DockerCleanup.cleanup_orphaned_containers) matches on this label, so it must

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -19,8 +19,11 @@ from typing import Any, Dict, List, Optional
 from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.constants import MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
 from tako_vm.execution.docker import (
+    EXECUTOR_ENTRYPOINT,
     base_isolation_args,
     generate_container_name,
+    image_exists,
+    image_has_executor_entrypoint,
     inspect_oom_killed,
     is_native_linux,
     kill_container,
@@ -925,6 +928,19 @@ class CodeExecutor:
                         ),
                         phase=phase,
                     )
+                elif result.get("config_error"):
+                    # The job was refused before any container ran (e.g. a raw
+                    # base_image without the executor entrypoint contract, or
+                    # an invalid image reference). Don't run classify_error on
+                    # the explanation text — this is a configuration problem,
+                    # not the user's code failing.
+                    record.error = ExecutionError(
+                        type="config_error",
+                        message=sanitize_error(
+                            result.get("error") or "Invalid job type configuration"
+                        ),
+                        phase=phase,
+                    )
                 else:
                     error_type, error_msg = classify_error(
                         result.get("exit_code", 1), result.get("stderr", ""), timed_out
@@ -1089,6 +1105,136 @@ class CodeExecutor:
 
         return replay_artifacts
 
+    def _resolve_image(
+        self, job_type: JobType
+    ) -> tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]:
+        """Resolve which Docker image to run for a job type.
+
+        Resolution order (each selection is logged for auditability):
+
+        1. **Pre-built job-type image** (``tako-vm-<name>:latest``, produced by
+           ``tako-vm build``) — preferred when it exists locally AND carries
+           the executor entrypoint contract (``ENTRYPOINT ["/entrypoint.sh"]``,
+           the cheap reliable marker of an executor-derived image). Its
+           ``job_type.requirements`` are baked in at build time, so the caller
+           skips runtime installation of those.
+        2. **``job_type.base_image``** — allowed ONLY when the image itself
+           carries the executor entrypoint contract (and is therefore present
+           locally, since the contract is verified via ``docker image
+           inspect``). A raw image (e.g. ``python:3.11-slim``) is refused with
+           a config error: without ``/entrypoint.sh`` the
+           TAKO_STARTUP_TIMEOUT/TAKO_EXECUTION_TIMEOUT env vars are ignored
+           (no in-container timeout at all), no phase/timing file is written,
+           and — worst — ``docker run`` appends only the image, so the image's
+           default CMD runs instead of ``/code/main.py``. For ``python:slim``
+           the REPL exits 0 on EOF, so the job would be recorded as
+           "succeeded" with empty output for code that NEVER ran.
+           ``ContainerBuilder`` exists precisely to wrap a base image with the
+           executor contract, so the error directs users to ``tako-vm build``.
+        3. **Default executor image** (``self.docker_image``) — the unchanged
+           legacy path; requirements are installed at container startup by the
+           entrypoint.
+
+        Returns:
+            ``(image_name, source, error)``: on success ``error`` is None and
+            ``source`` is ``"built"``/``"base"``/``"default"``; on failure
+            ``image_name``/``source`` are None and ``error`` is a
+            ready-to-return ``_run_container`` result dict.
+        """
+        built_image = job_type.image_name
+        if validate_docker_image(built_image) and image_exists(built_image):
+            if image_has_executor_entrypoint(built_image):
+                logger.info(
+                    "Job type '%s': using pre-built image %s "
+                    "(job type requirements baked in at build time)",
+                    job_type.name,
+                    built_image,
+                )
+                return built_image, "built", None
+            logger.warning(
+                "Job type '%s': pre-built image %s exists but its ENTRYPOINT is not %s "
+                "(likely built by an older 'tako-vm build' or from a non-executor "
+                "base_image); ignoring it. Rebuild with 'tako-vm build %s'.",
+                job_type.name,
+                built_image,
+                EXECUTOR_ENTRYPOINT,
+                job_type.name,
+            )
+
+        if job_type.base_image:
+            if not validate_docker_image(job_type.base_image):
+                return (
+                    None,
+                    None,
+                    {
+                        "success": False,
+                        "error": "Invalid base_image configuration",
+                        "stdout": "",
+                        "stderr": f"base_image '{job_type.base_image}' failed validation",
+                        "exit_code": -1,
+                        "config_error": True,
+                    },
+                )
+            if image_has_executor_entrypoint(job_type.base_image) is not True:
+                logger.error(
+                    "Job type '%s': refusing to run base_image %s — it does not carry "
+                    "the executor entrypoint contract (ENTRYPOINT %s) or is not present "
+                    "locally. Build an executor-derived image with 'tako-vm build %s'.",
+                    job_type.name,
+                    job_type.base_image,
+                    EXECUTOR_ENTRYPOINT,
+                    job_type.name,
+                )
+                return (
+                    None,
+                    None,
+                    {
+                        "success": False,
+                        "error": (
+                            f"base_image '{job_type.base_image}' for job type "
+                            f"'{job_type.name}' does not carry the executor entrypoint "
+                            f"({EXECUTOR_ENTRYPOINT}) or is not present locally; "
+                            f"run 'tako-vm build {job_type.name}' to build an "
+                            "executor-derived image for this job type"
+                        ),
+                        "stdout": "",
+                        "stderr": (
+                            "Raw base images cannot be run directly: without "
+                            "/entrypoint.sh the in-container timeouts are not enforced "
+                            "and the image's default CMD would run instead of "
+                            "/code/main.py, recording a bogus success for code that "
+                            f"never ran. Run 'tako-vm build {job_type.name}', or point "
+                            "base_image at an executor-derived image that exists on "
+                            "this host."
+                        ),
+                        "exit_code": -1,
+                        "config_error": True,
+                    },
+                )
+            logger.info(
+                "Job type '%s': using executor-derived base image %s",
+                job_type.name,
+                job_type.base_image,
+            )
+            return job_type.base_image, "base", None
+
+        image_name = self.docker_image
+        if not validate_docker_image(image_name):
+            return (
+                None,
+                None,
+                {
+                    "success": False,
+                    "error": "Invalid docker_image configuration",
+                    "stdout": "",
+                    "stderr": f"docker_image '{image_name}' failed validation",
+                    "exit_code": -1,
+                    "config_error": True,
+                },
+            )
+        logger.debug("Job type '%s': using default executor image %s", job_type.name, image_name)
+        return image_name, "default", None
+
     def _run_container(
         self,
         code_dir: Path,
@@ -1146,8 +1292,24 @@ class CodeExecutor:
                 "infra_failure": True,
             }
 
+        # Resolve which image to run: a pre-built job-type image, an
+        # executor-derived base image, or the default executor image. Raw
+        # base images without the executor entrypoint contract are refused
+        # here — running them would execute the image's default CMD instead
+        # of /code/main.py (see _resolve_image).
+        image_name, image_source, image_error = self._resolve_image(job_type)
+        if image_error is not None:
+            return image_error
+
         # Validate runtime requirements before deciding network and tmpfs policy.
-        all_requirements = list(job_type.requirements) if job_type.requirements else []
+        # A pre-built image already has job_type.requirements baked in at build
+        # time, so only per-job extra requirements still need runtime
+        # installation — otherwise the entrypoint would reinstall the full set
+        # on every run, defeating the point of `tako-vm build`.
+        if image_source == "built":
+            all_requirements = []
+        else:
+            all_requirements = list(job_type.requirements) if job_type.requirements else []
         if extra_requirements:
             all_requirements.extend(extra_requirements)
 
@@ -1187,30 +1349,6 @@ class CodeExecutor:
                 }
             requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
             requirements_file.chmod(0o444)
-
-        # Determine which image to use
-        # Use custom base_image if specified, otherwise use default executor
-        # Dependencies are installed at runtime from /input/_requirements.txt.
-        if job_type.base_image:
-            if not validate_docker_image(job_type.base_image):
-                return {
-                    "success": False,
-                    "error": "Invalid base_image configuration",
-                    "stdout": "",
-                    "stderr": f"base_image '{job_type.base_image}' failed validation",
-                    "exit_code": -1,
-                }
-            image_name = job_type.base_image
-        else:
-            image_name = self.docker_image
-            if not validate_docker_image(image_name):
-                return {
-                    "success": False,
-                    "error": "Invalid docker_image configuration",
-                    "stdout": "",
-                    "stderr": f"docker_image '{image_name}' failed validation",
-                    "exit_code": -1,
-                }
 
         # Check if runtime deps require network access
         has_runtime_deps = bool(validated_reqs)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,14 +1,19 @@
 """
-Tests for ContainerBuilder.build_all image build orchestration.
+Tests for ContainerBuilder.
 
-Covers the opt-in ``skip_existing`` behavior: ``build_all`` skips job types
-whose image is already present instead of rebuilding it, while the default
-still builds every registered job type.
+Covers the opt-in ``skip_existing`` behavior of ``build_all`` (skip job types
+whose image is already present) and the generated Dockerfile's executor
+entrypoint contract: built images must derive from the executor base image
+(inheriting ``ENTRYPOINT /entrypoint.sh``) and must not override USER/CMD —
+otherwise the worker refuses to run them (see CodeExecutor._resolve_image).
 """
 
 from pathlib import Path
 
-from tako_vm.execution.builder import ContainerBuilder
+import pytest
+
+from tako_vm.execution.builder import BuildError, ContainerBuilder
+from tako_vm.execution.docker import DEFAULT_EXECUTOR_IMAGE
 from tako_vm.job_types import JobType, JobTypeRegistry
 
 
@@ -65,3 +70,60 @@ class TestBuildAllSkipExisting:
 
         assert built == ["alpha", "beta"]
         assert results == {"alpha": True, "beta": True}
+
+
+class TestGenerateDockerfileEntrypointContract:
+    """Built images must keep the executor entrypoint contract."""
+
+    def test_default_base_is_executor_image(self):
+        """Without a base_image the build derives from the executor base, so
+        ENTRYPOINT /entrypoint.sh (timeouts, phase file, gosu drop, running
+        /code/main.py) is inherited."""
+        dockerfile = ContainerBuilder().generate_dockerfile(JobType(name="jt"))
+
+        assert f"FROM {DEFAULT_EXECUTOR_IMAGE}" in dockerfile
+        assert "FROM python:" not in dockerfile
+
+    def test_custom_base_image_is_honored(self):
+        dockerfile = ContainerBuilder().generate_dockerfile(
+            JobType(name="jt", base_image="my-executor:latest")
+        )
+
+        assert "FROM my-executor:latest" in dockerfile
+
+    def test_no_user_cmd_or_entrypoint_overrides(self):
+        """USER sandbox would prevent the entrypoint from installing extra
+        requirements and gosu-dropping; a CMD would mask the contract."""
+        dockerfile = ContainerBuilder().generate_dockerfile(JobType(name="jt"))
+
+        for line in dockerfile.splitlines():
+            stripped = line.strip()
+            assert not stripped.startswith("USER "), line
+            assert not stripped.startswith("CMD "), line
+            assert not stripped.startswith("ENTRYPOINT "), line
+
+    def test_requirements_are_baked_at_build_time(self):
+        dockerfile = ContainerBuilder().generate_dockerfile(
+            JobType(name="jt", requirements=["pandas", "numpy>=1.26"])
+        )
+
+        assert 'RUN uv pip install --system --no-cache "pandas" "numpy>=1.26"' in dockerfile
+
+    def test_sandbox_user_creation_is_guarded(self):
+        """useradd must be a no-op on the executor base (user already exists)
+        or the build would fail with 'user sandbox exists'."""
+        dockerfile = ContainerBuilder().generate_dockerfile(JobType(name="jt"))
+
+        assert "id -u sandbox >/dev/null 2>&1 || useradd -m -u 1000 sandbox" in dockerfile
+
+    def test_invalid_python_version_raises(self):
+        with pytest.raises(BuildError, match="Invalid python_version"):
+            ContainerBuilder().generate_dockerfile(
+                JobType(name="jt", python_version="3.11; rm -rf /")
+            )
+
+    def test_invalid_base_image_raises(self):
+        with pytest.raises(BuildError, match="Invalid base_image"):
+            ContainerBuilder().generate_dockerfile(
+                JobType(name="jt", base_image="bad image\nFROM evil")
+            )

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -7,16 +7,30 @@ Tests container naming, cleanup, and platform detection.
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tako_vm.execution.docker import (
     CONTAINER_LABEL,
     EXECUTION_ID_LABEL,
     base_isolation_args,
     generate_container_name,
+    image_exists,
+    image_has_executor_entrypoint,
     inspect_oom_killed,
     is_native_linux,
     kill_container,
     remove_container,
+    reset_image_caches,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clean_image_caches():
+    """image_exists/image_has_executor_entrypoint cache positives in-process;
+    isolate every test from cache state left by another."""
+    reset_image_caches()
+    yield
+    reset_image_caches()
 
 
 class TestIsNativeLinux:
@@ -213,6 +227,162 @@ class TestInspectOomKilled:
         mock_run.side_effect = Exception("boom")
 
         assert inspect_oom_killed("tako-test-123") is None
+
+
+class TestImageExists:
+    """Tests for image_exists() — cached local-image presence check."""
+
+    @patch("subprocess.run")
+    def test_calls_docker_image_inspect_with_timeout(self, mock_run):
+        """image_exists asks docker image inspect with a short timeout."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert image_exists("tako-vm-foo:latest") is True
+
+        mock_run.assert_called_once_with(
+            ["docker", "image", "inspect", "tako-vm-foo:latest"],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    def test_missing_image_returns_false(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+
+        assert image_exists("tako-vm-missing:latest") is False
+
+    @patch("subprocess.run")
+    def test_positive_result_is_cached(self, mock_run):
+        """A second lookup for a present image must not hit the daemon again."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert image_exists("tako-vm-foo:latest") is True
+        assert image_exists("tako-vm-foo:latest") is True
+
+        assert mock_run.call_count == 1
+
+    @patch("subprocess.run")
+    def test_negative_result_is_not_cached(self, mock_run):
+        """A missing image may be built/pulled at any moment: re-check it."""
+        mock_run.return_value = MagicMock(returncode=1)
+
+        assert image_exists("tako-vm-missing:latest") is False
+        assert image_exists("tako-vm-missing:latest") is False
+
+        assert mock_run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_cache_is_per_image(self, mock_run):
+        """Caching one image's presence must not answer for another image."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert image_exists("tako-vm-a:latest") is True
+        assert image_exists("tako-vm-b:latest") is True
+
+        assert mock_run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_timeout_returns_false(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
+
+        assert image_exists("tako-vm-foo:latest") is False
+
+    @patch("subprocess.run")
+    def test_exception_returns_false(self, mock_run):
+        mock_run.side_effect = Exception("boom")
+
+        assert image_exists("tako-vm-foo:latest") is False
+
+    @patch("subprocess.run")
+    def test_reset_image_caches_clears_positive_entries(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert image_exists("tako-vm-foo:latest") is True
+        reset_image_caches()
+        assert image_exists("tako-vm-foo:latest") is True
+
+        assert mock_run.call_count == 2
+
+
+class TestImageHasExecutorEntrypoint:
+    """Tests for image_has_executor_entrypoint() — the executor contract check."""
+
+    @staticmethod
+    def _inspect_result(stdout):
+        return MagicMock(returncode=0, stdout=stdout, stderr="")
+
+    @patch("subprocess.run")
+    def test_calls_docker_inspect_with_entrypoint_format(self, mock_run):
+        mock_run.return_value = self._inspect_result('["/entrypoint.sh"]\n')
+
+        assert image_has_executor_entrypoint("code-executor:latest") is True
+
+        mock_run.assert_called_once_with(
+            [
+                "docker",
+                "image",
+                "inspect",
+                "--format",
+                "{{json .Config.Entrypoint}}",
+                "code-executor:latest",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    def test_other_entrypoint_returns_false(self, mock_run):
+        mock_run.return_value = self._inspect_result('["python","-u","/code/main.py"]\n')
+
+        assert image_has_executor_entrypoint("custom:latest") is False
+
+    @patch("subprocess.run")
+    def test_no_entrypoint_returns_false(self, mock_run):
+        """A raw image like python:3.11-slim has a null entrypoint."""
+        mock_run.return_value = self._inspect_result("null\n")
+
+        assert image_has_executor_entrypoint("python:3.11-slim") is False
+
+    @patch("subprocess.run")
+    def test_failed_inspect_returns_none(self, mock_run):
+        """Image not present / daemon unreachable is unknown, not False."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="No such image")
+
+        assert image_has_executor_entrypoint("missing:latest") is None
+
+    @patch("subprocess.run")
+    def test_unparseable_output_returns_none(self, mock_run):
+        mock_run.return_value = self._inspect_result("not json")
+
+        assert image_has_executor_entrypoint("weird:latest") is None
+
+    @patch("subprocess.run")
+    def test_exception_returns_none(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
+
+        assert image_has_executor_entrypoint("code-executor:latest") is None
+
+    @patch("subprocess.run")
+    def test_positive_result_is_cached(self, mock_run):
+        mock_run.return_value = self._inspect_result('["/entrypoint.sh"]\n')
+
+        assert image_has_executor_entrypoint("code-executor:latest") is True
+        assert image_has_executor_entrypoint("code-executor:latest") is True
+
+        assert mock_run.call_count == 1
+
+    @patch("subprocess.run")
+    def test_negative_result_is_not_cached(self, mock_run):
+        """An image can be rebuilt with the contract at any moment: re-check."""
+        mock_run.return_value = self._inspect_result("null\n")
+
+        assert image_has_executor_entrypoint("python:3.11-slim") is False
+        assert image_has_executor_entrypoint("python:3.11-slim") is False
+
+        assert mock_run.call_count == 2
 
 
 class TestContainerNameValidation:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -296,6 +296,11 @@ class TestExecutorRejectsUnsafeIds:
         input_dir.mkdir()
         output_dir.mkdir()
 
+        # Keep image resolution off the (shared) subprocess mock: this test
+        # asserts that NO docker command runs once the policy rejects the job,
+        # and the pre-built-image probe would otherwise count as a call.
+        monkeypatch.setattr(worker_module, "image_exists", lambda name: False)
+
         fake_run = MagicMock()
         monkeypatch.setattr(worker_module.subprocess, "run", fake_run)
 

--- a/tests/test_worker_errors.py
+++ b/tests/test_worker_errors.py
@@ -42,7 +42,7 @@ import pytest
 import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
 from tako_vm.execution.worker import CodeExecutor, parse_phase_file
-from tako_vm.job_types import JobType
+from tako_vm.job_types import JobType, JobTypeRegistry
 
 DAEMON_DOWN_STDERR = (
     "docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. "
@@ -71,6 +71,16 @@ class FakeCircuitBreaker:
 @pytest.fixture(autouse=True)
 def mock_gvisor_available(monkeypatch):
     monkeypatch.setattr(worker_module, "_gvisor_available", True)
+
+
+@pytest.fixture(autouse=True)
+def no_prebuilt_images(monkeypatch):
+    """Keep image resolution hermetic: behave as if no pre-built job-type
+    image exists and no image can be entrypoint-inspected (the helpers live in
+    docker.py and would otherwise hit the real daemon). TestImageResolution
+    overrides these per test."""
+    monkeypatch.setattr(worker_module, "image_exists", lambda name: False)
+    monkeypatch.setattr(worker_module, "image_has_executor_entrypoint", lambda name: None)
 
 
 @pytest.fixture
@@ -142,10 +152,19 @@ def _patch_subprocess(monkeypatch, side_effect):
 
 
 def _mount_source_dir(cmd, target):
-    """Extract the host source dir of a bind mount from a docker run cmd."""
+    """Extract the host source dir of a bind mount from a docker run cmd.
+
+    Parses the --mount key=value fields so it also matches mounts carrying
+    trailing flags (e.g. the readonly /code and /input mounts).
+    """
     for arg in cmd:
-        if arg.startswith("--mount=type=bind,") and arg.endswith(f",target={target}"):
-            return Path(arg.split("source=", 1)[1].split(",", 1)[0])
+        if not arg.startswith("--mount=type=bind,"):
+            continue
+        fields = dict(
+            field.split("=", 1) for field in arg[len("--mount=") :].split(",") if "=" in field
+        )
+        if fields.get("target") == target:
+            return Path(fields["source"])
     raise AssertionError(f"docker run command has no {target} bind mount")
 
 
@@ -812,6 +831,226 @@ class TestPhaseFileTrust:
         assert record.status == "succeeded"
         assert seen_on_retry["entries"] == [], "meta dir must be empty when a retry starts"
         assert record.timing is None
+
+
+class TestImageResolution:
+    """F7: images built by `tako-vm build` must actually be executed, and raw
+    base images without the executor entrypoint contract must be refused —
+    running them would execute the image's default CMD instead of
+    /code/main.py and record a bogus success for code that never ran."""
+
+    def _executor(self, tmp_path, job_type):
+        registry = JobTypeRegistry(config_path=tmp_path / "job_types.json")
+        registry.register(job_type, persist=False)
+        config = TakoVMConfig(
+            security_mode="permissive",
+            data_dir=str(tmp_path / "data"),
+            max_retry_attempts=2,
+            retry_base_delay=0.1,
+            allow_runtime_requirements=True,
+        )
+        return CodeExecutor(config=config, registry=registry)
+
+    def test_built_image_preferred_and_requirements_skipped(self, tmp_path, breaker, monkeypatch):
+        """A pre-built job-type image with the executor contract is executed,
+        and its baked-in requirements are NOT reinstalled at runtime."""
+        jt = JobType(name="custom", requirements=["pandas", "numpy"])
+        monkeypatch.setattr(worker_module, "image_exists", lambda name: name == jt.image_name)
+        monkeypatch.setattr(
+            worker_module, "image_has_executor_entrypoint", lambda name: name == jt.image_name
+        )
+
+        seen = {}
+
+        def on_run(attempt_idx, cmd):
+            input_dir = _mount_source_dir(cmd, "/input")
+            seen["requirements_file_exists"] = (input_dir / "_requirements.txt").exists()
+
+        cli = _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-built-1", {"code": "import pandas", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert record.status == "succeeded"
+        # The built image is what actually ran
+        assert cli.run[0][-1] == "tako-vm-custom:latest"
+        # Requirements are baked into the image: no runtime install file...
+        assert seen["requirements_file_exists"] is False
+        # ...so no bridge network was needed for dependency installation
+        assert "--network=none" in cli.run[0]
+        assert "--network=bridge" not in cli.run[0]
+
+    def test_extra_requirements_still_installed_with_built_image(
+        self, tmp_path, breaker, monkeypatch
+    ):
+        """Per-job extra requirements are not baked in and still install at
+        runtime — but the job type's own requirements must not be re-listed."""
+        jt = JobType(name="custom", requirements=["pandas"])
+        monkeypatch.setattr(worker_module, "image_exists", lambda name: name == jt.image_name)
+        monkeypatch.setattr(
+            worker_module, "image_has_executor_entrypoint", lambda name: name == jt.image_name
+        )
+
+        seen = {}
+
+        def on_run(attempt_idx, cmd):
+            input_dir = _mount_source_dir(cmd, "/input")
+            seen["requirements"] = (input_dir / "_requirements.txt").read_text(encoding="utf-8")
+
+        cli = _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-built-extra",
+            {
+                "code": "import requests",
+                "input_data": {},
+                "job_type": "custom",
+                "requirements": ["requests>=2.31"],
+            },
+        )
+
+        assert record.status == "succeeded"
+        assert cli.run[0][-1] == "tako-vm-custom:latest"
+        assert seen["requirements"] == "requests>=2.31\n"
+
+    def test_fallback_to_default_image_when_no_built_image(self, tmp_path, breaker, monkeypatch):
+        """Without a built image, requirements install at runtime on the
+        default executor image (the legacy behavior)."""
+        jt = JobType(name="custom", requirements=["pandas"])
+        # autouse fixture: image_exists -> False everywhere
+
+        seen = {}
+
+        def on_run(attempt_idx, cmd):
+            input_dir = _mount_source_dir(cmd, "/input")
+            seen["requirements"] = (input_dir / "_requirements.txt").read_text(encoding="utf-8")
+
+        cli = _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-no-built", {"code": "import pandas", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert record.status == "succeeded"
+        assert cli.run[0][-1] == "code-executor:latest"
+        assert seen["requirements"] == "pandas\n"
+
+    def test_default_job_type_path_unchanged(self, executor, breaker, monkeypatch):
+        """The default job type keeps running the default executor image."""
+        cli = _patch_docker_cli(monkeypatch, [_success()])
+
+        record = executor.execute_job_with_record(
+            "job-default-img", {"code": "print('hi')", "input_data": {}}
+        )
+
+        assert record.status == "succeeded"
+        assert cli.run[0][-1] == "code-executor:latest"
+
+    def test_built_image_without_contract_is_ignored(self, tmp_path, breaker, monkeypatch):
+        """A stale built image lacking /entrypoint.sh (old `tako-vm build`)
+        must not be executed: fall back to the default executor image with
+        runtime dependency installation."""
+        jt = JobType(name="custom", requirements=["pandas"])
+        monkeypatch.setattr(worker_module, "image_exists", lambda name: name == jt.image_name)
+        monkeypatch.setattr(worker_module, "image_has_executor_entrypoint", lambda name: False)
+
+        seen = {}
+
+        def on_run(attempt_idx, cmd):
+            input_dir = _mount_source_dir(cmd, "/input")
+            seen["requirements_file_exists"] = (input_dir / "_requirements.txt").exists()
+
+        cli = _patch_docker_cli(monkeypatch, [_success()], on_run=on_run)
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-stale-built", {"code": "import pandas", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert record.status == "succeeded"
+        assert cli.run[0][-1] == "code-executor:latest"
+        assert seen["requirements_file_exists"] is True
+
+    def test_executor_derived_base_image_is_allowed(self, tmp_path, breaker, monkeypatch):
+        """A base_image that carries the executor entrypoint contract runs."""
+        jt = JobType(name="custom", base_image="my-executor:latest")
+        monkeypatch.setattr(
+            worker_module,
+            "image_has_executor_entrypoint",
+            lambda name: name == "my-executor:latest",
+        )
+
+        cli = _patch_docker_cli(monkeypatch, [_success()])
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-exec-base", {"code": "print('hi')", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert record.status == "succeeded"
+        assert cli.run[0][-1] == "my-executor:latest"
+
+    def test_raw_base_image_is_refused_not_bogus_success(self, tmp_path, breaker, monkeypatch):
+        """A raw base image (no /entrypoint.sh) must fail fast with a config
+        error — previously python:slim's default CMD (the REPL) ran instead of
+        the user's code, exited 0 on EOF, and the job was recorded
+        'succeeded' with empty output for code that NEVER ran."""
+        jt = JobType(name="custom", base_image="python:3.11-slim")
+        monkeypatch.setattr(worker_module, "image_has_executor_entrypoint", lambda name: False)
+
+        cli = _patch_docker_cli(monkeypatch, [])
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-raw-base", {"code": "print('hi')", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert cli.run == [], "no container may ever run a contract-less raw image"
+        assert record.status == "failed"
+        assert record.status != "succeeded"
+        assert record.error is not None
+        assert record.error.type == "config_error"
+        assert "entrypoint" in record.error.message
+        assert "tako-vm build custom" in record.error.message
+
+    def test_unverifiable_base_image_is_refused(self, tmp_path, breaker, monkeypatch):
+        """An inspect failure (image not local / daemon hiccup) is NOT a pass:
+        the contract must be positively verified before a base image runs."""
+        jt = JobType(name="custom", base_image="ghcr.io/acme/runner:1")
+        # autouse fixture: image_has_executor_entrypoint -> None (inspect failed)
+
+        cli = _patch_docker_cli(monkeypatch, [])
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-unverified-base", {"code": "print('hi')", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert cli.run == []
+        assert record.status == "failed"
+        assert record.error is not None
+        assert record.error.type == "config_error"
+
+    def test_built_image_preferred_over_base_image(self, tmp_path, breaker, monkeypatch):
+        """When a job type has both a built image and a base_image, the built
+        image (requirements baked in) wins."""
+        jt = JobType(name="custom", base_image="my-executor:latest", requirements=["pandas"])
+        monkeypatch.setattr(worker_module, "image_exists", lambda name: name == jt.image_name)
+        monkeypatch.setattr(worker_module, "image_has_executor_entrypoint", lambda name: True)
+
+        cli = _patch_docker_cli(monkeypatch, [_success()])
+        executor = self._executor(tmp_path, jt)
+
+        record = executor.execute_job_with_record(
+            "job-built-over-base", {"code": "print('hi')", "input_data": {}, "job_type": "custom"}
+        )
+
+        assert record.status == "succeeded"
+        assert cli.run[0][-1] == "tako-vm-custom:latest"
 
 
 class TestEntrypointScript:


### PR DESCRIPTION
## Bug (F7, HIGH — silent bogus success)

`CodeExecutor._run_container` selected `job_type.base_image` (or the default executor image) and **never referenced `job_type.image_name`** — the image `tako-vm build` produces with the job type's requirements baked in. Consequences:

1. **Dead weight**: everything `tako-vm build` produced was ignored; jobs reinstalled their full requirements at every container start.
2. **Bogus success**: a job type with a raw `base_image` (e.g. `python:3.11-slim`) ran an image with no `/entrypoint.sh`. The `TAKO_STARTUP_TIMEOUT`/`TAKO_EXECUTION_TIMEOUT` env vars were ignored (no in-container timeout at all), no phase/timing file was written, and — worst — `docker run` appends only the image with no command, so the image's **default CMD ran instead of `/code/main.py`**. For `python:slim` the REPL exits 0 on EOF, so the job was recorded **"succeeded" with empty output for code that never ran**.

A latent third problem surfaced while fixing this: the Dockerfile template in `builder.py` derived from `python:<version>-slim` (not the executor base), set `USER sandbox`, and set `CMD ["python","-u","/code/main.py"]` — so even built images lacked the entrypoint contract (no in-container timeouts, no phase file, no gosu privilege-drop flow, no runtime install of per-job extras).

## Fix

**Image resolution (`_resolve_image`, logged per run for auditability):**
1. **Pre-built job-type image** (`tako-vm-<name>:latest`) when it exists locally **and** carries the executor entrypoint contract (`ENTRYPOINT ["/entrypoint.sh"]` — a cheap, reliable `docker image inspect` check). Its requirements are baked in, so they're excluded from the runtime install set (no double install, no bridge-network fallback just to install them). Per-job extra requirements still install at runtime.
2. **`job_type.base_image`** — allowed **only** when it positively carries the contract (executor-derived). Raw images are **refused with a clear `config_error`** recommending `tako-vm build <job_type>`; the record is `failed`, never `succeeded`, and no container ever runs.
3. **Default executor image** — unchanged legacy path.

**Decision rationale for refusing raw base images (option i):** `ContainerBuilder` exists precisely to wrap a base image with the executor contract, the entrypoint script is not reliably available on the host at run time to inject, and "trust the image's CMD" is exactly the bogus-success failure mode being fixed. Executor-derived base images (entrypoint == `/entrypoint.sh`) keep working. Note the contract must be *positively* verified, so a base image must be present locally (an inspect failure is not a pass).

**`docker.py` helpers:** `image_exists()` / `image_has_executor_entrypoint()` with short-timeout inspects; positive results cached in-process with a 60s TTL (no per-run daemon round-trip), negatives never cached so a fresh build/pull is picked up immediately; `reset_image_caches()` for tests/rebuilds.

**`builder.py`:** generated Dockerfile now derives from the executor base image, drops the `USER sandbox`/`CMD` overrides (the inherited `/entrypoint.sh` must start as container root, install extras, then gosu-drop to run `/code/main.py` itself), guards `useradd` for bases where the sandbox user exists, and logs a loud warning after a build whose result lacks the contract (custom non-executor `base_image`). Images built by the old template are detected at run time and ignored with a warning recommending a rebuild — never executed.

**Behavior notes:**
- Default job type path is byte-for-byte unchanged when no built image exists.
- `python_version` no longer selects the builder's default base (the executor base pins Python); documented in the docstring.
- Pre-run refusals are recorded as `ExecutionError(type="config_error")` instead of being misclassified against the user's code.

## Tests

- `test_worker_errors.py::TestImageResolution`: built image preferred (image in cmd, requirements file skipped, `--network=none` kept); extras-only runtime install with built image; fallback to default when no built image; stale contract-less built image ignored; executor-derived base allowed; raw base refused (no `docker run`, `failed` + `config_error`, message names `tako-vm build`); unverifiable base refused; built image wins over base. Plus an autouse fixture keeping all existing tests hermetic from the new daemon probes.
- `test_docker_utils.py`: `image_exists` / `image_has_executor_entrypoint` command shape, TTL caching of positives only, per-image caching, failure → `False`/`None` semantics, cache reset.
- `test_builder.py::TestGenerateDockerfileEntrypointContract`: executor base default, no USER/CMD/ENTRYPOINT overrides, build-time requirement baking, guarded useradd, validation errors.

`ruff check` / `ruff format` clean; targeted suite (`test_worker_errors.py test_docker_utils.py test_runtime.py test_builder.py`): **128 passed, 1 skipped**; full suite: **432 passed, 147 skipped** (docker/postgres-gated skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)