### PR TITLE
fix(sandbox): verify OOM via docker inspect in library mode

### DIFF
--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -30,7 +30,8 @@ from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import (
     base_isolation_args,
     generate_container_name,
-    kill_container,
+    inspect_oom_killed,
+    remove_container,
 )
 from tako_vm.security import validate_pip_requirement
 
@@ -414,55 +415,85 @@ class Sandbox:
                 subprocess_timeout += self.config.startup_timeout
 
             start_time = time.time()
+            # The container runs without --rm (see _build_docker_command), so
+            # this try/finally — entered only once `docker run` is attempted —
+            # owns removal on every exit path: success, failure, OOM, host
+            # timeout, and unexpected exceptions. remove_container does
+            # `docker rm -f`, which also kills a still-running container (the
+            # TimeoutExpired case, where subprocess.run killed the docker CLI
+            # but the container kept running in the daemon).
             try:
-                proc = subprocess.run(
-                    cmd,
-                    timeout=subprocess_timeout,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                duration_ms = int((time.time() - start_time) * 1000)
+                try:
+                    proc = subprocess.run(
+                        cmd,
+                        timeout=subprocess_timeout,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    duration_ms = int((time.time() - start_time) * 1000)
 
-                # Read output
-                output_data = None
-                output_file = output_dir / "result.json"
-                if output_file.exists():
-                    try:
-                        output_data = json.loads(output_file.read_text())
-                    except json.JSONDecodeError:
-                        pass
+                    # Read output
+                    output_data = None
+                    output_file = output_dir / "result.json"
+                    if output_file.exists():
+                        try:
+                            output_data = json.loads(output_file.read_text())
+                        except json.JSONDecodeError:
+                            pass
 
-                # The in-container timeout (TAKO_EXECUTION_TIMEOUT, enforced by
-                # entrypoint.sh via timeout(1)) exits 124 when the code exceeds
-                # its budget, so most timeouts return here rather than through
-                # the TimeoutExpired backstop below. Surface them as timeouts.
-                error = None
-                if proc.returncode == 124:
-                    error = f"Execution timed out after {timeout}s"
+                    # The in-container timeout (TAKO_EXECUTION_TIMEOUT, enforced
+                    # by entrypoint.sh via timeout(1)) exits 124 when the code
+                    # exceeds its budget, so most timeouts return here rather
+                    # than through the TimeoutExpired backstop below. Surface
+                    # them as timeouts.
+                    error = None
+                    if proc.returncode == 124:
+                        error = f"Execution timed out after {timeout}s"
+                    elif proc.returncode == 137:
+                        # Exit 137 is SIGKILL — could be the OOM killer, but
+                        # also `docker kill` or user code calling
+                        # sys.exit(137). Only the exited container's
+                        # State.OOMKilled distinguishes them; inspect before
+                        # the finally block removes the container. In-container
+                        # timeout kills are already remapped to 124 by the
+                        # entrypoint, so a 137 seen here is a genuine SIGKILL.
+                        # None (inspect failed) falls back to reporting OOM so
+                        # a flaky inspect never loses a true OOM — same policy
+                        # as the server-side CodeExecutor.
+                        oom_killed = inspect_oom_killed(container_name)
+                        if oom_killed is False:
+                            error = "Process was killed (SIGKILL) but not by the memory limit"
+                        else:
+                            error = (
+                                "Container killed: out of memory "
+                                f"(memory_limit={self.config.memory_limit})"
+                            )
 
-                return SandboxResult(
-                    stdout=proc.stdout,
-                    stderr=proc.stderr,
-                    exit_code=proc.returncode,
-                    success=proc.returncode == 0,
-                    output=output_data,
-                    duration_ms=duration_ms,
-                    error=error,
-                )
+                    return SandboxResult(
+                        stdout=proc.stdout,
+                        stderr=proc.stderr,
+                        exit_code=proc.returncode,
+                        success=proc.returncode == 0,
+                        output=output_data,
+                        duration_ms=duration_ms,
+                        error=error,
+                    )
 
-            except subprocess.TimeoutExpired as exc:
-                # Kill the orphaned container (subprocess died but container keeps running)
-                kill_container(container_name)
-                duration_ms = int((time.time() - start_time) * 1000)
-                return SandboxResult(
-                    stdout=_decode_stream(exc.stdout),
-                    stderr=_decode_stream(exc.stderr),
-                    exit_code=-1,
-                    success=False,
-                    error=f"Execution timed out after {timeout}s",
-                    duration_ms=duration_ms,
-                )
+                except subprocess.TimeoutExpired as exc:
+                    duration_ms = int((time.time() - start_time) * 1000)
+                    return SandboxResult(
+                        stdout=_decode_stream(exc.stdout),
+                        stderr=_decode_stream(exc.stderr),
+                        exit_code=-1,
+                        success=False,
+                        error=f"Execution timed out after {timeout}s",
+                        duration_ms=duration_ms,
+                    )
+            finally:
+                # Best-effort kill+remove (`docker rm -f`, errors swallowed);
+                # the labeled orphan cleanup at startup is the backstop.
+                remove_container(container_name)
 
         finally:
             # Cleanup
@@ -510,18 +541,24 @@ class Sandbox:
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako-sandbox")
 
-        # Shared isolation base: --rm/--init/--read-only, capability drops, the
+        # Shared isolation base: --init/--read-only, capability drops, the
         # tako-vm-executor label (so startup cleanup can find orphans), and the
         # gVisor --runtime flag, resolved via the shared resolver so the
         # library path enforces the same posture as CodeExecutor (and fails
         # closed in strict mode when gVisor is unavailable). Library-mode runs
         # have no ExecutionRecord, so the unique container name doubles as the
         # traceability ID.
+        #
+        # auto_remove=False: keep the exited container so a 137 exit can be
+        # checked against `docker inspect .State.OOMKilled` (with --rm the
+        # daemon removes the container before it can be inspected). The
+        # try/finally in run() guarantees removal on every exit path.
         cmd = base_isolation_args(
             container_name,
             runtime=resolve_runtime(get_config()),
             enable_cap_restrictions=self.config.enable_cap_restrictions,
             execution_id=container_name,
+            auto_remove=False,
         )
 
         # Network isolation

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -456,6 +456,9 @@ class TestSandboxTimeoutEnforcement:
             lambda self, **kwargs: (["docker", "run", "fake"], "fake-container"),
         )
         monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
+        # The post-run container removal makes its own subprocess.run call;
+        # stub it out so it doesn't clobber the recorded docker-run timeout.
+        monkeypatch.setattr("tako_vm.sandbox.remove_container", lambda name: True)
 
         sb.run("print('hi')", timeout=10, requirements=["requests"])
         assert recorded["timeout"] == 100 + 10 + 5
@@ -474,7 +477,7 @@ class TestSandboxTimeoutEnforcement:
                 stderr=b"partial stderr",
             )
 
-        killed = {}
+        removed = {}
         sb = Sandbox()
         sb._image_checked = True  # Skip docker image inspect
         monkeypatch.setattr(
@@ -484,7 +487,7 @@ class TestSandboxTimeoutEnforcement:
         )
         monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
         monkeypatch.setattr(
-            "tako_vm.sandbox.kill_container", lambda name: killed.setdefault("name", name)
+            "tako_vm.sandbox.remove_container", lambda name: removed.setdefault("name", name)
         )
 
         result = sb.run("print('hi')", timeout=2)
@@ -494,7 +497,150 @@ class TestSandboxTimeoutEnforcement:
         assert result.stdout == "partial stdout"
         assert result.stderr == "partial stderr"
         assert "timed out" in result.error.lower()
-        assert killed["name"] == "fake-container"
+        # The container is no longer started with --rm, so the timeout path
+        # must kill+remove it (docker rm -f) itself.
+        assert removed["name"] == "fake-container"
+
+
+class TestSandboxOOMDetection:
+    """Unit tests for exit-137 OOM verification and container removal.
+
+    The sandbox no longer runs containers with ``--rm``: a 137 exit is
+    checked against ``docker inspect .State.OOMKilled`` (the only
+    authoritative OOM signal) and the container is removed in a finally on
+    every exit path. These tests monkeypatch subprocess.run and the docker
+    helpers, so no container is needed.
+    """
+
+    @staticmethod
+    def _make_sandbox(monkeypatch, returncode, events, oom_killed):
+        """Build a Sandbox whose docker run is faked to exit with returncode."""
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode, stdout="", stderr=""
+            )
+
+        def fake_inspect(name):
+            events.append(("inspect", name))
+            return oom_killed
+
+        def fake_remove(name):
+            events.append(("remove", name))
+            return True
+
+        sb = Sandbox(memory_limit="256m")
+        sb._image_checked = True  # Skip docker image inspect
+        monkeypatch.setattr(
+            Sandbox,
+            "_build_docker_command",
+            lambda self, **kwargs: (["docker", "run", "fake"], "fake-container"),
+        )
+        monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
+        monkeypatch.setattr("tako_vm.sandbox.inspect_oom_killed", fake_inspect)
+        monkeypatch.setattr("tako_vm.sandbox.remove_container", fake_remove)
+        return sb
+
+    def test_exit_137_oom_killed_reports_oom(self, monkeypatch):
+        """137 + State.OOMKilled=true -> OOM error including the memory limit."""
+        events = []
+        sb = self._make_sandbox(monkeypatch, returncode=137, events=events, oom_killed=True)
+
+        result = sb.run("x = 'a' * 10**9")
+
+        assert result.success is False
+        assert result.exit_code == 137
+        assert "out of memory" in result.error
+        assert "memory_limit=256m" in result.error
+        # Inspect must happen before the finally removes the container
+        assert events == [("inspect", "fake-container"), ("remove", "fake-container")]
+
+    def test_exit_137_not_oom_reports_sigkill(self, monkeypatch):
+        """137 + State.OOMKilled=false -> killed-but-not-OOM error."""
+        events = []
+        sb = self._make_sandbox(monkeypatch, returncode=137, events=events, oom_killed=False)
+
+        result = sb.run("import sys; sys.exit(137)")
+
+        assert result.success is False
+        assert result.exit_code == 137
+        assert "killed (SIGKILL)" in result.error
+        assert "not by the memory limit" in result.error
+        assert "out of memory" not in result.error
+        assert ("remove", "fake-container") in events
+
+    def test_exit_137_inspect_failure_falls_back_to_oom(self, monkeypatch):
+        """137 + inspect failed (None) -> assume OOM so a flaky inspect never loses one."""
+        events = []
+        sb = self._make_sandbox(monkeypatch, returncode=137, events=events, oom_killed=None)
+
+        result = sb.run("x = 'a' * 10**9")
+
+        assert result.success is False
+        assert "out of memory" in result.error
+
+    def test_container_removed_on_success(self, monkeypatch):
+        """Without --rm, the sandbox must remove the container after a clean exit."""
+        events = []
+        sb = self._make_sandbox(monkeypatch, returncode=0, events=events, oom_killed=False)
+
+        result = sb.run("print('hi')")
+
+        assert result.success is True
+        assert result.error is None
+        assert ("remove", "fake-container") in events
+        # No 137, so no inspect round-trip
+        assert ("inspect", "fake-container") not in events
+
+    def test_container_removed_on_failure(self, monkeypatch):
+        """The container is removed after a non-zero, non-137 exit too."""
+        events = []
+        sb = self._make_sandbox(monkeypatch, returncode=1, events=events, oom_killed=False)
+
+        result = sb.run("raise RuntimeError('boom')")
+
+        assert result.success is False
+        assert result.exit_code == 1
+        assert result.error is None
+        assert ("remove", "fake-container") in events
+        assert ("inspect", "fake-container") not in events
+
+    def test_no_container_removal_when_validation_fails(self, monkeypatch):
+        """ValueError before docker run means there is no container to remove."""
+        events = []
+
+        def fake_remove(name):
+            events.append(("remove", name))
+            return True
+
+        sb = Sandbox(memory_limit="256m")  # runtime requirements disabled
+        sb._image_checked = True  # Skip docker image inspect
+        monkeypatch.setattr("tako_vm.sandbox.remove_container", fake_remove)
+        monkeypatch.setattr("tako_vm.sandbox.subprocess.run", _fail_if_called)
+
+        result = sb.run("print('hi')", requirements=["pandas"])
+
+        assert result.success is False
+        assert "disabled" in result.error
+        assert events == []
+
+    def test_docker_command_omits_rm(self, tmp_path):
+        """The run command must not use --rm so the exited container can be inspected."""
+        code_dir, input_dir, output_dir = _make_workspace_dirs(tmp_path)
+
+        sb = Sandbox()
+        cmd, _ = sb._build_docker_command(
+            code_dir=code_dir,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            timeout=30,
+        )
+
+        assert "--rm" not in cmd
+
+
+def _fail_if_called(*args, **kwargs):
+    raise AssertionError("docker run must not be attempted when validation fails")
 
 
 @pytest.mark.requires_host_mounts


### PR DESCRIPTION
## Summary

Follow-up to #84, which fixed OOM detection in the server executor path (`CodeExecutor`). The library-mode `Sandbox` (`tako_vm/sandbox.py`) still ran containers with `--rm`, so on exit code 137 the exited container was gone before it could be inspected — every SIGKILL (OOM killer, `docker kill`, `sys.exit(137)`) surfaced identically as `success=False` with `error=None`.

This brings the sandbox to parity with the worker, reusing the `docker.py` helpers added in #84.

## Changes

- **Run without `--rm`**: `_build_docker_command` now passes `auto_remove=False` to `base_isolation_args`, keeping the exited container around for inspection.
- **Verify OOM on exit 137** via `inspect_oom_killed(container_name)`:
  - `True` → `error="Container killed: out of memory (memory_limit=<limit>)"`
  - `False` → `error="Process was killed (SIGKILL) but not by the memory limit"`
  - `None` (inspect failed) → assume OOM, the same fail-safe fallback as the worker, so a flaky inspect never loses a true OOM.
  - Exit 124 keeps its existing timeout mapping (#77); the entrypoint remaps in-container timeout kills to 124, so a 137 seen here is a genuine SIGKILL.
- **Guaranteed removal**: a `try/finally` — entered only once `docker run` is attempted — calls `remove_container()` (`docker rm -f`) on every exit path: success, failure, OOM, and the `TimeoutExpired` backstop (where `rm -f` covers both kill and remove, replacing the old `kill_container` call). The `ValueError` early-return for invalid requirements happens before any container exists and stays outside the `finally`.

## Tests (`tests/test_sandbox.py`)

Docker-free, monkeypatched unit tests following the existing `TestSandboxTimeoutEnforcement` patterns (conftest skips them locally without Docker; CI runs them):

- 137 + `OOMKilled=true` → OOM error including the memory limit, inspect happens before removal
- 137 + `OOMKilled=false` → killed-but-not-OOM error
- 137 + inspect failure (`None`) → falls back to OOM
- `remove_container` called on success, failure, and timeout paths
- No removal attempted when validation fails before `docker run`
- `--rm` absent from the built docker command
- Updated `test_subprocess_budget...` and `test_timeout_preserves_partial_output` for the new removal flow

## Verification

- `ruff check` / `ruff format --check`: clean
- All 13 docker-free unit tests in the touched classes pass when the conftest Docker gates are bypassed; full `pytest tests/test_sandbox.py -q` skips locally (no Docker) with no collection/import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)