### PR TITLE
chore(security): remove secrets-looking fixture, scrub legacy DLQ rows, warn on multi-worker topology

### DIFF
--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -70,7 +70,13 @@ def main():
     server_parser.add_argument(
         "--workers",
         type=int,
-        help="Number of worker processes (default: 1; cannot be combined with --reload)",
+        help=(
+            "Number of worker processes (default: 1; cannot be combined with --reload). "
+            "WARNING: each process runs its own in-memory worker pool, so async job "
+            "polling relies on database fallbacks and wait=true result streaming only "
+            "works on the submitting worker; prefer a single worker behind a load "
+            "balancer."
+        ),
     )
     server_parser.set_defaults(auto_start_postgres=True)
     server_parser.add_argument(
@@ -299,6 +305,14 @@ def run_server(args):
             file=sys.stderr,
         )
         sys.exit(1)
+    if workers > 1:
+        print(
+            f"WARNING: --workers {workers} runs {workers} independent worker pools; "
+            "async job polling relies on database fallbacks and wait=true result "
+            "streaming only works on the submitting worker. Prefer a single worker "
+            "behind a load balancer unless you know you need this.",
+            file=sys.stderr,
+        )
 
     # uvicorn requires the app as an import string for --reload or multiple
     # workers (it silently disables them when given an app object). Those modes

--- a/tako_vm/job_types.json
+++ b/tako_vm/job_types.json
@@ -65,29 +65,6 @@
         "count": null,
         "device_ids": []
       }
-    },
-    {
-      "name": "test-with-secrets",
-      "requirements": [],
-      "python_version": "3.11",
-      "base_image": null,
-      "shared_code": [],
-      "environment": {
-        "API_KEY": "sk-secret-api-key-12345",
-        "DATABASE_URL": "postgresql://user:password@db.internal:5432/app"
-      },
-      "memory_limit": "256m",
-      "cpu_limit": 0.5,
-      "timeout": 10,
-      "startup_timeout": 120,
-      "network_enabled": false,
-      "session_enabled": false,
-      "gpu": {
-        "enabled": false,
-        "vendor": null,
-        "count": null,
-        "device_ids": []
-      }
     }
   ]
 }

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -157,6 +157,24 @@ MIGRATIONS: list[tuple[str, str]] = [
         ALTER TABLE execution_records ADD COLUMN IF NOT EXISTS correlation_id TEXT
         """,
     ),
+    (
+        # DLQ rows written before DeadLetterEntry.build_job_summary existed
+        # retain raw code/input_data/idempotency material in job_data_json.
+        # Strip those keys in place and mark the rows so operators can tell
+        # redaction happened after the fact.
+        "0003_redact_dlq_job_data",
+        """
+        UPDATE dead_letter_queue
+        SET job_data_json = (
+                job_data_json - 'code' - 'input_data'
+                - 'idempotency_key' - 'idempotency_fingerprint'
+            )
+            || jsonb_build_object('redacted_by_migration', true)
+        WHERE job_data_json ?| array[
+            'code', 'input_data', 'idempotency_key', 'idempotency_fingerprint'
+        ]
+        """,
+    ),
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -659,8 +659,9 @@ class TestRunServerFunction:
 
         reset_config()
 
-    def test_run_server_workers_passed_through(self):
-        """--workers is forwarded to uvicorn with the app as an import string."""
+    def test_run_server_workers_passed_through(self, capsys):
+        """--workers is forwarded to uvicorn with the app as an import string,
+        and a multi-worker topology warning is printed to stderr."""
         import uvicorn
 
         from tako_vm.cli import run_server
@@ -686,10 +687,16 @@ class TestRunServerFunction:
         assert app_arg == "tako_vm.server.app:app"
         assert call_kwargs["workers"] == 4
 
+        captured = capsys.readouterr()
+        assert "WARNING: --workers 4 runs 4 independent worker pools" in captured.err
+        assert "wait=true result streaming only works on the submitting worker" in captured.err
+        assert "Prefer a single worker behind a load balancer" in captured.err
+
         reset_config()
 
-    def test_run_server_default_single_worker_uses_app_object(self):
-        """Without --workers/--reload, the app object is passed with workers=1."""
+    def test_run_server_default_single_worker_uses_app_object(self, capsys):
+        """Without --workers/--reload, the app object is passed with workers=1
+        and no multi-worker topology warning is emitted."""
         import uvicorn
 
         from tako_vm.cli import run_server
@@ -715,6 +722,9 @@ class TestRunServerFunction:
         call_kwargs = mock_run.call_args[1]
         assert app_arg is app
         assert call_kwargs["workers"] == 1
+
+        captured = capsys.readouterr()
+        assert "independent worker pools" not in captured.err
 
         reset_config()
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1042,3 +1042,62 @@ class TestCorrelationIdPersistence:
         assert retrieved is not None
         assert retrieved.status == "succeeded"
         assert retrieved.correlation_id == "req-keep-me"
+
+
+class TestRedactDLQMigration:
+    """Migration 0003 scrubs raw payloads from pre-redaction DLQ rows."""
+
+    def test_migration_0003_redacts_legacy_dlq_rows(self, storage):
+        """Legacy rows lose code/input_data/idempotency keys and gain a marker."""
+        from tako_vm.storage import MIGRATIONS
+
+        legacy = DeadLetterEntry(
+            job_id="legacy-raw-job",
+            job_data={
+                "job_type": "data-processing",
+                "code": "import os; print(os.environ)",
+                "input_data": {"api_token": "super-secret"},
+                "idempotency_key": "idem-raw-123",
+                "idempotency_fingerprint": "f" * 64,
+                "timeout": 30,
+            },
+            error_type="internal_error",
+            error_message="boom",
+        )
+        legacy_id = storage.add_to_dlq(legacy)
+
+        clean = DeadLetterEntry(
+            job_id="already-redacted-job",
+            job_data={"job_type": "default", "code_sha256": "a" * 64},
+            error_type="timeout",
+            error_message="slow",
+        )
+        clean_id = storage.add_to_dlq(clean)
+
+        # The fixture's init() already recorded 0003 in schema_migrations
+        # before these rows existed, so run the registered SQL directly --
+        # this exercises the exact statement shipped in MIGRATIONS.
+        migration_sql = dict(MIGRATIONS)["0003_redact_dlq_job_data"]
+
+        async def apply_migration():
+            pool = storage._inner._get_pool()
+            async with pool.connection() as conn:
+                await conn.execute(migration_sql)
+
+        storage._run(apply_migration())
+
+        redacted = storage.get_dlq_entry(legacy_id)
+        assert redacted is not None
+        for key in ("code", "input_data", "idempotency_key", "idempotency_fingerprint"):
+            assert key not in redacted.job_data
+        assert redacted.job_data["redacted_by_migration"] is True
+        # Non-sensitive diagnostic metadata is preserved.
+        assert redacted.job_data["job_type"] == "data-processing"
+        assert redacted.job_data["timeout"] == 30
+        assert redacted.error_type == "internal_error"
+
+        # Rows without raw fields are left untouched (no spurious marker).
+        untouched = storage.get_dlq_entry(clean_id)
+        assert untouched is not None
+        assert "redacted_by_migration" not in untouched.job_data
+        assert untouched.job_data == {"job_type": "default", "code_sha256": "a" * 64}


### PR DESCRIPTION
Three small security follow-up cleanups.

## 1. Remove checked-in secrets-looking job type

`tako_vm/job_types.json` (also the legacy registry seed) shipped a `test-with-secrets` entry with fake-credential-looking values (`API_KEY: sk-secret-api-key-12345`, a `postgresql://user:password@...` DATABASE_URL). Removed. The only code reference, `tests/test_proc_exposure.py`, already defines its own `JobType` fixture inline and registers it at runtime — it never depended on the checked-in file, so no test changes were needed.

## 2. Scrub raw payloads from pre-existing DLQ rows

PR #83 redacts NEW dead-letter entries via `DeadLetterEntry.build_job_summary`, but rows written before it retain raw `code`, `input_data`, and idempotency material in `dead_letter_queue.job_data_json` (JSONB) until TTL expiry. New migration `0003_redact_dlq_job_data` strips those keys in place and adds a `redacted_by_migration: true` marker; the `?|` guard leaves already-clean rows untouched. Note: the column is `job_data_json` (the task sketch said `job_data` — verified against the 0001 schema and `add_to_dlq`).

Postgres-backed test added at the end of `tests/test_storage.py`: inserts a raw legacy-style row and a clean row via `add_to_dlq`, executes the exact registered migration SQL through the pool, and asserts raw keys are gone, the marker is present, diagnostic metadata (`job_type`, `timeout`) survives, and the clean row is unmodified.

## 3. Multi-worker topology warning

`tako-vm server --workers N` (N > 1) gives each uvicorn process its own in-memory `WorkerPool`: async job polling only works reliably through the DB-backed fallbacks, and `GET /jobs/{id}/result?wait=true` on a non-submitting worker won't find the in-memory future. `run_server` now prints a stderr WARNING before `uvicorn.run` when `workers > 1`, and the `--workers` help text mentions the caveat. Extended the existing `test_cli.py` workers tests to assert the warning via capsys (and its absence in single-worker mode).

## Testing

- `ruff check` / `ruff format --check` clean
- `uv run --extra all --extra dev pytest tests/test_cli.py tests/test_job_types.py -q` — 60 passed
- `tests/test_storage.py` run locally against a real PostgreSQL 16 instance — 51 passed (including the new migration test; fixture init also exercised 0003 through the actual migration runner on fresh schemas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)