### PR TITLE
fix: capture and verbosely surface failure modes across the codebase

### DIFF
--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -24,12 +24,15 @@ except ImportError:
     pass
 
 import argparse
+import logging
 import os
 import subprocess
 import sys
 import time
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/tako_vm"
 MANAGED_POSTGRES_URL = "postgresql://postgres:postgres@localhost:55432/tako_vm"
@@ -254,9 +257,12 @@ def run_setup(args):
     if result.returncode == 0 and "ok" in result.stdout:
         print("  Executor image works")
     else:
-        print("Warning: Image pulled but verification failed.", file=sys.stderr)
+        # The image is unusable — exit non-zero so `tako-vm setup && ...`
+        # doesn't proceed on a broken image and report success.
+        print("Error: Image pulled but verification failed.", file=sys.stderr)
         if result.stderr:
             print(f"  {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
 
     print("\nSetup complete! Ready to run jobs.")
 
@@ -339,7 +345,10 @@ def _can_connect_database(database_url: str, timeout: int = 2) -> bool:
 
         with psycopg.connect(database_url, connect_timeout=timeout):
             return True
-    except Exception:
+    except Exception as e:
+        # Log the real reason so a bad URL / missing driver / auth failure
+        # isn't indistinguishable from "database is down".
+        logger.debug("Database connectivity check failed: %s", e)
         return False
 
 
@@ -531,15 +540,28 @@ def check_status(args):
 
     try:
         response = requests.get(f"{args.url}/health", timeout=5)
+        # A non-2xx /health means the server is up but unhealthy — surface the
+        # status code and body instead of blindly parsing JSON (which could
+        # raise, or worse, print a healthy-looking "unknown").
+        if response.status_code >= 400:
+            body = (response.text or "").strip()
+            print(f"Error: server returned HTTP {response.status_code}", file=sys.stderr)
+            if body:
+                print(f"  {body[:500]}", file=sys.stderr)
+            sys.exit(1)
         data = response.json()
         print(f"Status: {data.get('status', 'unknown')}")
         print(f"Docker: {'available' if data.get('docker_available') else 'unavailable'}")
         print(f"Version: {data.get('version', 'unknown')}")
     except requests.exceptions.ConnectionError:
-        print(f"Error: Cannot connect to {args.url}")
+        print(f"Error: Cannot connect to {args.url}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as e:
+        # Reachable but the body wasn't valid JSON — show what we got.
+        print(f"Error: invalid JSON from {args.url}/health: {e}", file=sys.stderr)
         sys.exit(1)
     except Exception as e:
-        print(f"Error: {e}")
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
 
@@ -586,9 +608,11 @@ def validate_config(args):
             if config.job_types:
                 for jt in config.job_types:
                     print(f"    - {jt.name}")
-        except (ImportError, ValueError, AttributeError):
-            # Silently skip summary if config can't be loaded for display
-            pass
+        except (ImportError, ValueError, AttributeError) as e:
+            # validate_config_file passed but the full loader (which also
+            # applies env overrides + resolve_paths) failed — that divergence
+            # matters, so don't hide it behind "Configuration is valid!".
+            print(f"(could not render config summary: {e})", file=sys.stderr)
 
 
 def show_config(args):

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -254,11 +254,25 @@ def check_gvisor_available() -> bool:
             text=True,
             timeout=10,
         )
-        _gvisor_available = result.returncode == 0 and "runsc" in result.stdout
+        if result.returncode != 0:
+            # `docker info` failed (daemon not up yet, transient hiccup). Don't
+            # cache this as "gVisor unavailable" — a one-time probe failure
+            # would otherwise sticky-degrade every later job to runc in
+            # permissive mode. Leave the cache unset so we re-probe next call.
+            logger.warning(
+                "gVisor probe inconclusive: `docker info` exited %s (%s); "
+                "will re-check on next job",
+                result.returncode,
+                (result.stderr or "").strip()[:200],
+            )
+            return False
+        _gvisor_available = "runsc" in result.stdout
         return _gvisor_available
     except Exception as e:
-        logger.warning(f"Failed to check gVisor availability: {e}")
-        _gvisor_available = False
+        # Transient failure (timeout, docker missing momentarily): log and
+        # return False WITHOUT caching, so a flaky probe doesn't permanently
+        # disable gVisor for the process lifetime.
+        logger.warning("Failed to check gVisor availability (will re-check): %s", e)
         return False
 
 
@@ -838,8 +852,13 @@ class CodeExecutor:
             elif output_file.exists():
                 try:
                     record.result_json = json.loads(output_file.read_text(encoding="utf-8"))
-                except json.JSONDecodeError:
-                    pass
+                except (json.JSONDecodeError, OSError, ValueError) as e:
+                    # Output existed but was unreadable/unparseable (truncated,
+                    # non-UTF-8, device error). Surface it loudly instead of
+                    # presenting result_json=None as "no output produced".
+                    logger.warning(
+                        "Failed to read/parse result.json for job %s: %s", job_id, e
+                    )
 
             # Parse phase timing file (written by entrypoint.sh). The
             # root-only meta_dir copy is preferred; the /output copy is a
@@ -906,6 +925,17 @@ class CodeExecutor:
                         phase=phase,
                     )
                 else:
+                    if result.get("oom_killed") is None:
+                        # inspect was inconclusive (daemon unreachable, container
+                        # already gone). We default to OOM so a flaky inspect
+                        # never loses a true OOM — but the classification is a
+                        # guess, so say so loudly rather than reporting a
+                        # confident "oom".
+                        logger.warning(
+                            "Job %s exited 137 but OOM inspect was inconclusive; "
+                            "defaulting to OOM classification",
+                            job_id,
+                        )
                     record.status = "oom"
                     record.error = ExecutionError(
                         type="oom",
@@ -950,7 +980,9 @@ class CodeExecutor:
             return record
 
         except Exception as e:
-            # Unexpected error
+            # Unexpected error — keep the full traceback server-side; the
+            # sanitized message is all the API consumer sees.
+            logger.exception("Unexpected error executing job %s: %s", job_id, e)
             record.status = "failed"
             record.ended_at = datetime.now(timezone.utc)
             record.error = ExecutionError(type="internal_error", message=sanitize_error(str(e)))
@@ -1283,6 +1315,10 @@ class CodeExecutor:
         # Check circuit breaker before attempting Docker operation
         circuit_breaker = get_circuit_breaker()
         if not circuit_breaker.is_available:
+            logger.warning(
+                "Refusing job %s: Docker circuit breaker is open (repeated Docker failures)",
+                job_id,
+            )
             return {
                 "success": False,
                 "error": "Docker service unavailable (circuit breaker open)",
@@ -1337,6 +1373,12 @@ class CodeExecutor:
         requirements_file = input_dir / "_requirements.txt"
         if validated_reqs:
             if not self.config.allow_runtime_requirements:
+                logger.warning(
+                    "Refusing job %s: %d runtime requirement(s) requested but "
+                    "allow_runtime_requirements=false",
+                    job_id,
+                    len(validated_reqs),
+                )
                 return {
                     "success": False,
                     "error": "Runtime dependency installation is disabled",
@@ -1457,6 +1499,10 @@ class CodeExecutor:
 
         container_timeout = startup_timeout + timeout + 5
         if not validate_docker_run_args(cmd):
+            logger.error(
+                "Refusing job %s: docker run arguments failed safety validation",
+                job_id,
+            )
             return {
                 "success": False,
                 "error": "Unsafe Docker command rejected",
@@ -1525,7 +1571,15 @@ class CodeExecutor:
         except subprocess.TimeoutExpired as e:
             # Timeout is not a Docker failure, don't record with circuit breaker
             # Kill the orphaned container (subprocess died but container keeps running)
-            kill_container(container_name)
+            if not kill_container(container_name):
+                # An untrusted container that outlived its host timeout and
+                # could not be killed is a real containment concern — surface it.
+                logger.warning(
+                    "Failed to kill container %s after host timeout for job %s; "
+                    "it may still be running",
+                    container_name,
+                    job_id,
+                )
             return {
                 "success": False,
                 "error": f"Execution timeout exceeded ({timeout}s)",
@@ -1552,6 +1606,15 @@ class CodeExecutor:
         except Exception as e:
             # Other errors might be Docker-related
             # Kill container in case it was started before the error
+            logger.error(
+                "Unexpected error running container for job %s: %s",
+                job_id,
+                e,
+                exc_info=True,
+            )
+            # Best-effort kill; the container may never have started (error
+            # before `docker run`), so a False return here is often benign and
+            # not worth a warning — the finally block removes it regardless.
             kill_container(container_name)
             error_msg = str(e).lower()
             if "docker" in error_msg or "daemon" in error_msg or "connection" in error_msg:

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -439,8 +439,14 @@ class Sandbox:
                     if output_file.exists():
                         try:
                             output_data = json.loads(output_file.read_text())
-                        except json.JSONDecodeError:
-                            pass
+                        except (json.JSONDecodeError, OSError, ValueError) as e:
+                            # Output existed but was unreadable/unparseable.
+                            # Don't silently present None as "no output".
+                            logger.warning(
+                                "result.json for %s was not valid JSON, ignoring: %s",
+                                container_name,
+                                e,
+                            )
 
                     # The in-container timeout (TAKO_EXECUTION_TIMEOUT, enforced
                     # by entrypoint.sh via timeout(1)) exits 124 when the code
@@ -482,18 +488,38 @@ class Sandbox:
 
                 except subprocess.TimeoutExpired as exc:
                     duration_ms = int((time.time() - start_time) * 1000)
+                    # Reaching the host backstop means the in-container timeout
+                    # (TAKO_EXECUTION_TIMEOUT) did NOT fire — daemon hung, heavy
+                    # container overhead, or a stuck startup phase. Report the
+                    # real budget consumed (subprocess_timeout), not the inner
+                    # code timeout, and say which limit tripped.
+                    logger.warning(
+                        "Sandbox %s hit the host timeout backstop after %ss "
+                        "(in-container timeout did not fire)",
+                        container_name,
+                        subprocess_timeout,
+                    )
                     return SandboxResult(
                         stdout=_decode_stream(exc.stdout),
                         stderr=_decode_stream(exc.stderr),
                         exit_code=-1,
                         success=False,
-                        error=f"Execution timed out after {timeout}s",
+                        error=(
+                            f"Execution killed by host backstop after "
+                            f"{subprocess_timeout}s (in-container timeout did not fire)"
+                        ),
                         duration_ms=duration_ms,
                     )
             finally:
-                # Best-effort kill+remove (`docker rm -f`, errors swallowed);
-                # the labeled orphan cleanup at startup is the backstop.
-                remove_container(container_name)
+                # Best-effort kill+remove (`docker rm -f`). A failure here leaks
+                # a sandbox container; the labeled orphan cleanup at startup is
+                # the backstop, but surface it so the leak isn't invisible.
+                if not remove_container(container_name):
+                    logger.warning(
+                        "Failed to remove sandbox container %s; "
+                        "relying on startup orphan cleanup",
+                        container_name,
+                    )
 
         finally:
             # Cleanup
@@ -603,8 +629,10 @@ class Sandbox:
         for i, pkg_dir in enumerate(self.config.package_dirs):
             pkg_path = Path(pkg_dir).absolute()
             if not pkg_path.exists():
-                logger.warning("Package directory does not exist: %s", pkg_dir)
-                continue
+                # The caller explicitly asked for this dependency; silently
+                # dropping it would surface later as a confusing in-sandbox
+                # ModuleNotFoundError instead of at the misconfiguration site.
+                raise ValueError(f"Package directory does not exist: {pkg_dir}")
             mount_target = f"/packages/pkg{i}"
             cmd.append(f"--mount=type=bind,source={pkg_path},target={mount_target},readonly")
             pythonpath_parts.append(mount_target)

--- a/tako_vm/sdk/client.py
+++ b/tako_vm/sdk/client.py
@@ -106,6 +106,10 @@ class ExecutionResult:
     exit_code: Optional[int] = None
     correlation_id: Optional[str] = None
     job_id: Optional[str] = None
+    # Set when the run succeeded but the output dict could not be coerced into
+    # the expected dataclass (output stays a raw dict). Lets callers detect the
+    # mismatch programmatically instead of scraping logs.
+    deserialization_error: Optional[str] = None
 
 
 class TakoVMError(Exception):
@@ -181,8 +185,35 @@ class SDKExecutionError(TakoVMError):
 ExecutionError = SDKExecutionError
 
 
+class MalformedResponseError(TakoVMError):
+    """Raised when the server returns 2xx but the body violates the expected
+    schema (missing/renamed fields). Surfaces a contract mismatch loudly
+    instead of letting a naked KeyError escape with no correlation context."""
+
+    def __init__(self, message: str, correlation_id: Optional[str] = None):
+        super().__init__(message)
+        self.correlation_id = correlation_id
+
+
 class ValidationError(TakoVMError):
     """Raised when input/output validation fails."""
+
+
+def _require_job_id(data: Any, correlation_id: Optional[str]) -> str:
+    """Extract ``job_id`` from a server response, raising a structured,
+    correlated error if the body is malformed instead of a naked KeyError."""
+    if not isinstance(data, dict) or not data.get("job_id"):
+        keys = list(data.keys()) if isinstance(data, dict) else type(data).__name__
+        logger.error(
+            "Server response missing 'job_id' (correlation_id=%s, keys=%s)",
+            correlation_id,
+            keys,
+        )
+        raise MalformedResponseError(
+            f"Server response did not contain a job_id (got keys: {keys})",
+            correlation_id=correlation_id,
+        )
+    return data["job_id"]
 
 
 def _build_session(pool_size: int = 10) -> requests.Session:
@@ -366,15 +397,20 @@ class TakoVM:
             value = info.get("timeout") if isinstance(info, dict) else None
             if isinstance(value, int):
                 resolved = value
+            # Only a definitive answer (success, whether or not a timeout was
+            # defined) is cached. A transient lookup failure below is NOT
+            # cached, so the client re-probes once the server recovers instead
+            # of pinning the conservative fallback for its whole lifetime.
+            self._job_type_timeouts[name] = resolved
         except TakoVMError as e:
             logger.warning(
                 "Could not resolve timeout for job type %r (%s); "
-                "falling back to the maximum read timeout of %.0fs for this client",
+                "falling back to the maximum read timeout of %.0fs for this call "
+                "(will re-check on next use)",
                 name,
                 e,
                 FALLBACK_READ_TIMEOUT,
             )
-        self._job_type_timeouts[name] = resolved
         return resolved
 
     def _resolve_read_timeout(
@@ -502,6 +538,9 @@ class TakoVM:
                 result.output = output_cls(**cast(Dict[str, Any], result.output))
             except (TypeError, ValueError, KeyError) as e:
                 # Keep as dict if deserialization fails (type mismatch, missing fields, etc.).
+                result.deserialization_error = (
+                    f"Could not deserialize output to {output_cls.__name__}: {e}"
+                )
                 logger.warning(
                     "Could not deserialize output to %s (correlation_id=%s); "
                     "returning the raw dict instead: %s",
@@ -617,6 +656,21 @@ class TakoVM:
                     f"Malformed response from server (HTTP {response.status_code}): "
                     f"{e}; body={snippet!r}"
                 ),
+                correlation_id=result_cid,
+            )
+        if not isinstance(data, dict) or "success" not in data:
+            # Valid JSON, but not the execution-result shape we expect. Surface
+            # the contract mismatch instead of coercing it to a vague
+            # "Execution failed" with no diagnostic.
+            keys = list(data.keys()) if isinstance(data, dict) else type(data).__name__
+            logger.error(
+                "Execution response missing 'success' field "
+                "(correlation_id=%s, keys=%s)",
+                result_cid,
+                keys,
+            )
+            raise MalformedResponseError(
+                f"Execution response was missing the 'success' field (got keys: {keys})",
                 correlation_id=result_cid,
             )
         logger.debug(
@@ -782,6 +836,7 @@ _execute()
             idempotency_key=key,
         )
         logger.debug("Submitting async job (correlation_id=%s, idempotency_key=%s)", cid, key)
+        data: Optional[Dict[str, Any]] = None
         for attempt in range(SUBMIT_MAX_ATTEMPTS):
             try:
                 data = self._request("POST", "/execute/async", json=payload, correlation_id=cid)
@@ -808,7 +863,7 @@ _execute()
                     e,
                 )
                 time.sleep(delay)
-        job_id = data["job_id"]
+        job_id = _require_job_id(data, cid)
         logger.debug("Async job %s queued (correlation_id=%s)", job_id, cid)
         return job_id
 
@@ -875,7 +930,8 @@ _execute()
             body["job_type"] = job_type
         if timeout is not None:
             body["timeout"] = timeout
-        return self._request("POST", f"/jobs/{job_id}/rerun", json=body)["job_id"]
+        data = self._request("POST", f"/jobs/{job_id}/rerun", json=body)
+        return _require_job_id(data, None)
 
     def fork(
         self,
@@ -891,7 +947,8 @@ _execute()
             body["job_type"] = job_type
         if timeout is not None:
             body["timeout"] = timeout
-        return self._request("POST", f"/jobs/{job_id}/fork", json=body)["job_id"]
+        data = self._request("POST", f"/jobs/{job_id}/fork", json=body)
+        return _require_job_id(data, None)
 
     def download_artifact(self, job_id: str, artifact_name: str) -> bytes:
         """Download a job artifact's bytes (GET /jobs/{job_id}/artifacts/{name})."""

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -785,6 +785,16 @@ async def health_check():
     Returns:
         Health status including Docker availability, circuit breaker, and queue stats
     """
+    # /health is exempt from auth and is what load balancers poll during
+    # startup/shutdown. Before lifespan assigns the worker pool (or after
+    # stop()), report a clear 503 "starting" instead of letting the
+    # state.worker_pool access raise an opaque 500.
+    if not hasattr(state, "worker_pool"):
+        return JSONResponse(
+            status_code=503,
+            content={"status": "starting", "detail": "Server is not ready yet"},
+        )
+
     circuit_breaker = get_circuit_breaker()
     docker_available = circuit_breaker.check_docker_health()
     gvisor_available = check_gvisor_available()

--- a/tako_vm/server/limits.py
+++ b/tako_vm/server/limits.py
@@ -9,6 +9,7 @@ This middleware provides lightweight API-layer protections:
 from __future__ import annotations
 
 import hmac
+import logging
 import math
 import time
 from threading import Lock
@@ -24,6 +25,8 @@ from tako_vm.server.correlation import (
     get_correlation_id,
     set_correlation_id,
 )
+
+logger = logging.getLogger(__name__)
 
 _CORRELATION_ID_HEADER_BYTES = CORRELATION_ID_HEADER.lower().encode("ascii")
 _RATE_LIMIT_EXEMPT_PATHS = {
@@ -105,6 +108,39 @@ class ApiProtectionMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # This middleware wraps the app *outside* FastAPI's exception handlers,
+        # so an unexpected error in the protection logic would otherwise escape
+        # as an opaque 500 with no correlated log line. Catch it, log loudly,
+        # and emit a sanitized 500 — unless the response has already started
+        # streaming, in which case we can only re-raise.
+        response_started = False
+
+        async def tracked_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self._dispatch(scope, receive, tracked_send)
+        except Exception as e:
+            logger.error(
+                "Unhandled error in API protection middleware (correlation_id=%s): %s",
+                get_correlation_id(),
+                e,
+                exc_info=True,
+            )
+            if response_started:
+                raise
+            await self._send_error_response(
+                scope,
+                receive,
+                send,
+                status_code=500,
+                detail="Internal server error.",
+            )
+
+    async def _dispatch(self, scope: Scope, receive: Receive, send: Send) -> None:
         config = self._config_getter()
         path = scope.get("path", "")
         authenticated_identity = None

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -652,6 +652,16 @@ class WorkerPool:
                         except Exception:
                             pass
                 await asyncio.sleep(1)  # Prevent tight loop on errors
+            finally:
+                # Backstop cleanup: the inner try's finally handles the normal
+                # path, but an exception raised after a job is placed in
+                # _running_jobs (line ~502) but before the inner try is entered
+                # would otherwise strand it as 'running' forever. pop() is
+                # idempotent, so double-cleanup is harmless.
+                if job is not None:
+                    async with self._jobs_lock:
+                        self._active_jobs.pop(job.job_id, None)
+                        self._running_jobs.pop(job.job_id, None)
 
         logger.info(f"Worker {worker_id} stopped")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,7 +164,9 @@ class TestCLIStatus:
             text=True,
         )
         assert result.returncode == 1
-        assert "cannot connect" in result.stdout.lower() or "error" in result.stdout.lower()
+        # Errors are written to stderr (stdout stays clean for parseable output).
+        combined = (result.stdout + result.stderr).lower()
+        assert "cannot connect" in combined or "error" in combined
 
 
 class TestCLIConfigPath:
@@ -267,6 +269,7 @@ class TestCheckStatusFunction:
         from tako_vm.cli import check_status
 
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {
             "status": "healthy",
             "docker_available": True,
@@ -291,6 +294,7 @@ class TestCheckStatusFunction:
         from tako_vm.cli import check_status
 
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {
             "status": "degraded",
             "docker_available": False,

--- a/tests/test_failure_mode_handling.py
+++ b/tests/test_failure_mode_handling.py
@@ -1,0 +1,207 @@
+"""Regression tests for verbose, non-swallowing failure handling.
+
+These cover failure modes that must surface loudly rather than crash opaquely
+or leave stuck state:
+  - an unexpected error in the API protection middleware (which runs *outside*
+    FastAPI's exception handlers) -> sanitized 500 + ERROR log, not a raw crash
+  - an exception in the worker's queued->running transition window -> the job
+    must not be stranded in the in-memory tracking dicts, and its future must
+    still resolve.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _build_app_with_failing_middleware(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from tako_vm.config import TakoVMConfig
+    from tako_vm.server.limits import ApiProtectionMiddleware
+
+    cfg = TakoVMConfig(api_auth_enabled=False, api_rate_limit_enabled=True)
+
+    app = FastAPI()
+
+    @app.get("/execute")
+    def _ep():  # non-exempt path so the protection logic runs
+        return {"ok": True}
+
+    # Inject a failure into the protection logic, which executes outside
+    # FastAPI's own exception handlers.
+    def boom(self, scope, identity):
+        raise RuntimeError("injected: limiter identity resolution failed")
+
+    monkeypatch.setattr(ApiProtectionMiddleware, "_get_client_identifier", boom)
+    app.add_middleware(ApiProtectionMiddleware, config_getter=lambda: cfg)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_middleware_unexpected_error_returns_sanitized_500(monkeypatch, caplog):
+    client = _build_app_with_failing_middleware(monkeypatch)
+    with caplog.at_level("ERROR"):
+        resp = client.get("/execute")
+
+    assert resp.status_code == 500
+    assert "Internal server error" in resp.text
+    # Verbose-on-failure: our own correlated ERROR log, not just Starlette's.
+    assert any(
+        "Unhandled error in API protection middleware" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_gvisor_probe_does_not_cache_transient_failure(monkeypatch):
+    """A transient probe failure must NOT sticky-cache gVisor as unavailable —
+    otherwise one flaky `docker info` degrades every later job to runc."""
+    import subprocess
+
+    import tako_vm.execution.worker as worker
+
+    worker.reset_gvisor_check()
+
+    # First call: probe raises (transient). Must return False but not cache.
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("docker", 10))
+    )
+    assert worker.check_gvisor_available() is False
+    assert worker._gvisor_available is None  # not cached
+
+    # Second call: docker recovers and reports runsc. Must now resolve True.
+    class _OK:
+        returncode = 0
+        stdout = "map[runc:... runsc:...]"
+        stderr = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _OK())
+    assert worker.check_gvisor_available() is True
+    worker.reset_gvisor_check()
+
+
+def test_gvisor_probe_does_not_cache_docker_info_nonzero(monkeypatch):
+    """`docker info` exiting non-zero (daemon not up) is also transient and
+    must not be cached as 'gVisor unavailable'."""
+    import subprocess
+
+    import tako_vm.execution.worker as worker
+
+    worker.reset_gvisor_check()
+
+    class _Fail:
+        returncode = 1
+        stdout = ""
+        stderr = "Cannot connect to the Docker daemon"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Fail())
+    assert worker.check_gvisor_available() is False
+    assert worker._gvisor_available is None
+    worker.reset_gvisor_check()
+
+
+def test_health_returns_503_before_worker_pool_ready():
+    """/health must report a clear 503 'starting' before the worker pool is
+    assigned, not an opaque 500 from accessing an unset attribute."""
+    from fastapi.testclient import TestClient
+
+    from tako_vm.server.app import app, state
+
+    # Simulate pre-lifespan state: worker_pool not yet assigned.
+    had_pool = hasattr(state, "worker_pool")
+    saved = getattr(state, "worker_pool", None)
+    if had_pool:
+        del state.worker_pool
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/health")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "starting"
+    finally:
+        if had_pool:
+            state.worker_pool = saved
+
+
+def test_sdk_surfaces_deserialization_mismatch_on_result():
+    """When a run succeeds but the output can't be coerced into the expected
+    dataclass, the mismatch must be visible on the result object, not only logs."""
+    from dataclasses import dataclass
+
+    from tako_vm.sdk.client import TakoVM
+
+    @dataclass
+    class In:
+        x: int
+
+    @dataclass
+    class Out:
+        y: int
+
+    def fn(a: In) -> Out:  # noqa: ARG001
+        return Out(y=1)
+
+    session = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.json.return_value = {
+        "success": True,
+        "output": {"WRONG_FIELD": 1},  # doesn't fit Out
+        "execution_time": 0.1,
+    }
+    resp.text = ""
+    session.request.return_value = resp
+
+    client = TakoVM(session=session)
+    result = client.send_raw(fn, In(x=1), timeout=5)
+    assert result.success is True
+    assert result.output == {"WRONG_FIELD": 1}  # raw dict preserved
+    assert result.deserialization_error is not None
+    assert "Out" in result.deserialization_error
+
+
+@pytest.mark.asyncio
+async def test_worker_exception_in_running_transition_does_not_strand_job(monkeypatch, caplog):
+    import tako_vm.server.queue as qmod
+    from tako_vm.server.queue import QueuedJob, WorkerPool
+
+    pool = WorkerPool(executor=MagicMock(), storage=AsyncMock())
+
+    # Fail AFTER the job is placed in _running_jobs but BEFORE the inner
+    # try/finally that normally cleans it up (set_correlation_id).
+    def boom(_cid):
+        raise RuntimeError("injected: set_correlation_id failed mid-transition")
+
+    monkeypatch.setattr(qmod, "set_correlation_id", boom)
+
+    loop = asyncio.get_running_loop()
+    job = QueuedJob(
+        job_id="adv-stuck-1",
+        job_data={"code": "x", "input_data": {}, "correlation_id": "cid-adv"},
+        client_ip=None,
+        future=loop.create_future(),
+    )
+    await pool._queue.put(job)
+    async with pool._jobs_lock:
+        pool._active_jobs[job.job_id] = job
+
+    worker = asyncio.create_task(pool._worker_loop(0))
+    try:
+        with caplog.at_level("ERROR"):
+            record = await asyncio.wait_for(job.future, timeout=5)
+    finally:
+        pool._shutdown = True
+        worker.cancel()
+        try:
+            await worker
+        except asyncio.CancelledError:
+            pass
+
+    # Client is not left hanging, and the failure is recorded + logged.
+    assert record is not None
+    assert record.status == "failed"
+    assert any("unexpected error" in r.getMessage().lower() for r in caplog.records)
+    # The job is not stranded in either tracking dict.
+    assert job.job_id not in pool._running_jobs
+    assert job.job_id not in pool._active_jobs

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -21,6 +21,7 @@ from tako_vm.sdk.client import (
     ClientError,
     ExecutionError,
     ExecutionResult,
+    MalformedResponseError,
     ServerError,
     TakoVM,
     TakoVMError,
@@ -306,6 +307,60 @@ class TestExecution:
         result = client.send_raw(add_numbers, InputData(1, 2), timeout=5)
         assert result.success is True
         assert result.output == {"unexpected": 1}
+
+
+class TestServerContractViolations:
+    """A 2xx response with a schema-mismatched body must surface a structured,
+    correlated MalformedResponseError — never a naked KeyError or a vague
+    "Execution failed" — and must be logged loudly (verbose-on-failure)."""
+
+    def test_submit_code_missing_job_id_raises_malformed(self, caplog):
+        session = _mock_session({"status": "queued", "oops": 1})  # no job_id
+        client = TakoVM(session=session)
+        with caplog.at_level("ERROR"):
+            with pytest.raises(MalformedResponseError) as exc:
+                client.submit_code("print(1)", {})
+        assert exc.value.correlation_id is not None
+        assert any("missing 'job_id'" in r.getMessage() for r in caplog.records)
+
+    def test_submit_code_non_dict_body_raises_malformed(self):
+        session = _mock_session(["not", "a", "dict"])
+        client = TakoVM(session=session)
+        with pytest.raises(MalformedResponseError):
+            client.submit_code("print(1)", {})
+
+    def test_rerun_missing_job_id_raises_malformed(self):
+        session = _mock_session({"nope": True})
+        client = TakoVM(session=session)
+        with pytest.raises(MalformedResponseError):
+            client.rerun("job-x")
+
+    def test_fork_missing_job_id_raises_malformed(self):
+        session = _mock_session({"nope": True})
+        client = TakoVM(session=session)
+        with pytest.raises(MalformedResponseError):
+            client.fork("job-x", "print(1)")
+
+    def test_execute_missing_success_field_raises_malformed(self, caplog):
+        # Valid JSON, but not the execution-result shape. Must not be coerced
+        # into a vague "Execution failed".
+        session = _mock_session({"stdout": "", "exit_code": 0})  # no 'success'
+        client = TakoVM(session=session)
+        with caplog.at_level("ERROR"):
+            with pytest.raises(MalformedResponseError):
+                client._execute("print(1)", {})
+        assert any("missing 'success'" in r.getMessage() for r in caplog.records)
+
+    def test_submit_code_all_retries_fail_raises_transport(self, caplog):
+        # Every attempt fails -> the real transport error must surface, not an
+        # UnboundLocalError from `data` never being assigned.
+        session = MagicMock()
+        session.request.side_effect = requests.exceptions.ConnectionError("refused")
+        client = TakoVM(session=session)
+        with caplog.at_level("ERROR"):
+            with pytest.raises(TransportError):
+                client.submit_code("print(1)", {})
+        assert any("gave up after" in r.getMessage() for r in caplog.records)
 
 
 class TestAuthPassthrough:


### PR DESCRIPTION
## Summary

Audit of failure-mode handling across Tako VM against the project's **verbose-on-failure** principle: every failure path must log with enough detail (correlation id, status, underlying error) and must not silently swallow errors, misclassify failures, or degrade silently. Findings were verified against source and, where possible, **adversarially tested** by driving the real code paths.

Full suite: **481 passed, 161 skipped** (skips are Docker/gVisor-gated), lint clean.

## HIGH
- **worker/sandbox**: malformed/truncated `result.json` was swallowed with a bare `pass` — now logged (WARNING) and `OSError`/`UnicodeDecodeError` are caught too.
- **sdk**: a schema-mismatched 2xx body escaped as a naked `KeyError` (`job_id`) or was coerced into a vague "Execution failed" (missing `success`). New `MalformedResponseError` surfaces both with correlation id + ERROR log.
- **queue**: an exception in the `queued→running` window stranded the job in `_running_jobs` forever; added a guarded outer `finally` backstop (proven by neutering it and reproducing the leak).
- **worker**: the unexpected-error catch-all now logs the full traceback.
- **limits**: the ASGI protection middleware (which runs outside FastAPI's exception handlers) now logs verbosely and emits a sanitized 500 instead of an opaque crash.

## MEDIUM / LOW
- **worker**: log silent job refusals (circuit breaker open, runtime reqs disabled, unsafe docker args), inconclusive-OOM classification, and failed kill after timeout; gVisor probe no longer caches transient failures.
- **sandbox**: accurate host-timeout-backstop message, container-removal WARNING, raise on missing `package_dir`.
- **app**: `/health` returns 503 "starting" before the worker pool is ready (was an opaque 500).
- **sdk**: `ExecutionResult.deserialization_error` surfaces output-coercion mismatches; job-type timeout lookups no longer cache failures.
- **cli**: log DB-connect cause, check `status_code` before parsing `/health`, surface validate-summary failures, exit non-zero on failed setup verification.

## Tests
- New `tests/test_failure_mode_handling.py`: middleware-throws, queue transition leak, gVisor transient caching, `/health` readiness, SDK deserialization surfacing.
- New `TestServerContractViolations` in `tests/test_sdk_client.py`.
- Updated existing CLI status tests for the stricter `check_status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)