### PR TITLE
docs: add community scaffolding — CONTRIBUTING, CoC, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,7 +35,7 @@ body:
     id: runtime
     attributes:
       label: Container runtime
-      description: Which runtime executes jobs? (`tako-vm status` shows whether gVisor is active)
+      description: Which runtime executes jobs? (`curl localhost:8000/health` reports `gvisor_available`)
       options:
         - runc (standard Docker)
         - runsc (gVisor)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Something doesn't work the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! **If this is a security vulnerability, do not file it here** — use
+        [private vulnerability reporting](https://github.com/las7/TakoVM/security/advisories/new) instead.
+  - type: input
+    id: version
+    attributes:
+      label: Tako VM version
+      description: Output of `tako-vm version`
+      placeholder: "0.1.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - PyPI (pip / uv)
+        - From source
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Ubuntu 24.04 / macOS 15 (colima)"
+    validations:
+      required: true
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Container runtime
+      description: Which runtime executes jobs? (`tako-vm status` shows whether gVisor is active)
+      options:
+        - runc (standard Docker)
+        - runsc (gVisor)
+        - Docker Desktop
+        - colima
+        - Other / not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: security-mode
+    attributes:
+      label: security_mode
+      options:
+        - permissive (default)
+        - strict
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal code or API calls that trigger the bug
+      placeholder: |
+        curl -X POST localhost:8000/execute -H 'Content-Type: application/json' \
+          -d '{"code": "..."}'
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected vs actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Server logs
+      description: >
+        Tako VM logs every failure verbosely — the server log around the time of the error
+        is usually the fastest path to a diagnosis. Paste the relevant lines (redact anything sensitive).
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/las7/TakoVM/security/advisories/new
+    about: Report security issues privately — never in a public issue.
+  - name: Questions & ideas
+    url: https://github.com/las7/TakoVM/discussions
+    about: Ask questions, share what you're building, or discuss ideas before they become issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that Tako VM doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? API sketches welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other ways this could be solved
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What & why
+
+<!-- What does this PR change, and what problem does it solve? Link related issues. -->
+
+## How was this tested?
+
+<!-- Commands run, new/updated tests, manual verification against a live server, etc. -->
+
+## Checklist
+
+- [ ] `pre-commit run --all-files` passes (ruff lint/format + pyright)
+- [ ] `TAKO_VM_SECURITY_MODE=permissive pytest tests/` passes locally
+- [ ] Docs updated if behavior changed (`docs/`, README)
+- [ ] PR title uses conventional-commit style (`feat:`, `fix:`, `docs:`, `chore:`) — it becomes the squash commit message
+- [ ] New failure paths log and surface errors verbosely (no silent swallowing)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at seiji@intencion.io. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Tako VM
+
+Thanks for your interest in contributing! This guide covers everything you need to get a development environment running and a pull request merged.
+
+## Where to start
+
+- Issues labeled [`good first issue`](https://github.com/las7/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are well-scoped entry points.
+- Issues labeled [`help wanted`](https://github.com/las7/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are larger pieces where design input is welcome — comment on the issue before starting.
+- Questions and ideas: [GitHub Discussions](https://github.com/las7/TakoVM/discussions).
+
+**Security issues are the exception: never open a public issue.** Report privately via the [Security tab](https://github.com/las7/TakoVM/security/advisories/new) — see [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+Requirements: Python 3.10+, Docker, and `git`.
+
+```bash
+git clone https://github.com/las7/TakoVM.git
+cd TakoVM
+
+# Install in editable mode with dev + server extras
+pip install -e ".[dev,server]"        # or: uv pip install -e ".[dev,server]"
+
+# Build the executor image (one-time)
+docker build -t code-executor:latest -f docker/Dockerfile.executor .
+
+# Start local PostgreSQL for development
+tako-vm dev up
+```
+
+### macOS notes
+
+- [colima](https://github.com/abiosoft/colima) works fine as the Docker runtime for development (no gVisor — tests requiring it auto-skip).
+- Set `TAKO_VM_WORKSPACE` to a directory under `$HOME`. The default macOS temp dir (`/var/folders/...`) cannot be bind-mounted into the colima VM, and executions fail with `bind source path does not exist`.
+- To test against real gVisor on macOS, use the Lima VM config in [`lima-gvisor.yaml`](lima-gvisor.yaml).
+
+## Running tests
+
+```bash
+TAKO_VM_SECURITY_MODE=permissive pytest tests/ -v
+```
+
+- Tests need Docker running and local PostgreSQL (`tako-vm dev up`).
+- Markers `requires_gvisor` and `requires_host_mounts` auto-skip when the environment doesn't support them; `slow` marks long-running tests.
+- CI runs the suite on Python 3.10, 3.11, and 3.12 with a coverage gate, plus `TAKO_VM_ENABLE_SECCOMP=false` (GitHub runners don't support the seccomp profile).
+
+## Lint and format
+
+Install the pre-commit hooks once and they'll handle everything:
+
+```bash
+pre-commit install
+```
+
+This runs `ruff` (lint + format) and `pyright`. To run manually:
+
+```bash
+ruff check tako_vm/ tests/
+ruff format tako_vm/ tests/
+```
+
+> **Note:** The ruff version is pinned (`0.15.16`) and must stay in sync across three files: `pyproject.toml`, `.github/workflows/lint.yml`, and `.pre-commit-config.yaml`. If you bump it, bump all three.
+
+## Pull requests
+
+- Use conventional-commit style titles: `feat:`, `fix:`, `docs:`, `chore:`, with an optional scope like `feat(sdk):`.
+- PRs are squash-merged, so the PR title becomes the commit message — make it descriptive.
+- CI must pass: ruff, the test matrix (3.10–3.12), and CodeQL.
+- Update docs (`docs/`, README) when behavior changes.
+- One of the failure-handling principles of this project: **failures are logged and surfaced verbosely, never silently swallowed**. New code paths should follow suit.
+
+## Project architecture
+
+See [docs/architecture.md](docs/architecture.md) for the full picture, and the module map in [CLAUDE.md](CLAUDE.md) for a quick orientation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,10 @@ TAKO_VM_SECURITY_MODE=permissive pytest tests/ -v
 
 ## Lint and format
 
-Install the pre-commit hooks once and they'll handle everything:
+`pre-commit` and `pyright` live in the `tools` dependency group (PEP 735), which the `[dev]` extra does **not** install. Install them once, then enable the hooks:
 
 ```bash
+pip install --group tools      # pip >= 25.1; or: uv sync --group tools
 pre-commit install
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -94,6 +94,10 @@ tako-vm --config my.yaml server   # 指定した設定ファイルを使用
 | デプロイ | [docs/deployment/how-to-deploy.md](docs/deployment/how-to-deploy.md) |
 | 設定リファレンス | [tako_vm.yaml.example](tako_vm.yaml.example) |
 
+## コントリビューション
+
+コントリビューションを歓迎します！開発環境のセットアップ、テスト、PR の規約については [CONTRIBUTING.md](CONTRIBUTING.md)（英語）をご覧ください。[`good first issue`](https://github.com/las7/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) ラベルの付いた Issue から始めるのがおすすめです。質問やアイデアは [Discussions](https://github.com/las7/TakoVM/discussions) へどうぞ。
+
 ## ライセンス
 
 Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ See [SECURITY.md](SECURITY.md) for the threat model and hardening guidance, and 
 
 **Found a vulnerability?** Report it privately via the [Security tab](https://github.com/las7/TakoVM/security) → **Report a vulnerability**. Please do not open public issues for security findings.
 
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, testing, and PR conventions. Good entry points are issues labeled [`good first issue`](https://github.com/las7/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), and [Discussions](https://github.com/las7/TakoVM/discussions) is open for questions and ideas.
+
 ## License
 
 Apache License 2.0


### PR DESCRIPTION
## What & why

Adds the contributor on-ramp that GitHub's community checklist flags as missing — follow-up to #91's engagement work.

- **CONTRIBUTING.md** — dev setup (including the macOS/colima `TAKO_VM_WORKSPACE` gotcha), exact test/lint commands, the three-file ruff pin sync warning, PR conventions (conventional-commit titles, squash merges), and pointers to `good first issue` / Discussions. Security reports explicitly routed to private advisories.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 (official text downloaded verbatim), enforcement contact seiji@intencion.io.
- **Issue forms** — bug report (version, install method, OS, container runtime, security_mode, repro, and server logs all required — logs are the key diagnostic given the verbose-failure philosophy) and feature request. `config.yml` adds contact links: security → private vulnerability reporting, questions → Discussions.
- **PR template** — what/why, testing, checklist (pre-commit, pytest, docs, conventional title, verbose failure handling).
- **README / README.ja** — short Contributing section linking it all.

## How was this tested?

- All three issue-form YAML files validated with a YAML parser.
- Markdown-only change otherwise; CI (ruff/tests) unaffected.
- After merge: verify https://github.com/las7/TakoVM/issues/new/choose renders both forms + 2 contact links, and the community profile health score via `gh api repos/las7/TakoVM/community/profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)