### PR TITLE
feat: add safe builtins module for restricted Python execution

### DIFF
--- a/tako_vm/restricted_builtins.py
+++ b/tako_vm/restricted_builtins.py
@@ -1,0 +1,307 @@
+"""
+Safe builtins module for restricted Python execution.
+
+Provides a curated __builtins__ dictionary that exposes only safe
+operations and blocks access to the filesystem, network, process
+control, and Python runtime internals.
+
+Used by the restricted_python execution mode (see issues #10, #11).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class RestrictedLimits:
+    """Configurable limits for restricted execution primitives."""
+
+    max_range: int = 10_000_000
+    max_string_length: int = 10_000_000
+    max_collection_size: int = 1_000_000
+    max_int_bits: int = 4096
+
+
+_DEFAULT_LIMITS = RestrictedLimits()
+
+
+def _make_safe_range(limits: RestrictedLimits):
+    """Create a range wrapper that enforces a maximum iteration count."""
+
+    _builtin_range = range
+
+    def safe_range(*args: int) -> range:
+        if len(args) == 1:
+            start, stop, step = 0, args[0], 1
+        elif len(args) == 2:
+            start, stop, step = args[0], args[1], 1
+        elif len(args) == 3:
+            start, stop, step = args[0], args[1], args[2]
+        else:
+            raise TypeError(
+                f"range expected at most 3 arguments, got {len(args)}"
+            )
+
+        if step == 0:
+            raise ValueError("range() arg 3 must not be zero")
+
+        if step > 0:
+            length = max(0, (stop - start + step - 1) // step)
+        else:
+            length = max(0, (start - stop - step - 1) // (-step))
+
+        if length > limits.max_range:
+            raise ValueError(
+                f"range() would produce {length} items, "
+                f"exceeding the limit of {limits.max_range}"
+            )
+
+        return _builtin_range(*args)
+
+    return safe_range
+
+
+# Builtins that are always safe: pure computation, no I/O or introspection.
+_SAFE_BUILTIN_NAMES = frozenset(
+    {
+        # Aggregation / ordering
+        "len",
+        "sum",
+        "min",
+        "max",
+        "sorted",
+        "reversed",
+        "enumerate",
+        "zip",
+        "map",
+        "filter",
+        # Type constructors / conversions
+        "int",
+        "float",
+        "str",
+        "bool",
+        "list",
+        "tuple",
+        "dict",
+        "set",
+        "frozenset",
+        "bytes",
+        "bytearray",
+        "complex",
+        # Numeric helpers
+        "abs",
+        "round",
+        "pow",
+        "divmod",
+        # String / representation
+        "repr",
+        "format",
+        "chr",
+        "ord",
+        "bin",
+        "oct",
+        "hex",
+        "ascii",
+        # Predicates
+        "isinstance",
+        "issubclass",
+        "callable",
+        "hasattr",
+        "all",
+        "any",
+        # Iteration
+        "iter",
+        "next",
+        "slice",
+        # Misc safe
+        "id",
+        "hash",
+        "type",
+        "object",
+        "super",
+        "property",
+        "staticmethod",
+        "classmethod",
+        # Exceptions (needed so user code can raise/catch)
+        "Exception",
+        "BaseException",
+        "ArithmeticError",
+        "AssertionError",
+        "AttributeError",
+        "BlockingIOError",
+        "BrokenPipeError",
+        "BufferError",
+        "BytesWarning",
+        "ChildProcessError",
+        "ConnectionAbortedError",
+        "ConnectionError",
+        "ConnectionRefusedError",
+        "ConnectionResetError",
+        "DeprecationWarning",
+        "EOFError",
+        "EnvironmentError",
+        "FileExistsError",
+        "FileNotFoundError",
+        "FloatingPointError",
+        "FutureWarning",
+        "GeneratorExit",
+        "IOError",
+        "ImportError",
+        "ImportWarning",
+        "IndentationError",
+        "IndexError",
+        "InterruptedError",
+        "IsADirectoryError",
+        "KeyError",
+        "KeyboardInterrupt",
+        "LookupError",
+        "MemoryError",
+        "ModuleNotFoundError",
+        "NameError",
+        "NotADirectoryError",
+        "NotImplementedError",
+        "OSError",
+        "OverflowError",
+        "PendingDeprecationWarning",
+        "PermissionError",
+        "ProcessLookupError",
+        "RecursionError",
+        "ReferenceError",
+        "ResourceWarning",
+        "RuntimeError",
+        "RuntimeWarning",
+        "StopAsyncIteration",
+        "StopIteration",
+        "SyntaxError",
+        "SyntaxWarning",
+        "SystemError",
+        "SystemExit",
+        "TabError",
+        "TimeoutError",
+        "TypeError",
+        "UnboundLocalError",
+        "UnicodeDecodeError",
+        "UnicodeEncodeError",
+        "UnicodeError",
+        "UnicodeTranslationError",
+        "UnicodeWarning",
+        "UserWarning",
+        "ValueError",
+        "Warning",
+        "ZeroDivisionError",
+        # Constants
+        "True",
+        "False",
+        "None",
+        "Ellipsis",
+        "NotImplemented",
+        # Print is allowed (captured by sandbox stdout)
+        "print",
+        # Required by Python internals for class definitions
+        "__build_class__",
+    }
+)
+
+# Builtins explicitly denied — any of these in __builtins__ would allow
+# sandbox escape or environment leakage.
+_DENIED_BUILTIN_NAMES = frozenset(
+    {
+        "__import__",
+        "open",
+        "input",
+        "help",
+        "dir",
+        "vars",
+        "globals",
+        "locals",
+        "eval",
+        "exec",
+        "compile",
+        "getattr",
+        "setattr",
+        "delattr",
+        "breakpoint",
+        "exit",
+        "quit",
+        "license",
+        "credits",
+        "copyright",
+        "memoryview",
+    }
+)
+
+
+def build_safe_builtins(
+    limits: Optional[RestrictedLimits] = None,
+) -> Dict[str, Any]:
+    """
+    Build a __builtins__ dict containing only safe operations.
+
+    The returned dict can be passed as the ``__builtins__`` key inside
+    a globals dict used with ``exec()`` to sandbox user code.
+
+    Args:
+        limits: Optional execution limits. Uses defaults if None.
+
+    Returns:
+        Dictionary suitable for use as ``__builtins__``.
+    """
+    if limits is None:
+        limits = _DEFAULT_LIMITS
+
+    import builtins as _builtins
+
+    safe: Dict[str, Any] = {}
+
+    for name in _SAFE_BUILTIN_NAMES:
+        obj = getattr(_builtins, name, None)
+        if obj is not None:
+            safe[name] = obj
+
+    # Replace range with the bounded version
+    safe["range"] = _make_safe_range(limits)
+
+    return safe
+
+
+def wrap_code_with_restricted_builtins(
+    code: str,
+    limits: Optional[RestrictedLimits] = None,
+) -> str:
+    """
+    Generate a wrapper script that executes *code* under restricted builtins.
+
+    The wrapper imports ``restricted_builtins``, builds the safe dict,
+    compiles the user code, and ``exec()``s it with the restricted
+    ``__builtins__``.  This is the entrypoint injected by the execution
+    layer when ``execution_mode == "restricted_python"``.
+
+    Args:
+        code: Raw user Python source.
+        limits: Optional execution limits.
+
+    Returns:
+        Python source string for the wrapper script.
+    """
+    if limits is None:
+        limits = _DEFAULT_LIMITS
+
+    # Escape the user code for embedding as a raw string literal.
+    escaped = code.replace("\\", "\\\\").replace("'", "\\'")
+
+    return f"""\
+import tako_vm.restricted_builtins as _rb
+
+_limits = _rb.RestrictedLimits(
+    max_range={limits.max_range!r},
+    max_string_length={limits.max_string_length!r},
+    max_collection_size={limits.max_collection_size!r},
+    max_int_bits={limits.max_int_bits!r},
+)
+_safe = _rb.build_safe_builtins(_limits)
+_code = '''{escaped}'''
+_compiled = compile(_code, "<user>", "exec")
+exec(_compiled, {{"__builtins__": _safe, "__name__": "__restricted__"}})
+"""

--- a/tests/test_restricted_builtins.py
+++ b/tests/test_restricted_builtins.py
@@ -1,0 +1,275 @@
+"""Tests for the restricted builtins module."""
+
+import pytest
+
+from tako_vm.restricted_builtins import (
+    RestrictedLimits,
+    _DENIED_BUILTIN_NAMES,
+    _SAFE_BUILTIN_NAMES,
+    build_safe_builtins,
+    wrap_code_with_restricted_builtins,
+)
+
+
+class TestBuildSafeBuiltins:
+    def test_includes_allowed_builtins(self):
+        safe = build_safe_builtins()
+        for name in ("len", "sum", "min", "max", "sorted", "print"):
+            assert name in safe, f"{name} missing from safe builtins"
+
+    def test_excludes_denied_builtins(self):
+        safe = build_safe_builtins()
+        for name in _DENIED_BUILTIN_NAMES:
+            assert name not in safe, f"{name} should be denied"
+
+    def test_no_open(self):
+        safe = build_safe_builtins()
+        assert "open" not in safe
+
+    def test_no_import(self):
+        safe = build_safe_builtins()
+        assert "__import__" not in safe
+
+    def test_no_eval_exec_compile(self):
+        safe = build_safe_builtins()
+        assert "eval" not in safe
+        assert "exec" not in safe
+        assert "compile" not in safe
+
+    def test_no_input(self):
+        safe = build_safe_builtins()
+        assert "input" not in safe
+
+    def test_no_help_dir(self):
+        safe = build_safe_builtins()
+        assert "help" not in safe
+        assert "dir" not in safe
+
+    def test_no_reflection(self):
+        safe = build_safe_builtins()
+        assert "getattr" not in safe
+        assert "setattr" not in safe
+        assert "delattr" not in safe
+        assert "globals" not in safe
+        assert "locals" not in safe
+        assert "vars" not in safe
+
+    def test_range_is_safe_variant(self):
+        safe = build_safe_builtins()
+        assert "range" in safe
+        assert safe["range"] is not range
+
+    def test_includes_exception_types(self):
+        safe = build_safe_builtins()
+        assert safe["ValueError"] is ValueError
+        assert safe["TypeError"] is TypeError
+        assert safe["KeyError"] is KeyError
+
+    def test_includes_type_constructors(self):
+        safe = build_safe_builtins()
+        assert safe["int"] is int
+        assert safe["float"] is float
+        assert safe["str"] is str
+        assert safe["list"] is list
+        assert safe["dict"] is dict
+
+    def test_denied_and_safe_are_disjoint(self):
+        overlap = _SAFE_BUILTIN_NAMES & _DENIED_BUILTIN_NAMES
+        assert not overlap, f"Overlap between safe and denied: {overlap}"
+
+
+class TestSafeRange:
+    def test_basic_range(self):
+        safe = build_safe_builtins()
+        assert list(safe["range"](5)) == [0, 1, 2, 3, 4]
+
+    def test_range_with_start_stop(self):
+        safe = build_safe_builtins()
+        assert list(safe["range"](2, 6)) == [2, 3, 4, 5]
+
+    def test_range_with_step(self):
+        safe = build_safe_builtins()
+        assert list(safe["range"](0, 10, 3)) == [0, 3, 6, 9]
+
+    def test_negative_step(self):
+        safe = build_safe_builtins()
+        assert list(safe["range"](5, 0, -1)) == [5, 4, 3, 2, 1]
+
+    def test_empty_range(self):
+        safe = build_safe_builtins()
+        assert list(safe["range"](0)) == []
+
+    def test_zero_step_raises(self):
+        safe = build_safe_builtins()
+        with pytest.raises(ValueError, match="must not be zero"):
+            safe["range"](0, 10, 0)
+
+    def test_exceeds_limit_raises(self):
+        limits = RestrictedLimits(max_range=100)
+        safe = build_safe_builtins(limits)
+        with pytest.raises(ValueError, match="exceeding the limit"):
+            safe["range"](101)
+
+    def test_at_limit_ok(self):
+        limits = RestrictedLimits(max_range=100)
+        safe = build_safe_builtins(limits)
+        r = safe["range"](100)
+        assert len(r) == 100
+
+    def test_too_many_args(self):
+        safe = build_safe_builtins()
+        with pytest.raises(TypeError, match="at most 3"):
+            safe["range"](1, 2, 3, 4)
+
+    def test_default_limit_allows_reasonable_range(self):
+        safe = build_safe_builtins()
+        r = safe["range"](1_000_000)
+        assert len(r) == 1_000_000
+
+
+class TestRestrictedExecution:
+    """Integration tests: exec user code with restricted builtins."""
+
+    def _exec_restricted(self, code: str, limits=None):
+        safe = build_safe_builtins(limits)
+        g = {"__builtins__": safe, "__name__": "__restricted__"}
+        exec(compile(code, "<test>", "exec"), g)
+        return g
+
+    def test_basic_arithmetic(self):
+        g = self._exec_restricted("result = 2 + 3")
+        assert g["result"] == 5
+
+    def test_list_operations(self):
+        g = self._exec_restricted("result = sorted([3, 1, 2])")
+        assert g["result"] == [1, 2, 3]
+
+    def test_len_sum_min_max(self):
+        code = """\
+data = [10, 20, 30]
+length = len(data)
+total = sum(data)
+lo = min(data)
+hi = max(data)
+"""
+        g = self._exec_restricted(code)
+        assert g["length"] == 3
+        assert g["total"] == 60
+        assert g["lo"] == 10
+        assert g["hi"] == 30
+
+    def test_print_works(self, capsys):
+        self._exec_restricted("print('hello')")
+        assert "hello" in capsys.readouterr().out
+
+    def test_import_blocked(self):
+        with pytest.raises((ImportError, NameError)):
+            self._exec_restricted("import os")
+
+    def test_open_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("open('/etc/passwd')")
+
+    def test_eval_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("eval('1+1')")
+
+    def test_exec_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("exec('x=1')")
+
+    def test_dunder_import_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("__import__('os')")
+
+    def test_input_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("input('>')")
+
+    def test_dir_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("dir()")
+
+    def test_help_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("help()")
+
+    def test_globals_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("globals()")
+
+    def test_locals_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("locals()")
+
+    def test_getattr_blocked(self):
+        with pytest.raises(NameError):
+            self._exec_restricted("getattr(int, '__bases__')")
+
+    def test_range_bounded(self):
+        limits = RestrictedLimits(max_range=50)
+        with pytest.raises(ValueError, match="exceeding the limit"):
+            self._exec_restricted("list(range(100))", limits=limits)
+
+    def test_exception_handling_works(self):
+        code = """\
+try:
+    x = 1 / 0
+except ZeroDivisionError:
+    result = 'caught'
+"""
+        g = self._exec_restricted(code)
+        assert g["result"] == "caught"
+
+    def test_class_definition_works(self):
+        code = """\
+class Point:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+p = Point(1, 2)
+result = p.x + p.y
+"""
+        g = self._exec_restricted(code)
+        assert g["result"] == 3
+
+    def test_list_comprehension_works(self):
+        g = self._exec_restricted("result = [x**2 for x in range(5)]")
+        assert g["result"] == [0, 1, 4, 9, 16]
+
+    def test_dict_comprehension_works(self):
+        g = self._exec_restricted("result = {k: k*2 for k in range(3)}")
+        assert g["result"] == {0: 0, 1: 2, 2: 4}
+
+    def test_lambda_works(self):
+        g = self._exec_restricted("fn = lambda x: x + 1; result = fn(5)")
+        assert g["result"] == 6
+
+
+class TestWrapCode:
+    def test_produces_valid_python(self):
+        wrapper = wrap_code_with_restricted_builtins("x = 1 + 1")
+        compile(wrapper, "<test>", "exec")
+
+    def test_escapes_quotes(self):
+        wrapper = wrap_code_with_restricted_builtins("x = 'hello'")
+        assert "\\'" in wrapper
+
+    def test_custom_limits_embedded(self):
+        limits = RestrictedLimits(max_range=500)
+        wrapper = wrap_code_with_restricted_builtins("x = 1", limits=limits)
+        assert "max_range=500" in wrapper
+
+
+class TestRestrictedLimits:
+    def test_defaults(self):
+        limits = RestrictedLimits()
+        assert limits.max_range == 10_000_000
+        assert limits.max_string_length == 10_000_000
+        assert limits.max_collection_size == 1_000_000
+        assert limits.max_int_bits == 4096
+
+    def test_custom_values(self):
+        limits = RestrictedLimits(max_range=100, max_int_bits=256)
+        assert limits.max_range == 100
+        assert limits.max_int_bits == 256


### PR DESCRIPTION
## Summary
- New `tako_vm/restricted_builtins.py` module providing a curated `__builtins__` dict for sandboxed code execution
- Allowlist: `len`, `sum`, `min`, `max`, `sorted`, type constructors, exception types, `print`
- Denied: `open`, `__import__`, `eval`, `exec`, `compile`, `getattr`, `dir`, `help`, `input`, `globals`, `locals`, `vars`, `breakpoint`
- Safe `range()` wrapper with configurable max iteration limit (default 10M)
- `RestrictedLimits` dataclass for per-job configuration
- `wrap_code_with_restricted_builtins()` helper for execution layer integration

Addresses las7/TakoVM#11

## Test plan
- [x] 48 tests passing covering allowlist, denial, safe range, and integration
- [x] Verify no regressions in existing test suite