### PR TITLE
fix(sdk): get_result never long-polled — send wait=true when a timeout is given

### DIFF
--- a/tako_vm/sdk/client.py
+++ b/tako_vm/sdk/client.py
@@ -66,6 +66,10 @@ from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
 
+# Server-side cap on /jobs/{id}/result?wait=true long-polling
+# (MAX_WAIT_TIMEOUT in tako_vm/server/app.py).
+_MAX_RESULT_WAIT_SECONDS = 300
+
 # Type variables for generic typing
 InputT = TypeVar("InputT")
 OutputT = TypeVar("OutputT")
@@ -901,12 +905,25 @@ _execute()
     ) -> dict:
         """
         Get an async job's result, waiting up to ``timeout`` seconds for it
-        (GET /jobs/{job_id}/result). Pass ``view="full"`` for artifacts,
-        resource usage, hashes, and lineage.
+        (GET /jobs/{job_id}/result?wait=true). Without ``timeout``, returns
+        the current record immediately (which may still be queued/running).
+        Pass ``view="full"`` for artifacts, resource usage, hashes, and lineage.
         """
         params: Dict[str, Any] = {}
-        if timeout is not None:
-            params["timeout"] = timeout
+        if timeout:
+            # The server only honors ``timeout`` when ``wait`` is set, and caps
+            # the long-poll at MAX_WAIT_TIMEOUT (300s). Clamp rather than 422.
+            wait_timeout = min(timeout, _MAX_RESULT_WAIT_SECONDS)
+            if wait_timeout != timeout:
+                logger.warning(
+                    "get_result(timeout=%s) exceeds the server's %ss long-poll cap; "
+                    "waiting %ss per request instead",
+                    timeout,
+                    _MAX_RESULT_WAIT_SECONDS,
+                    wait_timeout,
+                )
+            params["wait"] = "true"
+            params["timeout"] = wait_timeout
         if view:
             params["view"] = view
         return self._request(

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -633,8 +633,24 @@ class TestAsyncLifecycle:
         session = _mock_session({"status": "completed"})
         client = TakoVM(session=session)
         client.get_result("j", timeout=30, view="full")
-        assert session.request.call_args.kwargs["params"] == {"timeout": 30, "view": "full"}
+        assert session.request.call_args.kwargs["params"] == {
+            "wait": "true",
+            "timeout": 30,
+            "view": "full",
+        }
         assert session.request.call_args.args[1].endswith("/jobs/j/result")
+
+    def test_get_result_without_timeout_does_not_wait(self):
+        session = _mock_session({"status": "queued"})
+        client = TakoVM(session=session)
+        client.get_result("j")
+        assert session.request.call_args.kwargs["params"] == {}
+
+    def test_get_result_clamps_timeout_to_server_wait_cap(self):
+        session = _mock_session({"status": "completed"})
+        client = TakoVM(session=session)
+        client.get_result("j", timeout=900)
+        assert session.request.call_args.kwargs["params"] == {"wait": "true", "timeout": 300}
 
     def test_cancel(self):
         session = _mock_session({"status": "cancelled", "job_id": "j"})


### PR DESCRIPTION
## What & why

`TakoVM.get_result(job_id, timeout=N)` promised blocking semantics (its own docstring: *'waiting up to timeout seconds'*; `docs/api/sdk.md`: *'waits up to 60s'*) but never sent `wait=true` — and the server ignores `timeout` unless `wait` is set. Since a preliminary `queued` record is persisted at submit time, every documented `get_result` pattern returned a non-final record immediately for any job slower than one HTTP round-trip.

Fix: a truthy `timeout` now sends `wait=true&timeout=N` (clamped to the server's 300s `MAX_WAIT_TIMEOUT` with a logged warning — previously >300 would have 422'd); omitting `timeout` keeps the immediate non-blocking read.

Found by the multi-agent review of #94, whose agent-integration examples build on this call.

## Testing

- Updated `test_get_result_passes_timeout_and_view` for the new params
- New: `test_get_result_without_timeout_does_not_wait`, `test_get_result_clamps_timeout_to_server_wait_cap`
- `tests/test_sdk_client.py`: 86 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)