### PR TITLE
docs: reposition vision filesystem-first for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # Tako VM
 
-Secure Python code execution in isolated Docker containers. Lets AI agents and platforms run untrusted code safely by sandboxing it behind a gVisor-backed container boundary. REST API for sync/async job execution, plus a Python SDK for library-mode usage.
+A secure file system and Python execution layer for AI agents. Lets agents and platforms run untrusted code safely in gVisor-backed, isolated containers — each with its own workspace — backed by job queues, retries, and execution history. REST API for sync/async job execution, plus a Python SDK for library-mode usage.
+
+**Direction:** evolving toward a "serverless filesystem for agents" — durable, per-agent workspaces that persist and rehydrate across runs (object-store-backed, content-addressed snapshots, hydrate/flush at run boundary). Today each container is single-use; persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
 
 ## Why gVisor?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>信頼できない Python コードを安全に実行。ジョブキューと Docker による隔離を標準搭載。エンタープライズでの採用実績あり。</strong>
+  <strong>エージェントのためのファイルシステムと Python 実行環境。ジョブキューと Docker による隔離を標準搭載。エンタープライズの開発チームで採用。</strong>
 </p>
 
 <p align="center">
@@ -16,7 +16,9 @@
   <a href="README.md">English</a> | <strong>日本語</strong>
 </p>
 
-AI が生成したコードを、隔離された Docker コンテナ内で実行します。必要に応じて gVisor によるサンドボックス化にも対応可能です。ジョブキュー・リトライ・実行履歴を標準で搭載しています。
+**エージェントが安全にコードを実行するためのファイルシステム。** 各ジョブは、専用ワークスペースを備えた隔離された Docker コンテナ内で実行されます。必要に応じて gVisor によるサンドボックス化にも対応し、ジョブキュー・リトライ・実行履歴を標準で搭載しています。
+
+> **今後の方向性：** 実行をまたいで永続化・再ハイドレートできる、エージェントごとの耐久性のあるワークスペース（エージェントのためのサーバーレスファイルシステム）を目指しています。現時点では各コンテナは使い捨てで、永続ワークスペースはロードマップ上の機能です。隔離境界は引き続き gVisor のみに依存します。
 
 <p align="center">
   <a href="https://las7.github.io/TakoVM/"><strong>ドキュメント</strong></a> · <a href="https://las7.github.io/TakoVM/getting-started/quickstart/"><strong>クイックスタート</strong></a> · <a href="https://las7.github.io/TakoVM/api/rest/"><strong>API リファレンス</strong></a>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Run untrusted Python safely. Job queues and Docker isolation built-in. Used by enterprises.</strong>
+  <strong>File system and Python execution for your agents. Job queues and Docker isolation built-in. Used by teams deploying in enterprise.</strong>
 </p>
 
 <p align="center">
@@ -16,8 +16,13 @@
   <strong>English</strong> | <a href="README.ja.md">日本語</a>
 </p>
 
-Run AI-generated code in isolated Docker containers with optional gVisor sandboxing.
-Job queues, retries, and execution history included.
+**A secure file system for your agents to execute code.** Every job runs in its own
+isolated Docker container — with an ephemeral workspace, optional gVisor sandboxing, job
+queues, retries, and execution history included.
+
+> **Where this is headed:** durable, per-agent workspaces that persist and rehydrate
+> across runs — a serverless filesystem for agents. Today each container is single-use;
+> persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
 
 <p align="center">
   <a href="https://las7.github.io/TakoVM/"><strong>Documentation</strong></a> · <a href="https://las7.github.io/TakoVM/getting-started/quickstart/"><strong>Quick Start</strong></a> · <a href="https://las7.github.io/TakoVM/api/rest/"><strong>API Reference</strong></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM is job queue infrastructure for AI agents — secure Python code execution in gVisor-isolated Docker containers, with queue, workers, retries, and replay."
+description: "Tako VM is a secure file system and Python execution layer for AI agents — gVisor-isolated Docker containers with job queues, workers, retries, and replay."
 hide:
   - navigation
   - toc
@@ -9,8 +9,8 @@ hide:
 
 # Tako VM
 
-<p class="tako-tagline"><strong>Job queue infrastructure for AI agents. Not just a sandbox.</strong><br>
-Run untrusted Python in gVisor-isolated containers — with the queue, workers, execution history, retries, and replay you'd otherwise build yourself.</p>
+<p class="tako-tagline"><strong>A secure file system for your agents to execute code.</strong><br>
+File system and Python execution for your agents — run untrusted code in gVisor-isolated containers, with the queue, workers, execution history, retries, and replay you'd otherwise build yourself.</p>
 
 <div class="tako-badges" markdown>
 [![PyPI](https://img.shields.io/pypi/v/tako-vm)](https://pypi.org/project/tako-vm/)
@@ -138,6 +138,9 @@ Three core concepts:
 - **Sandbox** — a gVisor-backed, single-use container that executes one job and is destroyed.
 - **Job** — an asynchronous unit of work with a persisted `ExecutionRecord` lifecycle (`queued → running → succeeded/failed/timeout/oom/cancelled`).
 - **Executor image** — the container image jobs run in; runtime `requirements` can be installed per-job via `uv` (opt-in: `allow_runtime_requirements`), with an optional shared cache (`enable_runtime_dependency_cache`) to speed up repeat installs.
+
+!!! note "Where Tako VM is headed"
+    The direction is a **serverless filesystem for agents**: durable, per-agent workspaces that persist and rehydrate across runs, spinning up on demand and scaling to zero with state preserved. Today each container is single-use; persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
 
 ## Next steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tako-vm"
 version = "0.1.4"
-description = "Secure Python code execution in isolated Docker containers"
+description = "A secure file system and Python execution layer for AI agents — isolated Docker/gVisor containers with job queues, retries, and history"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -14,6 +14,8 @@ authors = [
 ]
 keywords = [
     "code-execution",
+    "filesystem",
+    "agent-infrastructure",
     "docker",
     "sandbox",
     "sandboxing",


### PR DESCRIPTION
Aligns Tako VM's public messaging to a **filesystem-first** vision, leading with *"a secure file system for your agents to execute code"* in place of the prior execution-first framing.

## Framing: vision now, capability soon
Each job already runs in its own isolated workspace, so the filesystem framing is honest **today**. The durable, rehydratable per-agent workspaces that persist across runs — the "serverless filesystem for agents" direction — are **explicitly marked as roadmap**, not shipped capability, everywhere the persistence claim appears.

## Surfaces updated
| Surface | Change |
|---|---|
| `README.md` / `README.ja.md` | Tagline + intro + roadmap note (both languages) |
| `docs/index.md` | Hero tagline, SEO `description`, "where this is headed" admonition |
| `CLAUDE.md` | Project blurb + Direction paragraph |
| `pyproject.toml` | PyPI `description` + `filesystem`/`agent-infrastructure` keywords |

Docs/metadata only — no code changed. The new `pyproject.toml` description reaches PyPI on the next `v*` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)