### PR TITLE
security: mirror worker ulimits onto the library Sandbox path (#97)

### DIFF
--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -303,6 +303,32 @@ def inspect_oom_killed(container_name: str) -> Optional[bool]:
         return None
 
 
+def ulimit_args(limits) -> list[str]:
+    """Return the ``--ulimit`` flags shared by every execution path.
+
+    ``RLIMIT_FSIZE``/``RLIMIT_NOFILE``/``RLIMIT_NPROC`` are kernel rlimits that
+    gVisor does not impose on its own; they only take effect when passed via
+    ``--ulimit`` at container creation. Both builders (``CodeExecutor`` and the
+    library ``Sandbox``) assemble their own ``docker run`` command, so this is
+    factored out to keep them from drifting — the drift this guards against is
+    exactly issue #97, where the ``Sandbox`` path shipped with no ``--ulimit``
+    at all and left ``RLIMIT_FSIZE`` unbounded against the writable ``/output``
+    bind-mount (a host-disk-exhaustion DoS the gVisor boundary does not cover).
+
+    Args:
+        limits: A ``ContainerLimits`` (or any object exposing ``nofile_soft``,
+            ``nofile_hard``, ``nproc_soft``, ``nproc_hard``, ``fsize``).
+
+    Returns:
+        The three ``--ulimit`` flags, ready to append to a ``docker run`` command.
+    """
+    return [
+        f"--ulimit=nofile={limits.nofile_soft}:{limits.nofile_hard}",
+        f"--ulimit=nproc={limits.nproc_soft}:{limits.nproc_hard}",
+        f"--ulimit=fsize={limits.fsize}",
+    ]
+
+
 def base_isolation_args(
     container_name: str,
     *,

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -28,6 +28,7 @@ from tako_vm.execution.docker import (
     is_native_linux,
     kill_container,
     remove_container,
+    ulimit_args,
 )
 from tako_vm.execution.health import get_circuit_breaker
 from tako_vm.execution.retry import RetryConfig, RetryContext, is_transient_error
@@ -1448,10 +1449,9 @@ class CodeExecutor:
                 f"--memory-swap={job_type.memory_limit}",
                 f"--cpus={job_type.cpu_limit}",
                 f"--pids-limit={limits.pids_limit}",
-                # Configurable ulimits
-                f"--ulimit=nofile={limits.nofile_soft}:{limits.nofile_hard}",
-                f"--ulimit=nproc={limits.nproc_soft}:{limits.nproc_hard}",
-                f"--ulimit=fsize={limits.fsize}",
+                # Configurable ulimits (shared with the library Sandbox path via
+                # ulimit_args so the two builders can't drift; see issue #97)
+                *ulimit_args(limits),
                 # Mounts
                 f"--mount=type=bind,source={code_dir.absolute()},target=/code,readonly",
                 f"--mount=type=bind,source={input_dir.absolute()},target=/input,readonly",

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -32,6 +32,7 @@ from tako_vm.execution.docker import (
     generate_container_name,
     inspect_oom_killed,
     remove_container,
+    ulimit_args,
 )
 from tako_vm.security import validate_pip_requirement
 
@@ -601,13 +602,20 @@ class Sandbox:
                 cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
             cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 
-        # Resource limits
+        # Resource limits. The pids-limit and the --ulimit set (nofile/nproc/
+        # fsize) come from the shared container_limits config so the library
+        # path enforces the same kernel rlimits the worker does. Without the
+        # --ulimit=fsize cap, untrusted code could write an arbitrarily large
+        # file to the writable /output bind-mount (host-disk-exhaustion DoS);
+        # gVisor does not impose RLIMIT_FSIZE on its own (issue #97).
+        limits = get_config().container_limits
         cmd.extend(
             [
                 f"--memory={self.config.memory_limit}",
                 f"--memory-swap={self.config.memory_limit}",
                 f"--cpus={self.config.cpu_limit}",
-                "--pids-limit=100",
+                f"--pids-limit={limits.pids_limit}",
+                *ulimit_args(limits),
             ]
         )
 

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -66,3 +66,36 @@ class TestSandboxRuntimeEnforcement:
         _set_gvisor(monkeypatch, True)
         with pytest.raises(RuntimeUnavailableError):
             _runtime_flags(tmp_path)
+
+
+class TestSandboxUlimits:
+    """The library Sandbox path must set the same kernel rlimits as the worker.
+
+    Without --ulimit=fsize, RLIMIT_FSIZE is unbounded and untrusted code can
+    write an arbitrarily large file to the writable /output bind-mount, a
+    host-disk-exhaustion DoS gVisor does not cover (issue #97).
+    """
+
+    def _build(self, monkeypatch, tmp_path):
+        _use_config(monkeypatch, container_runtime="runsc", security_mode="strict")
+        _set_gvisor(monkeypatch, True)
+        sb = Sandbox(auto_build=False)
+        cmd, _ = sb._build_docker_command(
+            code_dir=tmp_path, input_dir=tmp_path, output_dir=tmp_path, timeout=10
+        )
+        return cmd
+
+    def test_sets_fsize_ulimit(self, monkeypatch, tmp_path):
+        cmd = self._build(monkeypatch, tmp_path)
+        from tako_vm.config import ContainerLimits
+
+        limits = ContainerLimits()
+        assert f"--ulimit=fsize={limits.fsize}" in cmd
+
+    def test_sets_nofile_and_nproc_ulimits(self, monkeypatch, tmp_path):
+        cmd = self._build(monkeypatch, tmp_path)
+        from tako_vm.config import ContainerLimits
+
+        limits = ContainerLimits()
+        assert f"--ulimit=nofile={limits.nofile_soft}:{limits.nofile_hard}" in cmd
+        assert f"--ulimit=nproc={limits.nproc_soft}:{limits.nproc_hard}" in cmd


### PR DESCRIPTION
## Summary
The library-mode `Sandbox` path built its `docker run` command with `--memory`/`--memory-swap`/`--cpus` and a hardcoded `--pids-limit=100`, but **no `--ulimit` flags at all**. That left `RLIMIT_FSIZE` unbounded, and since `/output` is a writable host bind-mount, untrusted code could write an arbitrarily large file and exhaust host disk — a DoS the gVisor boundary does not cover (`RLIMIT_FSIZE` is only applied via `--ulimit`). `nofile` also fell back to the daemon default.

## Fix
- New shared `ulimit_args(limits)` helper in `tako_vm/execution/docker.py` returns the three `--ulimit` flags (`nofile`/`nproc`/`fsize`).
- Both the worker path and the library `Sandbox` path now use it, so the two builders can't drift again (the exact failure mode this issue describes).
- The `Sandbox` path sources its limits from the shared `container_limits` config and now also honors the configured `pids_limit` instead of hardcoding `100`.

## Tests
- Added `TestSandboxUlimits` in `tests/test_sandbox_runtime.py` asserting the sandbox command now carries `--ulimit=fsize`, `--ulimit=nofile`, and `--ulimit=nproc` (pure command-construction, no Docker required).
- Existing runtime-enforcement tests still pass.

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)