### PR TITLE
security: reap leaked containers in the periodic cleanup loop (#96)

### DIFF
--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from tako_vm import __version__
 from tako_vm.config import TakoVMConfig, get_config
-from tako_vm.execution.health import get_circuit_breaker, startup_cleanup
+from tako_vm.execution.health import DockerCleanup, get_circuit_breaker, startup_cleanup
 from tako_vm.execution.worker import (
     CodeExecutor,
     check_gvisor_available,
@@ -195,6 +195,18 @@ async def _periodic_cleanup(
             old_runs = prune_old_run_dirs(data_dir, record_ttl_days)
             if old_runs > 0:
                 logger.info(f"Cleanup: pruned {old_runs} expired run artifact dir(s)")
+            # Reap leaked executor containers. Previously the reaper ran only at
+            # startup, so a `docker rm -f` that failed at teardown on a
+            # long-lived server left the container (and, for a network-enabled
+            # job, its live egress) alive until the next process restart. The
+            # age guard is reused from workspace_max_age_seconds: a *running*
+            # labeled container older than that provably cannot belong to a live
+            # job of this server (max lifetime is startup_timeout + timeout +
+            # grace), so reaping it never kills in-flight work. Exited orphans
+            # are removed unconditionally. (issue #96)
+            orphaned = DockerCleanup.cleanup_orphaned_containers(workspace_max_age_seconds)
+            if orphaned > 0:
+                logger.info(f"Cleanup: reaped {orphaned} orphaned container(s)")
         except asyncio.CancelledError:
             logger.info("Periodic cleanup task cancelled")
             break

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -151,6 +151,67 @@ class TestCleanupOrphanedContainers:
         assert _removed_ids(calls) == []
 
 
+class TestPeriodicCleanupReapsOrphans:
+    """The hourly cleanup loop must reap leaked containers, not only startup.
+
+    Regression guard for issue #96: the reaper used to run only at startup, so a
+    teardown `docker rm -f` failure on a long-lived server left the container
+    (and any network-enabled job's live egress) alive until the next restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_loop_calls_reaper_with_workspace_age_guard(self, monkeypatch):
+        import importlib
+
+        # The submodule `tako_vm.server.app` is shadowed by the package's `app`
+        # FastAPI attribute, so import the real module object explicitly.
+        app_module = importlib.import_module("tako_vm.server.app")
+
+        recorded = {}
+
+        def fake_reaper(max_age_seconds):
+            recorded["age"] = max_age_seconds
+            return 2
+
+        # The reaper must be force-removing *running* containers only past the
+        # same age a live job could possibly run, so it can never kill in-flight
+        # work. Assert the loop passes that guard through.
+        monkeypatch.setattr(
+            DockerCleanup, "cleanup_orphaned_containers", staticmethod(fake_reaper)
+        )
+        monkeypatch.setattr(app_module, "prune_stale_workspaces", lambda *a, **k: 0)
+        monkeypatch.setattr(app_module, "prune_old_run_dirs", lambda *a, **k: 0)
+
+        # Run exactly one iteration: first sleep proceeds, second cancels the loop.
+        sleeps = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            sleeps["n"] += 1
+            if sleeps["n"] >= 2:
+                raise __import__("asyncio").CancelledError()
+
+        monkeypatch.setattr(app_module.asyncio, "sleep", fake_sleep)
+
+        class FakeStorage:
+            async def cleanup_old_records(self, _ttl):
+                return 0
+
+            async def cleanup_old_dlq_entries(self, _ttl):
+                return 0
+
+        from pathlib import Path
+
+        await app_module._periodic_cleanup(
+            FakeStorage(),
+            record_ttl_days=7,
+            data_dir=Path("/tmp"),
+            workspace_max_age_seconds=99999,
+            dlq_ttl_days=7,
+        )
+
+        assert recorded["age"] == 99999
+
+
 class TestParseCreatedAt:
     """Tests for DockerCleanup._parse_created_at."""
 

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -176,9 +176,7 @@ class TestPeriodicCleanupReapsOrphans:
         # The reaper must be force-removing *running* containers only past the
         # same age a live job could possibly run, so it can never kill in-flight
         # work. Assert the loop passes that guard through.
-        monkeypatch.setattr(
-            DockerCleanup, "cleanup_orphaned_containers", staticmethod(fake_reaper)
-        )
+        monkeypatch.setattr(DockerCleanup, "cleanup_orphaned_containers", staticmethod(fake_reaper))
         monkeypatch.setattr(app_module, "prune_stale_workspaces", lambda *a, **k: 0)
         monkeypatch.setattr(app_module, "prune_old_run_dirs", lambda *a, **k: 0)
 


### PR DESCRIPTION
## Summary
The orphaned-container reaper (`DockerCleanup.cleanup_orphaned_containers`) was wired only into **startup** cleanup. The hourly `_periodic_cleanup` task pruned records, DLQ entries, and stale workspace/run dirs but never reaped leaked containers. So if `docker rm -f` failed at teardown (daemon hiccup/timeout) on a long-lived server, the leaked container survived until the next process restart — and for a network-enabled job, that means unbounded live egress.

## Fix
- Call `cleanup_orphaned_containers()` from the existing periodic loop.
- Reuse the existing `workspace_max_age` guard (`max(3600, max_startup_timeout + max_timeout + 300)`). A *running* labeled container older than that provably cannot belong to a live job of this server (max lifetime is `startup_timeout + timeout + grace`), so reaping it never kills in-flight work. Exited orphans are removed unconditionally.

## Tests
- Added `TestPeriodicCleanupReapsOrphans` driving exactly one loop iteration and asserting the reaper is called with the workspace age guard. The reaper's own behavior (label-only matching, age guard, exited-vs-running) is already covered by `TestCleanupOrphanedContainers`.

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)