### PR TITLE
security: run the dependency install as the unprivileged sandbox user (#102)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,17 +48,36 @@ if [ -s "$REQS_FILE" ]; then
     # Using --target instead of --system to install to /tmp/site-packages
     TARGET_DIR="/tmp/site-packages"
     mkdir -p "$TARGET_DIR"
-    UV_INSTALL_CMD=(uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE")
 
+    # Run the install as the unprivileged sandbox user (uid 1000), NOT as
+    # container root. Installing a package can execute arbitrary code at build
+    # time (setup.py / PEP 517 hooks), and the requirements list is reachable
+    # from the API request, so installing as root would hand an attacker-chosen
+    # sdist in-container root. The install only needs to write its target and
+    # cache dirs, which the sandbox user can own. (issue #102)
+    #
+    # As root (we have not dropped privileges yet), make those writable targets
+    # owned by the sandbox user before handing the install to gosu. HOME is set
+    # explicitly so uv never tries to write under /root (uid 1000 cannot).
+    SANDBOX_HOME="/home/sandbox"
+    UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+    chown sandbox:sandbox "$TARGET_DIR"
+    mkdir -p "$UV_CACHE_DIR"
+    chown -R sandbox:sandbox "$UV_CACHE_DIR" 2>/dev/null || true
+
+    INSTALL_ENV=("HOME=$SANDBOX_HOME" "UV_CACHE_DIR=$UV_CACHE_DIR")
     if [ -n "$TAKO_DEPENDENCY_PROXY_URL" ]; then
-        UV_INSTALL_CMD=(
-            env
+        INSTALL_ENV+=(
             "HTTP_PROXY=$TAKO_DEPENDENCY_PROXY_URL"
             "HTTPS_PROXY=$TAKO_DEPENDENCY_PROXY_URL"
             "ALL_PROXY=$TAKO_DEPENDENCY_PROXY_URL"
-            "${UV_INSTALL_CMD[@]}"
         )
     fi
+    UV_INSTALL_CMD=(
+        gosu sandbox
+        env "${INSTALL_ENV[@]}"
+        uv pip install --target "$TARGET_DIR" --link-mode=copy -r "$REQS_FILE"
+    )
 
     # Capture install result (don't exit on error yet so we can record timing).
     # uv output goes to stderr (1>&2): user stdout stays clean, and the server

--- a/tako_vm/constants.py
+++ b/tako_vm/constants.py
@@ -14,6 +14,17 @@ DEFAULT_IMAGE = "code-executor:latest"
 # Docker volume name for uv cache (speeds up repeated dependency installs)
 UV_CACHE_VOLUME = "tako-uv-cache"
 
+# In-container uv cache locations. The shared-volume mount point lives under the
+# sandbox user's home (uid 1000), deliberately NOT under /root: the dependency
+# install runs unprivileged via gosu (issue #102), and /root is mode 0700 so
+# uid 1000 cannot even traverse into a cache mounted there. uv's cache is
+# content-addressed and location-independent, so relocating an existing volume
+# from the old /root path to here reuses its contents unchanged.
+UV_CACHE_VOLUME_DIR = "/home/sandbox/.cache/uv"
+# Ephemeral per-container uv cache used when the shared volume is disabled.
+# Lives on the writable /tmp tmpfs, which the sandbox user can write.
+UV_CACHE_TMP_DIR = "/tmp/uv-cache"
+
 # Workspace directory for job files (can be set via TAKO_VM_WORKSPACE env var)
 # When running the server in a container with Docker socket mounted, this must
 # be a path that exists on the host and is mounted into the server container.

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -17,7 +17,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from tako_vm.config import TakoVMConfig, get_config
-from tako_vm.constants import MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
+from tako_vm.constants import (
+    MAX_REQUIREMENTS,
+    UV_CACHE_TMP_DIR,
+    UV_CACHE_VOLUME,
+    UV_CACHE_VOLUME_DIR,
+    WORKSPACE_DIR,
+)
 from tako_vm.execution.docker import (
     EXECUTOR_ENTRYPOINT,
     base_isolation_args,
@@ -1420,9 +1426,9 @@ class CodeExecutor:
 
         # Mount uv cache volume for faster repeated installs
         if has_runtime_deps:
-            uv_cache_dir = "/tmp/uv-cache"
+            uv_cache_dir = UV_CACHE_TMP_DIR
             if self.config.enable_runtime_dependency_cache:
-                uv_cache_dir = "/root/.cache/uv"
+                uv_cache_dir = UV_CACHE_VOLUME_DIR
                 cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
             cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -25,7 +25,14 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit
 
 from tako_vm.config import get_config
-from tako_vm.constants import DEFAULT_IMAGE, MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
+from tako_vm.constants import (
+    DEFAULT_IMAGE,
+    MAX_REQUIREMENTS,
+    UV_CACHE_TMP_DIR,
+    UV_CACHE_VOLUME,
+    UV_CACHE_VOLUME_DIR,
+    WORKSPACE_DIR,
+)
 from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import (
     base_isolation_args,
@@ -595,9 +602,9 @@ class Sandbox:
 
         # Mount uv cache for faster installs
         if has_requirements:
-            uv_cache_dir = "/tmp/uv-cache"
+            uv_cache_dir = UV_CACHE_TMP_DIR
             if self.config.enable_runtime_dependency_cache:
-                uv_cache_dir = "/root/.cache/uv"
+                uv_cache_dir = UV_CACHE_VOLUME_DIR
                 cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
             cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -102,6 +102,50 @@ class TestGenerateDockerfileEntrypointContract:
             assert not stripped.startswith("CMD "), line
             assert not stripped.startswith("ENTRYPOINT "), line
 
+
+class TestEntrypointInstallsUnprivileged:
+    """The dependency install must drop to the sandbox user (issue #102).
+
+    Installing a package can run arbitrary build-time code, and the requirements
+    list is attacker-reachable, so the install must not run with the container
+    root privileges the rest of the entrypoint holds. This guards the entrypoint
+    contract statically; the executor image build + real package-install tests
+    exercise it dynamically in CI.
+    """
+
+    def _entrypoint_text(self):
+        from pathlib import Path
+
+        return (Path(__file__).resolve().parent.parent / "docker" / "entrypoint.sh").read_text()
+
+    def _install_cmd_block(self, text):
+        """Extract the UV_INSTALL_CMD=( ... ) array literal."""
+        start = text.index("UV_INSTALL_CMD=(")
+        end = text.index(")", start)
+        return text[start:end]
+
+    def test_install_command_runs_under_gosu(self):
+        block = self._install_cmd_block(self._entrypoint_text())
+        # The uv install itself must be wrapped in gosu sandbox (the execution
+        # phase already drops privileges; this is specifically the install).
+        assert "gosu sandbox" in block
+        assert "uv pip install" in block
+        assert block.index("gosu sandbox") < block.index("uv pip install")
+
+    def test_install_targets_are_chowned_to_sandbox(self):
+        text = self._entrypoint_text()
+        # The unprivileged install can only write dirs it owns, so root must hand
+        # ownership of the target and cache dirs over before dropping privileges.
+        assert 'chown sandbox:sandbox "$TARGET_DIR"' in text
+        assert 'chown -R sandbox:sandbox "$UV_CACHE_DIR"' in text
+
+    def test_install_sets_home_for_sandbox_user(self):
+        text = self._entrypoint_text()
+        # HOME must be set (in INSTALL_ENV, applied via `env`) so uv never falls
+        # back to writing under /root, which uid 1000 cannot traverse.
+        assert "HOME=$SANDBOX_HOME" in text
+        assert 'env "${INSTALL_ENV[@]}"' in self._install_cmd_block(text)
+
     def test_requirements_are_baked_at_build_time(self):
         dockerfile = ContainerBuilder().generate_dockerfile(
             JobType(name="jt", requirements=["pandas", "numpy>=1.26"])

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from tako_vm.constants import UV_CACHE_VOLUME
+from tako_vm.constants import UV_CACHE_TMP_DIR, UV_CACHE_VOLUME, UV_CACHE_VOLUME_DIR
 from tako_vm.sandbox import DEFAULT_STARTUP_TIMEOUT, Sandbox, SandboxResult
 from tako_vm.sandbox import run as sandbox_run
 
@@ -398,8 +398,8 @@ print(f"version: {requests.__version__}")
             requirements=["requests"],
         )
 
-        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target=/root/.cache/uv"
-        expected_cache_dir = "/root/.cache/uv" if cache_enabled else "/tmp/uv-cache"
+        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target={UV_CACHE_VOLUME_DIR}"
+        expected_cache_dir = UV_CACHE_VOLUME_DIR if cache_enabled else UV_CACHE_TMP_DIR
         assert (cache_mount in cmd) is expect_cache_mount
         assert f"--env=UV_CACHE_DIR={expected_cache_dir}" in cmd
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -6,7 +6,7 @@ import pytest
 
 import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
-from tako_vm.constants import UV_CACHE_VOLUME
+from tako_vm.constants import UV_CACHE_TMP_DIR, UV_CACHE_VOLUME, UV_CACHE_VOLUME_DIR
 from tako_vm.execution import CodeExecutor
 from tako_vm.job_types import JobType
 from tako_vm.security import (
@@ -419,8 +419,8 @@ class TestExecutorRejectsUnsafeIds:
             job_id="job-123",
         )
 
-        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target=/root/.cache/uv"
-        expected_cache_dir = "/root/.cache/uv" if cache_enabled else "/tmp/uv-cache"
+        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target={UV_CACHE_VOLUME_DIR}"
+        expected_cache_dir = UV_CACHE_VOLUME_DIR if cache_enabled else UV_CACHE_TMP_DIR
         assert result["success"] is True
         assert (cache_mount in captured["cmd"]) is expect_cache_mount
         assert f"--env=UV_CACHE_DIR={expected_cache_dir}" in captured["cmd"]


### PR DESCRIPTION
## Summary
The startup dependency-install phase ran as container **root**, before the gosu drop to uid 1000. Installing a package executes arbitrary code at build time (`setup.py` / PEP 517 hooks), and the requirements list flows from the API request, so an attacker-chosen sdist ran as in-container root. gVisor still contained it from the host, but it defeated the in-container defense-in-depth (the unprivileged-user assumption, `/output`, the root-only mounts).

## Fix
- Run `uv pip install` itself under `gosu sandbox`. As root (before dropping privileges) the entrypoint hands ownership of the install's writable targets (the `--target` dir and the uv cache dir) to the sandbox user, sets `HOME`, then execs the install as uid 1000.
- Relocated the shared uv cache volume mount from `/root/.cache/uv` to `/home/sandbox/.cache/uv`: `/root` is `0700`, so uid 1000 cannot traverse a cache mounted there. uv's cache is content-addressed and location-independent, so existing volumes reuse their contents at the new path.
- Hoisted the cache path into shared constants (`UV_CACHE_VOLUME_DIR` / `UV_CACHE_TMP_DIR`) used by both the worker and the library `Sandbox`, instead of a literal duplicated across both.

This is gated behind `allow_runtime_requirements` (default false), so it only affects deployments that opt into runtime installs.

## Validation
- **Dynamic, local:** built the executor image, ran a real `requests` install through the entrypoint on both the cache-off and cache-on (volume) paths. The install succeeded and the cache volume contents came out **owned by uid 1000**, confirming the install ran unprivileged (not as root).
- **CI:** builds the executor image and exercises the real package-install path (`TestSandboxRequirements`) in a Linux container.
- Added `TestEntrypointInstallsUnprivileged` as a static regression guard that the install block is wrapped in `gosu sandbox`, targets are chowned, and `HOME` is set.

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)