### PR TITLE
security: record and surface the effective isolation runtime per job (#99)

### DIFF
--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -420,10 +420,11 @@ def resolve_runtime(config: TakoVMConfig) -> str:
 
     Single source of truth shared by every execution path — the server
     ``CodeExecutor`` and the library ``Sandbox`` — so they apply gVisor
-    identically and can't drift. In strict mode (the default) gVisor must be
-    available or this fails closed; in permissive mode a missing gVisor falls
-    back to runc with a loud warning. An explicit ``container_runtime='runc'``
-    is honored only outside strict mode.
+    identically and can't drift. In strict mode gVisor must be available or this
+    fails closed; in permissive mode (the current default, see
+    ``TakoVMConfig.security_mode``) a missing gVisor falls back to runc with a
+    loud warning. An explicit ``container_runtime='runc'`` is honored only
+    outside strict mode.
 
     Raises:
         RuntimeUnavailableError: strict mode and gVisor unavailable, or runc
@@ -667,6 +668,11 @@ class CodeExecutor:
             code_hash=sha256_content(code),
             input_hash=sha256_json(input_data),
             client_ip=client_ip,
+            # Record the effective isolation runtime this job runs under, so the
+            # gVisor-vs-runc decision is auditable per job (issue #99). This is
+            # the same value passed to base_isolation_args() for the container,
+            # so the record can never disagree with what actually ran.
+            runtime=self._runtime,
             # Propagate idempotency and lineage fields from job data
             idempotency_key=job.get("idempotency_key"),
             idempotency_fingerprint=job.get("idempotency_fingerprint"),

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -287,6 +287,16 @@ class ExecutionRecord(BaseModel):
     worker_id: Optional[str] = Field(default=None, max_length=64)
     """ID of worker that executed this job."""
 
+    # Effective isolation runtime the container actually ran under. 'runsc' is
+    # the gVisor sandbox (the product's security boundary); 'runc' is the
+    # weaker, host-kernel-sharing fallback (only reachable in permissive mode
+    # when gVisor is unavailable). Persisted and surfaced in the API so a caller
+    # can prove, after the fact, whether a given job had the gVisor boundary and
+    # refuse to trust results from a runc run. None for legacy rows written
+    # before this field existed.
+    runtime: Optional[str] = Field(default=None, max_length=16)
+    """Effective container runtime: 'runsc' (gVisor) or 'runc' (weaker fallback)."""
+
     # Idempotency
     idempotency_key: Optional[str] = Field(default=None, max_length=128)
     """Client-provided key to prevent duplicate executions."""

--- a/tako_vm/sdk/client.py
+++ b/tako_vm/sdk/client.py
@@ -110,6 +110,10 @@ class ExecutionResult:
     exit_code: Optional[int] = None
     correlation_id: Optional[str] = None
     job_id: Optional[str] = None
+    # Effective isolation runtime the job ran under: 'runsc' (gVisor) or 'runc'
+    # (weaker fallback). Lets a caller confirm the gVisor boundary was in effect
+    # before trusting the output. None if the server predates this field.
+    runtime: Optional[str] = None
     # Set when the run succeeded but the output dict could not be coerced into
     # the expected dataclass (output stays a raw dict). Lets callers detect the
     # mismatch programmatically instead of scraping logs.
@@ -692,6 +696,7 @@ class TakoVM:
             exit_code=data.get("exit_code"),
             correlation_id=result_cid,
             job_id=data.get("execution_id") or data.get("job_id"),
+            runtime=data.get("runtime"),
         )
 
     @staticmethod

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -379,6 +379,13 @@ class ExecuteResponse(BaseModel):
         default=None,
         description="Execution ID correlating this run with /executions records and logs",
     )
+    runtime: Optional[str] = Field(
+        default=None,
+        description=(
+            "Effective isolation runtime: 'runsc' (gVisor) or 'runc' (weaker "
+            "fallback). Lets a caller confirm the gVisor boundary was in effect."
+        ),
+    )
 
 
 # Status type aliases for API type safety
@@ -461,6 +468,11 @@ class ExecutionRecordResponse(BaseModel):
     timing: Optional[ExecutionTimingResponse] = None
     """Detailed timing breakdown by execution phase."""
 
+    runtime: Optional[str] = None
+    """Effective isolation runtime the job ran under: 'runsc' (gVisor) or 'runc'
+    (weaker fallback). None for legacy records predating this field. Lets a
+    caller confirm a job had the gVisor boundary before trusting its output."""
+
     @classmethod
     def from_record(cls, record: ExecutionRecord) -> "ExecutionRecordResponse":
         timing_response = None
@@ -488,6 +500,7 @@ class ExecutionRecordResponse(BaseModel):
             output=record.result_json,
             error=record.error.model_dump() if record.error else None,
             timing=timing_response,
+            runtime=record.runtime,
         )
 
 
@@ -911,6 +924,7 @@ async def execute_code(request: ExecuteRequest, http_request: Request):
             error=record.error.message if record.error else None,
             job_type=record.job_type,
             execution_id=record.execution_id,
+            runtime=record.runtime,
         )
 
     except Exception as e:

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -175,6 +175,15 @@ MIGRATIONS: list[tuple[str, str]] = [
         ]
         """,
     ),
+    (
+        # Effective isolation runtime ('runsc'/'runc') the job ran under, so the
+        # gVisor-vs-runc decision is auditable per job (issue #99). Nullable:
+        # legacy rows predate the column.
+        "0004_runtime",
+        """
+        ALTER TABLE execution_records ADD COLUMN IF NOT EXISTS runtime TEXT
+        """,
+    ),
 ]
 
 
@@ -368,12 +377,12 @@ class ExecutionStorage:
                     max_rss_mb, cpu_time_ms, wall_time_ms,
                     timing_json,
                     artifacts_json, error_json,
-                    client_ip, correlation_id, parent_execution_id, relationship
+                    client_ip, correlation_id, parent_execution_id, relationship, runtime
                 ) VALUES (
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s, %s, %s, %s, %s
+                    %s, %s, %s, %s, %s, %s, %s
                 )
                 ON CONFLICT (execution_id) DO UPDATE SET
                     status = EXCLUDED.status,
@@ -424,7 +433,8 @@ class ExecutionStorage:
                         EXCLUDED.parent_execution_id
                     ),
                     relationship =
-                        COALESCE(execution_records.relationship, EXCLUDED.relationship)
+                        COALESCE(execution_records.relationship, EXCLUDED.relationship),
+                    runtime = COALESCE(EXCLUDED.runtime, execution_records.runtime)
                 WHERE execution_records.status NOT IN ({terminal_list})
                 """,
                 (
@@ -464,6 +474,7 @@ class ExecutionStorage:
                     record.correlation_id,
                     record.parent_execution_id,
                     record.relationship,
+                    record.runtime,
                 ),
             )
             return cursor.rowcount
@@ -708,6 +719,7 @@ class ExecutionStorage:
             correlation_id=row.get("correlation_id"),
             parent_execution_id=row.get("parent_execution_id"),
             relationship=row.get("relationship"),
+            runtime=row.get("runtime"),
         )
 
     async def save_version(self, version: JobVersion) -> None:

--- a/tests/test_runtime_observability.py
+++ b/tests/test_runtime_observability.py
@@ -1,0 +1,92 @@
+"""
+Tests for per-job runtime (gVisor vs runc) observability (issue #99).
+
+The effective isolation runtime each job ran under must be recorded on the
+ExecutionRecord and surfaced in the API responses, so a caller can prove after
+the fact whether a job had the gVisor boundary before trusting its output.
+
+These are pure unit tests: the worker stamping is exercised via the
+job-type-not-found early return (no container launch), and the response mapping
+is a pure function. The storage round-trip is covered in test_storage.py (CI).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import tako_vm.execution.worker as worker_module
+from tako_vm.config import TakoVMConfig
+from tako_vm.execution.worker import CodeExecutor
+from tako_vm.models import ExecutionRecord
+from tako_vm.server.app import ExecuteResponse, ExecutionRecordResponse
+
+
+@pytest.fixture
+def gvisor_executor(tmp_path, monkeypatch):
+    """A CodeExecutor that resolves to the gVisor (runsc) runtime."""
+    monkeypatch.setattr(worker_module, "_gvisor_available", True)
+    monkeypatch.setattr(
+        worker_module,
+        "get_circuit_breaker",
+        lambda: SimpleNamespace(
+            is_available=True,
+            record_success=lambda *a, **k: None,
+            record_failure=lambda *a, **k: None,
+        ),
+    )
+    config = TakoVMConfig(
+        security_mode="permissive",
+        production_mode=True,
+        data_dir=str(tmp_path / "data"),
+    )
+    return CodeExecutor(config=config)
+
+
+class TestWorkerStampsRuntime:
+    def test_record_carries_effective_runtime(self, gvisor_executor):
+        # production_mode + an unknown job type returns the record early (no
+        # container launch), but the runtime is stamped at record construction,
+        # so it is present on that early-return record.
+        record = gvisor_executor.execute_job_with_record(
+            "job-runtime-1",
+            {"code": "print(1)", "job_type": "does-not-exist"},
+        )
+
+        assert gvisor_executor._runtime == "runsc"
+        assert record.runtime == "runsc"
+        # Sanity: this is the early-return failure path, not a real run.
+        assert record.status == "failed"
+
+    def test_runtime_matches_executor_resolution(self, gvisor_executor):
+        # The recorded value must be exactly the runtime the container would use,
+        # so the record can never disagree with what actually ran.
+        record = gvisor_executor.execute_job_with_record(
+            "job-runtime-2",
+            {"code": "print(1)", "job_type": "does-not-exist"},
+        )
+        assert record.runtime == gvisor_executor._runtime
+
+
+class TestResponsesSurfaceRuntime:
+    def _record(self, runtime):
+        return ExecutionRecord(
+            execution_id="rec-1",
+            status="succeeded",
+            job_type="default",
+            code_hash="a" * 64,
+            input_hash="b" * 64,
+            runtime=runtime,
+        )
+
+    def test_execution_record_response_includes_runtime(self):
+        resp = ExecutionRecordResponse.from_record(self._record("runsc"))
+        assert resp.runtime == "runsc"
+
+    def test_execution_record_response_runtime_defaults_none(self):
+        # Legacy records (no runtime) surface as None, not an error.
+        resp = ExecutionRecordResponse.from_record(self._record(None))
+        assert resp.runtime is None
+
+    def test_execute_response_accepts_runtime(self):
+        resp = ExecuteResponse(success=True, execution_time=1.0, runtime="runc")
+        assert resp.runtime == "runc"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -139,6 +139,7 @@ class TestExecutionRecordCRUD:
             client_ip="192.168.1.1",
             parent_execution_id="parent-123",
             relationship="rerun",
+            runtime="runsc",
         )
 
         storage.save_record(record)
@@ -146,6 +147,7 @@ class TestExecutionRecordCRUD:
 
         assert retrieved is not None
         assert retrieved.job_ref == "custom-job@sha256:abc123"
+        assert retrieved.runtime == "runsc"
         assert retrieved.duration_ms == 3000
         assert retrieved.worker_id == "worker-1"
         assert retrieved.resource_usage is not None


### PR DESCRIPTION
## Summary
Implements the **observability half** of #99. It does **not** change the permissive default (that fail-open default flip is a separate behavioral decision being handled apart from this PR).

You previously could not prove, after the fact, whether a given job ran under gVisor (`runsc`) or the weaker `runc` fallback: the runtime was resolved once and never written to the record or returned by the API. A startup-time gVisor outage that pinned `runc` for the process lifetime left no per-job trace.

## Changes
- **Model:** `ExecutionRecord` gains a nullable `runtime` field, stamped at record construction with the **same value passed to `base_isolation_args()`** for the container, so the record can never disagree with what actually ran.
- **Storage:** new migration `0004_runtime` adds a nullable `runtime` column; the upsert and the row→record mapping carry it (COALESCE-preserving on update so a status update never clobbers it).
- **API:** `ExecutionRecordResponse` and the legacy `ExecuteResponse` now include `runtime`; the SDK `ExecutionResult` surfaces it. A caller can refuse to trust output from a `runc` run.
- **Docstring fix:** `resolve_runtime` wrongly claimed strict was the default; corrected to permissive (matching `config` and `tako_vm.yaml.example`).

## Tests
- `test_runtime_observability.py`: worker stamping (exercised via the job-type-not-found early return, no container launch), response mapping, legacy `None` handling.
- `test_storage.py`: `runtime` added to the all-fields round-trip (CI Postgres validates the SQL/migration).

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)