### PR TITLE
security: pin base images by digest and verify the docker binary checksum (#98)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Keep the digest-pinned base images current. Without this, the sha256 pins
+  # in the Dockerfiles and docker-compose.yaml (added for supply-chain
+  # integrity) would silently go stale and miss upstream security patches.
+  - package-ecosystem: docker
+    directories:
+      - /docker
+      - /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Keep the Python dependencies (pyproject) patched.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Keep the CI action versions current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,9 @@
 
 services:
   docker-socket-proxy:
-    image: tecnativa/docker-socket-proxy:latest
+    # Digest-pinned so a repointed upstream tag can't change the proxy that
+    # gates the server's Docker access (dependabot keeps the digest current).
+    image: tecnativa/docker-socket-proxy:latest@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
     container_name: tako-vm-docker-socket-proxy
     environment:
       # Docker CLI health/startup checks
@@ -69,7 +71,8 @@ services:
       retries: 3
 
   postgres:
-    image: postgres:16-alpine
+    # Digest-pinned (dependabot keeps the digest current).
+    image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
     container_name: tako-vm-postgres
     environment:
       - POSTGRES_USER=postgres

--- a/docker/Dockerfile.executor
+++ b/docker/Dockerfile.executor
@@ -1,11 +1,14 @@
-FROM python:3.11-slim
+# Base image pinned by digest (not just the mutable :3.11-slim tag) so a
+# repointed upstream tag can't silently change what we ship. The tag is kept
+# alongside the digest for readability and so dependabot can bump both.
+FROM python:3.11-slim@sha256:ae52c5bef62a6bdd42cd1e8dffef86b9cd284bde9427da79839de7a4b983e7ca
 
 # Install gosu for proper privilege dropping
 RUN apt-get update && apt-get install -y --no-install-recommends gosu \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv for fast dependency installation
-COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /usr/local/bin/uv
+# Install uv for fast dependency installation (digest-pinned, see above)
+COPY --from=ghcr.io/astral-sh/uv:0.5.14@sha256:f0786ad49e2e684c18d38697facb229f538a6f5e374c56f54125aabe7d14b3f7 /uv /usr/local/bin/uv
 
 # Install custom libraries
 # Place your .whl files in tako_vm/custom_libs/ directory before building

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -13,7 +13,9 @@
 # Note: Docker socket access gives container root-equivalent access to host.
 # This is necessary for spawning executor containers.
 
-FROM python:3.11-slim
+# Base image pinned by digest (not just the mutable :3.11-slim tag) so a
+# repointed upstream tag can't silently change what we ship.
+FROM python:3.11-slim@sha256:ae52c5bef62a6bdd42cd1e8dffef86b9cd284bde9427da79839de7a4b983e7ca
 
 WORKDIR /app
 
@@ -23,14 +25,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Docker CLI from official binaries
-RUN ARCH=$(uname -m) && \
-    curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-27.5.1.tgz" | \
-    tar -xz --strip-components=1 -C /usr/local/bin docker/docker && \
-    chmod +x /usr/local/bin/docker
+# Install the Docker CLI from the official static binaries, pinned by version
+# and verified against a known SHA256 before extraction. The tarball is fetched
+# over HTTPS with no signature, so without this check a compromised mirror or
+# MITM could swap the binary the server uses to launch every sandbox container.
+ARG DOCKER_VERSION=27.5.1
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64) sha256="4f798b3ee1e0140eab5bf30b0edc4e84f4cdb53255a429dc3bbae9524845d640" ;; \
+        aarch64) sha256="e6b53725a73763ab3f988c73f8772eaed429754c1a579db5ff11f21990fd1817" ;; \
+        *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://download.docker.com/linux/static/stable/${arch}/docker-${DOCKER_VERSION}.tgz" -o /tmp/docker.tgz; \
+    echo "${sha256}  /tmp/docker.tgz" | sha256sum -c -; \
+    tar -xz --strip-components=1 -C /usr/local/bin -f /tmp/docker.tgz docker/docker; \
+    chmod +x /usr/local/bin/docker; \
+    rm -f /tmp/docker.tgz
 
-# Install uv for fast dependency installation
-COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /usr/local/bin/uv
+# Install uv for fast dependency installation (digest-pinned, see above)
+COPY --from=ghcr.io/astral-sh/uv:0.5.14@sha256:f0786ad49e2e684c18d38697facb229f538a6f5e374c56f54125aabe7d14b3f7 /uv /usr/local/bin/uv
 
 # Copy package files
 COPY pyproject.toml README.md LICENSE ./

--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -143,8 +143,9 @@ class ContainerBuilder:
 FROM {base_image}
 
 # Install uv for fast dependency installation (already present on the
-# executor base; kept so custom executor-derived bases get it too)
-COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /usr/local/bin/uv
+# executor base; kept so custom executor-derived bases get it too).
+# Digest-pinned to match docker/Dockerfile.executor; bump both together.
+COPY --from=ghcr.io/astral-sh/uv:0.5.14@sha256:f0786ad49e2e684c18d38697facb229f538a6f5e374c56f54125aabe7d14b3f7 /uv /usr/local/bin/uv
 
 # Install custom libraries if present
 COPY ./custom_libs /tmp/custom_libs


### PR DESCRIPTION
## Summary
Nothing in the build pipeline was pinned by digest, so a repointed upstream tag could change what we ship, and the server image fetched the docker static binary over HTTPS with no integrity check. gVisor still confines untrusted code at runtime, so this is build-time supply-chain integrity rather than a runtime escape.

## Changes
- Pin `python:3.11-slim` and `ghcr.io/astral-sh/uv:0.5.14` by `sha256` digest in `docker/Dockerfile.executor`, `docker/Dockerfile.server`, and the builder's generated Dockerfile (tags kept alongside the digest for readability and dependabot).
- Pin `postgres:16-alpine` and `tecnativa/docker-socket-proxy:latest` by digest in `docker-compose.yaml` (the socket proxy gates the server's Docker access).
- Verify the docker static-binary tarball against a known **per-arch** SHA256 (`x86_64` + `aarch64`) before extracting, instead of piping `curl` straight into `tar`. `set -eux` aborts the build on mismatch.
- Add `.github/dependabot.yml` (docker + pip + github-actions) so the digest pins stay current instead of silently going stale.

## Validation
- Built **both** images locally. The server build's `sha256sum -c` step reported `/tmp/docker.tgz: OK`, confirming the verification path works and the pins resolve.
- CI builds only the executor image, so the executor pins are CI-gated; the **server image / docker-binary checksum is not covered by CI** and was validated locally (aarch64 here; the x86_64 checksum was computed from the same official URL).

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)