### PR TITLE
refactor: dedup stream-decode and image-exists across execution paths

### DIFF
--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -28,6 +28,7 @@ from tako_vm.execution.docker import (
     image_has_executor_entrypoint,
     reset_image_caches,
 )
+from tako_vm.execution.docker import image_exists as docker_image_exists
 from tako_vm.job_types import JobType, JobTypeRegistry
 from tako_vm.security import (
     validate_docker_image,
@@ -316,13 +317,10 @@ WORKDIR /app
         Returns:
             True if image exists
         """
-        try:
-            subprocess.run(
-                ["docker", "image", "inspect", job_type.image_name], capture_output=True, check=True
-            )
-            return True
-        except subprocess.CalledProcessError:
-            return False
+        # Delegate to the shared, timeout-bounded, cached existence check so the
+        # builder, worker, and sandbox all probe the daemon identically (the
+        # bare subprocess version here had no timeout and could hang).
+        return docker_image_exists(job_type.image_name)
 
     def remove_image(self, job_type: JobType) -> bool:
         """

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -45,6 +45,22 @@ def reset_image_caches() -> None:
     _executor_entrypoint_cache.clear()
 
 
+def decode_subprocess_stream(value) -> str:
+    """Coerce captured subprocess output (``str`` | ``bytes`` | ``None``) to ``str``.
+
+    ``subprocess.TimeoutExpired.stdout``/``.stderr`` hold the raw ``bytes``
+    captured before the kill even when ``subprocess.run`` was invoked with
+    ``text=True`` (CPython populates them from the byte buffers), so any caller
+    reading partial output on timeout must handle all three types. Shared by the
+    worker and the library Sandbox so the decoding can't drift between them.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def image_exists(image_name: str) -> bool:
     """Check whether a Docker image exists locally (cached).
 

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -27,6 +27,7 @@ from tako_vm.constants import (
 from tako_vm.execution.docker import (
     EXECUTOR_ENTRYPOINT,
     base_isolation_args,
+    decode_subprocess_stream,
     generate_container_name,
     image_exists,
     image_has_executor_entrypoint,
@@ -75,21 +76,6 @@ _DOCKER_INFRA_STDERR_PATTERNS = (
     "error during connect",
     "docker daemon is not running",
 )
-
-
-def _coerce_output(value: Any) -> str:
-    """Coerce captured subprocess output to ``str``.
-
-    ``subprocess.TimeoutExpired.stdout``/``.stderr`` hold the raw ``bytes``
-    captured before the kill even when ``subprocess.run`` was invoked with
-    ``text=True`` (CPython populates them from the byte buffers), so this
-    must handle ``str``, ``bytes``, and ``None``.
-    """
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    return value
 
 
 def _require_safe_execution_id(execution_id: str) -> str:
@@ -1595,8 +1581,8 @@ class CodeExecutor:
                 "error": f"Execution timeout exceeded ({timeout}s)",
                 # Preserve partial output captured up to the kill so the user
                 # can see how far their code got before the host-level kill.
-                "stdout": _coerce_output(e.stdout),
-                "stderr": _coerce_output(e.stderr),
+                "stdout": decode_subprocess_stream(e.stdout),
+                "stderr": decode_subprocess_stream(e.stderr),
                 "exit_code": -1,
                 "timeout": timeout,
                 # Marker for the caller: this run hit the host-level timeout,

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -36,7 +36,9 @@ from tako_vm.constants import (
 from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import (
     base_isolation_args,
+    decode_subprocess_stream,
     generate_container_name,
+    image_exists,
     inspect_oom_killed,
     remove_container,
     ulimit_args,
@@ -51,19 +53,6 @@ _SAFE_PROXY_URL_CHARS = frozenset(
 
 DEFAULT_STARTUP_TIMEOUT = 120
 """Default startup (dependency install) timeout in seconds, matching server defaults."""
-
-
-def _decode_stream(value: Any) -> str:
-    """Decode partial subprocess output that may be None, bytes, or str.
-
-    subprocess.TimeoutExpired carries raw bytes even when subprocess.run
-    was invoked with text=True.
-    """
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    return value
 
 
 @dataclass
@@ -246,14 +235,11 @@ class Sandbox:
         if self._image_checked:
             return
 
-        # Check if image exists
-        result = subprocess.run(
-            ["docker", "image", "inspect", self.config.image],
-            capture_output=True,
-            check=False,
-        )
-
-        if result.returncode == 0:
+        # Existence check goes through the shared, timeout-bounded, cached
+        # docker.image_exists so all three call sites (worker, builder, sandbox)
+        # probe the daemon identically instead of re-rolling `docker image
+        # inspect` with their own timeout/error handling.
+        if image_exists(self.config.image):
             self._image_checked = True
             return
 
@@ -508,8 +494,8 @@ class Sandbox:
                         subprocess_timeout,
                     )
                     return SandboxResult(
-                        stdout=_decode_stream(exc.stdout),
-                        stderr=_decode_stream(exc.stderr),
+                        stdout=decode_subprocess_stream(exc.stdout),
+                        stderr=decode_subprocess_stream(exc.stderr),
                         exit_code=-1,
                         success=False,
                         error=(

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -13,6 +13,7 @@ from tako_vm.execution.docker import (
     CONTAINER_LABEL,
     EXECUTION_ID_LABEL,
     base_isolation_args,
+    decode_subprocess_stream,
     generate_container_name,
     image_exists,
     image_has_executor_entrypoint,
@@ -22,6 +23,27 @@ from tako_vm.execution.docker import (
     remove_container,
     reset_image_caches,
 )
+
+
+class TestDecodeSubprocessStream:
+    """Single source for coercing partial subprocess output (str | bytes |
+    None), shared by the worker and the library Sandbox so the timeout-output
+    decoding can't drift between them (previously duplicated as _coerce_output
+    and _decode_stream)."""
+
+    def test_none_becomes_empty_string(self):
+        assert decode_subprocess_stream(None) == ""
+
+    def test_str_passes_through(self):
+        assert decode_subprocess_stream("hello") == "hello"
+
+    def test_bytes_are_utf8_decoded(self):
+        assert decode_subprocess_stream(b"hello") == "hello"
+
+    def test_invalid_utf8_is_replaced_not_raised(self):
+        # TimeoutExpired byte buffers can be cut mid-codepoint; decoding must
+        # never raise (errors="replace").
+        assert decode_subprocess_stream(b"\xff\xfe") == "��"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
DRY cleanup surfaced by the codebase analysis. **Behavior-preserving** — no API, security, or persisted-data change.

## Changes
- `_coerce_output` (worker.py) and `_decode_stream` (sandbox.py) were **byte-identical** helpers coercing partial subprocess output (`str | bytes | None`) captured on timeout. Replaced both with one shared `decode_subprocess_stream()` in `execution/docker.py` so the decoding can't drift.
- The Docker image-existence check existed in **three forms**: the canonical cached, timeout-bounded `docker.image_exists`, plus a re-rolled `ContainerBuilder.image_exists` and an inline copy in `Sandbox._ensure_image` — the latter two with **no timeout** (could hang). Both now delegate to `docker.image_exists`.

## Tests
- Added `decode_subprocess_stream` cases to `test_docker_utils.py`.
- Existing worker/sandbox/builder tests unchanged and passing (they mock `worker_module.image_exists` / skip via `_image_checked`, both still valid).

Part of the DRY/KISS consolidation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)