### PR TITLE
fix: ?view=full dropped timing and runtime; delegate to base response mapper

### DIFF
--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -672,6 +672,16 @@ class ArtifactResponse(BaseModel):
     sha256: str = Field(..., description="SHA256 hash of file contents")
     content_type: Optional[str] = Field(default=None, description="MIME type")
 
+    @classmethod
+    def from_model(cls, artifact) -> "ArtifactResponse":
+        """Build from an Artifact / InputArtifact model (same field shape)."""
+        return cls(
+            name=artifact.name,
+            size_bytes=artifact.size_bytes,
+            sha256=artifact.sha256,
+            content_type=artifact.content_type,
+        )
+
 
 class ResourceUsageResponse(BaseModel):
     """Resource consumption metrics."""
@@ -731,42 +741,21 @@ class ExecutionRecordFullResponse(ExecutionRecordResponse):
 
     @classmethod
     def from_record(cls, record: ExecutionRecord) -> "ExecutionRecordFullResponse":
-        """Create full response from ExecutionRecord."""
+        """Create full response from ExecutionRecord.
+
+        The base fields (including ``timing`` and ``runtime``) are taken from
+        ``ExecutionRecordResponse.from_record`` rather than re-mapped here: when
+        this override hand-copied the base fields it silently dropped ``timing``
+        (and later ``runtime``), so ``?view=full`` returned them as null while
+        the slim view did not. Delegating keeps the two views in lockstep.
+        """
+        base = ExecutionRecordResponse.from_record(record).model_dump()
         return cls(
-            # Base fields
-            execution_id=record.execution_id,
-            status=record.status,
-            job_type=record.job_type,
-            job_version=record.job_ref,
-            created_at=record.created_at.isoformat(),
-            started_at=record.started_at.isoformat() if record.started_at else None,
-            ended_at=record.ended_at.isoformat() if record.ended_at else None,
-            duration_ms=record.duration_ms,
-            exit_code=record.exit_code,
-            stdout=record.stdout,
-            stderr=record.stderr,
-            output=record.result_json,
-            error=record.error.model_dump() if record.error else None,
-            # Extended fields
+            **base,
+            # Extended fields only
             job_ref=record.job_ref,
-            artifacts=[
-                ArtifactResponse(
-                    name=a.name,
-                    size_bytes=a.size_bytes,
-                    sha256=a.sha256,
-                    content_type=a.content_type,
-                )
-                for a in record.artifacts
-            ],
-            input_artifacts=[
-                ArtifactResponse(
-                    name=a.name,
-                    size_bytes=a.size_bytes,
-                    sha256=a.sha256,
-                    content_type=a.content_type,
-                )
-                for a in record.input_artifacts
-            ],
+            artifacts=[ArtifactResponse.from_model(a) for a in record.artifacts],
+            input_artifacts=[ArtifactResponse.from_model(a) for a in record.input_artifacts],
             resource_usage=ResourceUsageResponse(
                 max_rss_mb=record.resource_usage.max_rss_mb,
                 cpu_time_ms=record.resource_usage.cpu_time_ms,

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -1,0 +1,83 @@
+"""
+Tests for API response-model construction in tako_vm.server.app.
+
+Guards the consolidation of ExecutionRecordFullResponse.from_record onto the
+base ExecutionRecordResponse.from_record: the previous hand-copied override
+silently dropped `timing` (and later `runtime`) from the ?view=full payload
+while the slim view kept them. These assert the two views stay in lockstep.
+"""
+
+from tako_vm.models import Artifact, ExecutionRecord, ExecutionTiming, ResourceUsage
+from tako_vm.server.app import (
+    ArtifactResponse,
+    ExecutionRecordFullResponse,
+    ExecutionRecordResponse,
+)
+
+
+def _record_with_detail():
+    return ExecutionRecord(
+        execution_id="rec-full",
+        status="succeeded",
+        job_type="default",
+        code_hash="a" * 64,
+        input_hash="b" * 64,
+        runtime="runsc",
+        timing=ExecutionTiming(startup_ms=100, dep_install_ms=10, execution_ms=200, total_ms=300),
+        resource_usage=ResourceUsage(max_rss_mb=12.5, cpu_time_ms=50, wall_time_ms=300),
+        artifacts=[
+            Artifact(
+                name="out.png",
+                size_bytes=10,
+                sha256="c" * 64,
+                content_type="image/png",
+                storage_key="runs/rec-full/artifacts/out.png",
+            )
+        ],
+    )
+
+
+class TestFullViewMatchesSlimView:
+    def test_full_view_includes_timing(self):
+        # Regression: full view used to return timing=null even when slim did not.
+        full = ExecutionRecordFullResponse.from_record(_record_with_detail())
+        assert full.timing is not None
+        assert full.timing.execution_ms == 200
+
+    def test_full_view_includes_runtime(self):
+        # Regression: the runtime field (issue #99) was also dropped by the
+        # hand-copied override.
+        full = ExecutionRecordFullResponse.from_record(_record_with_detail())
+        assert full.runtime == "runsc"
+
+    def test_full_and_slim_agree_on_base_fields(self):
+        record = _record_with_detail()
+        slim = ExecutionRecordResponse.from_record(record)
+        full = ExecutionRecordFullResponse.from_record(record)
+        assert full.runtime == slim.runtime
+        assert (full.timing is None) == (slim.timing is None)
+        assert full.execution_id == slim.execution_id
+        assert full.status == slim.status
+
+    def test_full_view_maps_artifacts(self):
+        full = ExecutionRecordFullResponse.from_record(_record_with_detail())
+        assert len(full.artifacts) == 1
+        assert full.artifacts[0].name == "out.png"
+        assert full.resource_usage is not None
+        assert full.resource_usage.max_rss_mb == 12.5
+
+
+class TestArtifactResponseFromModel:
+    def test_from_model_copies_fields(self):
+        art = Artifact(
+            name="x.bin",
+            size_bytes=3,
+            sha256="d" * 64,
+            content_type="application/octet-stream",
+            storage_key="runs/x/artifacts/x.bin",
+        )
+        resp = ArtifactResponse.from_model(art)
+        assert resp.name == "x.bin"
+        assert resp.size_bytes == 3
+        assert resp.sha256 == "d" * 64
+        assert resp.content_type == "application/octet-stream"


### PR DESCRIPTION
## Bug
`ExecutionRecordFullResponse.from_record` hand-copied the base `ExecutionRecord` field mapping instead of delegating, and the copy **omitted `timing`** — and, after the #99 change, **`runtime`**. So `GET /executions/{id}?view=full` returned `timing=null` and `runtime=null` even when the slim view (no `?view`) returned them. A classic copy-paste drift.

## Fix
- `ExecutionRecordFullResponse.from_record` now builds the base via `ExecutionRecordResponse.from_record(...).model_dump()` and only adds the **extended** fields, so the two views can't drift on shared fields again.
- Added `ArtifactResponse.from_model()` and used it for both `artifacts` and `input_artifacts` (previously two identical inline comprehensions).

## Tests
`test_response_models.py`: asserts the full view now carries `timing` and `runtime`, agrees with the slim view on base fields, and maps artifacts. No existing test relied on the buggy behavior.

Part of the DRY/KISS consolidation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)