### PR TITLE
refactor: whole-package review pass (simplify, consolidate, durable, verbose errors)

### DIFF
--- a/tako_vm/__init__.py
+++ b/tako_vm/__init__.py
@@ -40,7 +40,12 @@ except ImportError:
     pass
 
 from tako_vm.config import TakoVMConfig, get_config
-from tako_vm.constants import DEFAULT_IMAGE, MAX_REQUIREMENTS, UV_CACHE_VOLUME, WORKSPACE_DIR
+from tako_vm.constants import (
+    DEFAULT_IMAGE,
+    MAX_REQUIREMENTS,
+    UV_CACHE_VOLUME,
+    get_workspace_dir,
+)
 from tako_vm.job_types import JobType, JobTypeRegistry
 from tako_vm.models import Artifact, ExecutionRecord, JobVersion, ResourceUsage
 from tako_vm.sandbox import Sandbox, SandboxResult
@@ -122,7 +127,7 @@ __all__ = [
     # Constants
     "DEFAULT_IMAGE",
     "UV_CACHE_VOLUME",
-    "WORKSPACE_DIR",
+    "get_workspace_dir",
     "MAX_REQUIREMENTS",
     # Exceptions
     "TakoVMError",

--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -40,6 +40,34 @@ MANAGED_POSTGRES_CONTAINER = "tako-vm-postgres"
 MANAGED_POSTGRES_VOLUME = "tako-vm-postgres-data"
 
 
+def _mask_database_url(url: str) -> str:
+    """Mask the password in a database URL for display, keeping the username."""
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    creds, host = parts.netloc.rsplit("@", 1)
+    username = creds.split(":", 1)[0] if creds else ""
+    masked_creds = f"{username}:***" if username else "***"
+    return urlunsplit(
+        (parts.scheme, f"{masked_creds}@{host}", parts.path, parts.query, parts.fragment)
+    )
+
+
+def _postgres_container_running() -> bool:
+    """Probe whether the managed PostgreSQL container is in the running state.
+
+    Assumes the container exists (caller has already inspected it). Returns
+    True only when `docker inspect` reports State.Running == true.
+    """
+    running_proc = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", MANAGED_POSTGRES_CONTAINER],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return running_proc.stdout.strip().lower() == "true"
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="tako-vm",
@@ -247,13 +275,21 @@ def run_setup(args):
 
     # Verify with a quick test
     print("Verifying...")
-    result = subprocess.run(
-        ["docker", "run", "--rm", "--entrypoint", "python", DEFAULT_IMAGE, "-c", "print('ok')"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["docker", "run", "--rm", "--entrypoint", "python", DEFAULT_IMAGE, "-c", "print('ok')"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        # A hung verification means the image is unusable; exit non-zero so
+        # `tako-vm setup && ...` doesn't proceed on a broken image and report
+        # success.
+        print("Error: Image pulled but verification failed.", file=sys.stderr)
+        print("  Verification timed out after 30s.", file=sys.stderr)
+        sys.exit(1)
     if result.returncode == 0 and "ok" in result.stdout:
         print("  Executor image works")
     else:
@@ -363,13 +399,7 @@ def _ensure_managed_postgres() -> None:
     )
 
     if inspect_proc.returncode == 0:
-        running_proc = subprocess.run(
-            ["docker", "inspect", "-f", "{{.State.Running}}", MANAGED_POSTGRES_CONTAINER],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        if running_proc.stdout.strip().lower() != "true":
+        if not _postgres_container_running():
             subprocess.run(
                 ["docker", "start", MANAGED_POSTGRES_CONTAINER],
                 check=True,
@@ -426,13 +456,7 @@ def _managed_postgres_state() -> str:
     if inspect_proc.returncode != 0:
         return "missing"
 
-    running_proc = subprocess.run(
-        ["docker", "inspect", "-f", "{{.State.Running}}", MANAGED_POSTGRES_CONTAINER],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return "running" if running_proc.stdout.strip().lower() == "true" else "stopped"
+    return "running" if _postgres_container_running() else "stopped"
 
 
 def _auto_start_local_postgres_if_needed(config) -> None:
@@ -626,17 +650,6 @@ def show_config(args):
         sys.exit(1)
 
     config_file = get_config_path()
-
-    def _mask_database_url(url: str) -> str:
-        parts = urlsplit(url)
-        if "@" not in parts.netloc:
-            return url
-        creds, host = parts.netloc.rsplit("@", 1)
-        username = creds.split(":", 1)[0] if creds else ""
-        masked_creds = f"{username}:***" if username else "***"
-        return urlunsplit(
-            (parts.scheme, f"{masked_creds}@{host}", parts.path, parts.query, parts.fragment)
-        )
 
     if args.json:
         import json

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -15,6 +15,8 @@ from urllib.parse import parse_qsl, urlsplit, urlunsplit
 import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
+from tako_vm.constants import DEFAULT_IMAGE
+
 logger = logging.getLogger(__name__)
 
 # Default config file locations (searched in order)
@@ -44,6 +46,27 @@ def _sanitize_validation_error(e: ValidationError) -> str:
         loc = ".".join(str(part) for part in err.get("loc", ())) or "config"
         lines.append(f"field {loc}: {err.get('msg', 'invalid value')}")
     return "; ".join(lines) or "validation failed"
+
+
+def _parse_size_to_mb(v: str, *, allow_k_and_bytes: bool) -> int:
+    """Parse a size string ('512m', '1g', etc.) to whole megabytes.
+
+    Shared by tmpfs_size and memory_limit validation. ``v`` must already be
+    lowercased and stripped. When ``allow_k_and_bytes`` is True a 'k' suffix or
+    a bare integer (bytes) is accepted (tmpfs); otherwise only 'm'/'g' are
+    allowed (memory_limit) and anything else raises ValueError. Integer parse
+    failures propagate as ValueError so pydantic reports them.
+    """
+    if v.endswith("g"):
+        return int(v[:-1]) * 1024
+    if v.endswith("m"):
+        return int(v[:-1])
+    if allow_k_and_bytes:
+        if v.endswith("k"):
+            return int(v[:-1]) // 1024
+        # Assume bytes.
+        return int(v) // (1024 * 1024)
+    raise ValueError("memory_limit must end with 'm' or 'g'")
 
 
 def get_default_data_dir() -> Path:
@@ -89,16 +112,7 @@ class ContainerLimits(BaseModel):
         if not v:
             raise ValueError("tmpfs_size cannot be empty")
 
-        # Parse size
-        if v.endswith("g"):
-            size_mb = int(v[:-1]) * 1024
-        elif v.endswith("m"):
-            size_mb = int(v[:-1])
-        elif v.endswith("k"):
-            size_mb = int(v[:-1]) // 1024
-        else:
-            # Assume bytes
-            size_mb = int(v) // (1024 * 1024)
+        size_mb = _parse_size_to_mb(v, allow_k_and_bytes=True)
 
         # Validate bounds (10MB to 2GB)
         if size_mb < 10:
@@ -221,13 +235,7 @@ class JobTypeConfig(BaseModel):
         if not v:
             raise ValueError("memory_limit cannot be empty")
 
-        # Parse and validate
-        if v.endswith("g"):
-            size_mb = int(v[:-1]) * 1024
-        elif v.endswith("m"):
-            size_mb = int(v[:-1])
-        else:
-            raise ValueError("memory_limit must end with 'm' or 'g'")
+        size_mb = _parse_size_to_mb(v, allow_k_and_bytes=False)
 
         if size_mb < 64:
             raise ValueError("memory_limit must be at least 64m")
@@ -433,7 +441,7 @@ class TakoVMConfig(BaseModel):
     )
 
     # Docker
-    docker_image: str = Field(default="code-executor:latest")
+    docker_image: str = Field(default=DEFAULT_IMAGE)
     enable_seccomp: bool = Field(default=True)
     enable_cap_restrictions: bool = Field(
         default=True,
@@ -523,10 +531,21 @@ class TakoVMConfig(BaseModel):
         return self
 
     def resolve_paths(self) -> "TakoVMConfig":
-        """Resolve all paths and create directories."""
-        # Data directory
+        """Resolve all paths and create the data directory.
+
+        Pure path resolution lives in ``_resolve_path_strings``; the data
+        directory creation is the one explicit, idempotent side effect and is
+        kept in ``_ensure_data_dir`` so callers (and the ``data_dir`` property)
+        can be reasoned about clearly. Behavior is unchanged: this still
+        resolves every path and mkdir's the data dir.
+        """
+        self._resolve_path_strings()
+        self._ensure_data_dir()
+        return self
+
+    def _resolve_path_strings(self) -> None:
+        """Resolve configured path strings to Path objects (no filesystem writes)."""
         self._resolved_data_dir = Path(self.data_dir_str)
-        self._resolved_data_dir.mkdir(parents=True, exist_ok=True)
 
         # Seccomp profile
         if self.seccomp_profile_path_str:
@@ -536,14 +555,23 @@ class TakoVMConfig(BaseModel):
                 str(_resource_files("tako_vm").joinpath("seccomp_profile.json"))
             )
 
-        return self
+    def _ensure_data_dir(self) -> None:
+        """Create the resolved data directory if missing (idempotent mkdir)."""
+        if self._resolved_data_dir is None:
+            self._resolve_path_strings()
+        self._resolved_data_dir.mkdir(parents=True, exist_ok=True)  # type: ignore
 
     # Backward-compatible properties that return Path objects
     @property
     def data_dir(self) -> Path:
-        """Get data directory as Path (backward compatible)."""
+        """Get data directory as Path (backward compatible).
+
+        Reading this property ensures the data directory exists, preserving the
+        historical mkdir-on-access behavior that existing callers rely on.
+        """
         if self._resolved_data_dir is None:
-            self.resolve_paths()
+            self._resolve_path_strings()
+        self._ensure_data_dir()
         return self._resolved_data_dir  # type: ignore
 
     @property
@@ -742,7 +770,13 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         # which can leak secrets (e.g. database_url passwords) into logs/CLI output.
         raise ConfigurationError(f"Invalid configuration: {_sanitize_validation_error(e)}") from e
     except Exception as e:
-        raise ConfigurationError(f"Invalid configuration: {e}") from e
+        # Do not interpolate the raw exception text: like ValidationError it can
+        # echo arbitrary config payloads (e.g. database_url passwords) into logs
+        # and CLI output. Log the type for diagnosis and surface only the type.
+        logger.error("Configuration load failed with %s", type(e).__name__, exc_info=True)
+        raise ConfigurationError(
+            f"Invalid configuration: {type(e).__name__} (see logs for details)"
+        ) from e
 
     for warning in config.security_warnings():
         logger.warning(warning)

--- a/tako_vm/constants.py
+++ b/tako_vm/constants.py
@@ -25,10 +25,18 @@ UV_CACHE_VOLUME_DIR = "/home/sandbox/.cache/uv"
 # Lives on the writable /tmp tmpfs, which the sandbox user can write.
 UV_CACHE_TMP_DIR = "/tmp/uv-cache"
 
+
 # Workspace directory for job files (can be set via TAKO_VM_WORKSPACE env var)
 # When running the server in a container with Docker socket mounted, this must
 # be a path that exists on the host and is mounted into the server container.
-WORKSPACE_DIR = os.environ.get("TAKO_VM_WORKSPACE", tempfile.gettempdir())
+#
+# Read live (not captured at import time) so a TAKO_VM_WORKSPACE set after the
+# module is imported, or changed between runs, takes effect, and so tests can
+# point it at a temp dir without monkeypatching a module-level constant.
+def get_workspace_dir() -> str:
+    """Return the configured workspace directory, reading TAKO_VM_WORKSPACE live."""
+    return os.environ.get("TAKO_VM_WORKSPACE", tempfile.gettempdir())
+
 
 # Maximum number of runtime requirements to prevent env var overflow and slow startups
 MAX_REQUIREMENTS = 50

--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -210,34 +210,43 @@ WORKDIR /app
             dockerfile_path = build_path / "Dockerfile"
             dockerfile_path.write_text(dockerfile_content, encoding="utf-8")
 
-            # Copy custom_libs
-            custom_libs_dest = build_path / "custom_libs"
-            custom_libs_dest.mkdir()
-            if self.custom_libs_path.exists():
-                for item in self.custom_libs_path.iterdir():
-                    if item.is_file():
-                        shutil.copy2(item, custom_libs_dest)
+            # Prepare the build context (copy custom_libs / shared_code). Wrap
+            # the filesystem work so an OSError here surfaces as a BuildError,
+            # letting build_all record a single failure for this job type
+            # instead of aborting the whole batch.
+            try:
+                # Copy custom_libs
+                custom_libs_dest = build_path / "custom_libs"
+                custom_libs_dest.mkdir()
+                if self.custom_libs_path.exists():
+                    for item in self.custom_libs_path.iterdir():
+                        if item.is_file():
+                            shutil.copy2(item, custom_libs_dest)
 
-            # Copy shared code with path validation
-            shared_code_dest = build_path / "shared_code"
-            shared_code_dest.mkdir()
-            # Get current working directory as the allowed base for shared_code
-            allowed_base = Path.cwd().resolve()
-            for code_path in job_type.shared_code:
-                src = Path(code_path).resolve()
-                # Security: Ensure shared_code paths don't escape the allowed directory
-                try:
-                    src.relative_to(allowed_base)
-                except ValueError:
-                    logger.warning(
-                        "Skipping shared_code path that escapes allowed directory: %s", code_path
-                    )
-                    continue
-                if src.exists():
-                    if src.is_file():
-                        shutil.copy2(src, shared_code_dest)
-                    else:
-                        shutil.copytree(src, shared_code_dest / src.name)
+                # Copy shared code with path validation
+                shared_code_dest = build_path / "shared_code"
+                shared_code_dest.mkdir()
+                # Get current working directory as the allowed base for shared_code
+                allowed_base = Path.cwd().resolve()
+                for code_path in job_type.shared_code:
+                    src = Path(code_path).resolve()
+                    # Security: Ensure shared_code paths don't escape the allowed directory
+                    try:
+                        src.relative_to(allowed_base)
+                    except ValueError:
+                        logger.warning(
+                            "Skipping shared_code path that escapes allowed directory: %s",
+                            code_path,
+                        )
+                        continue
+                    if src.exists():
+                        if src.is_file():
+                            shutil.copy2(src, shared_code_dest)
+                        else:
+                            shutil.copytree(src, shared_code_dest / src.name)
+            except OSError as e:
+                logger.error("Failed to prepare build context for %s: %s", job_type.name, e)
+                raise BuildError(f"Failed to prepare build context for {job_type.name}: {e}") from e
 
             # Build the image
             cmd = ["docker", "build", "-t", job_type.image_name]
@@ -246,7 +255,9 @@ WORKDIR /app
             cmd.append(str(build_path))
 
             try:
-                subprocess.run(cmd, capture_output=not quiet, text=True, check=True)
+                # Generous timeout: image builds can install many deps, but an
+                # unbounded subprocess.run could hang the caller forever.
+                subprocess.run(cmd, capture_output=not quiet, text=True, check=True, timeout=1800)
                 logger.info("Successfully built image: %s", job_type.image_name)
                 # The tag now points at new content: drop any cached inspect
                 # results so the worker re-verifies the rebuilt image.
@@ -266,6 +277,11 @@ WORKDIR /app
                         job_type.name,
                     )
                 return True
+            except subprocess.TimeoutExpired as e:
+                logger.error("Build timed out for %s after %ss", job_type.name, e.timeout)
+                raise BuildError(
+                    f"Failed to build {job_type.name}: docker build timed out after {e.timeout}s"
+                ) from e
             except subprocess.CalledProcessError as e:
                 error_msg = e.stderr if e.stderr else str(e)
                 logger.error("Failed to build image: %s", error_msg)
@@ -335,7 +351,8 @@ WORKDIR /app
         try:
             subprocess.run(["docker", "rmi", job_type.image_name], capture_output=True, check=True)
             return True
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
+            logger.warning("Failed to remove image %s: %s", job_type.image_name, e.stderr or e)
             return False
 
 

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -10,9 +10,22 @@ import platform
 import subprocess
 import time
 import uuid
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from tako_vm.security import validate_pip_requirement
 
 logger = logging.getLogger(__name__)
+
+# stderr substrings that indicate the docker CLI could not reach the daemon.
+# These are infrastructure failures, never the fault of the user's code. Shared
+# by classify_docker_run_result so the worker and the library Sandbox detect
+# daemon/infra failures identically.
+_DOCKER_INFRA_STDERR_PATTERNS = (
+    "cannot connect to the docker daemon",
+    "error during connect",
+    "docker daemon is not running",
+)
 
 # Default executor base image. Built from docker/Dockerfile.executor; carries
 # uv, gosu, the sandbox user, and the /entrypoint.sh contract (see
@@ -232,11 +245,24 @@ def kill_container(container_name: str) -> bool:
         if result.returncode == 0:
             logger.debug("Killed container %s", container_name)
             return True
-        logger.debug("Container %s was not running", container_name)
+        # Distinguish the benign "no such container" (already gone / never
+        # started) from a genuine kill failure (a still-running untrusted
+        # container we could not stop), which is a real containment concern.
+        stderr = decode_subprocess_stream(result.stderr).strip()
+        if "no such container" in stderr.lower():
+            logger.debug("Container %s was not running", container_name)
+        else:
+            logger.warning(
+                "Failed to kill container %s (exit %s): %s",
+                container_name,
+                result.returncode,
+                stderr,
+            )
         return False
     except Exception as e:
-        # Ignore errors - container may not exist or already be stopped
-        logger.debug("Failed to kill container %s: %s", container_name, e)
+        # A docker CLI error (daemon unreachable, timeout) leaves the container
+        # state unknown; surface it rather than silently swallowing.
+        logger.warning("Failed to kill container %s: %s", container_name, e)
         return False
 
 
@@ -269,11 +295,24 @@ def remove_container(container_name: str) -> bool:
         if result.returncode == 0:
             logger.debug("Removed container %s", container_name)
             return True
-        logger.debug("Container %s did not exist", container_name)
+        # ``docker rm -f`` is a no-op success for a missing container on modern
+        # daemons; a non-zero exit therefore signals a genuine removal failure
+        # (a leaked container), unless it is the benign "no such container".
+        stderr = decode_subprocess_stream(result.stderr).strip()
+        if "no such container" in stderr.lower():
+            logger.debug("Container %s did not exist", container_name)
+        else:
+            logger.warning(
+                "Failed to remove container %s (exit %s): %s; it may leak",
+                container_name,
+                result.returncode,
+                stderr,
+            )
         return False
     except Exception as e:
-        # Ignore errors - container may not exist or daemon may be unreachable
-        logger.debug("Failed to remove container %s: %s", container_name, e)
+        # A docker CLI error (daemon unreachable, timeout) means the container
+        # may still exist and leak; surface it rather than swallowing.
+        logger.warning("Failed to remove container %s: %s", container_name, e)
         return False
 
 
@@ -423,3 +462,164 @@ def base_isolation_args(
         args.append(f"--runtime={runtime}")
 
     return args
+
+
+def prepare_requirements_file(
+    requirements: Optional[Sequence[str]],
+    input_dir: Path,
+    *,
+    allow_runtime_requirements: bool,
+    max_requirements: int,
+) -> List[str]:
+    """Validate runtime requirements and write the ``_requirements.txt`` file.
+
+    Single source of truth for the runtime-requirements policy shared by the
+    server ``CodeExecutor`` and the library ``Sandbox``, so the two paths cannot
+    drift on how they cap, validate, gate, and persist requirements.
+
+    Policy (fail closed):
+
+    - An empty/None list is a no-op and returns ``[]`` (no file written).
+    - If requirements are present but ``allow_runtime_requirements`` is False,
+      raise ``ValueError`` (runtime installs are disabled).
+    - More than ``max_requirements`` entries raises ``ValueError``.
+    - Any entry failing ``validate_pip_requirement`` raises ``ValueError``:
+      invalid requirements are REJECTED, never silently skipped, so a typo or an
+      injection attempt fails loudly instead of running with a different
+      dependency set than the caller asked for.
+    - The validated list is written to ``input_dir/_requirements.txt`` and
+      chmod 0o444 (read-only) for the entrypoint to install.
+
+    The policy is checked before validation so an all-invalid list cannot bypass
+    the ``allow_runtime_requirements`` gate.
+
+    Args:
+        requirements: Requested pip requirements (may be None/empty).
+        input_dir: Directory mounted read-only at /input where the entrypoint
+            looks for ``_requirements.txt``.
+        allow_runtime_requirements: Whether runtime installs are permitted.
+        max_requirements: Maximum number of requirements allowed.
+
+    Returns:
+        The validated requirements list (empty when none were requested).
+
+    Raises:
+        ValueError: policy violation (installs disabled, too many, or an invalid
+            requirement).
+    """
+    if not requirements:
+        return []
+
+    # Enforce the policy before validation so an all-invalid list cannot bypass
+    # the allow_runtime_requirements check.
+    if not allow_runtime_requirements:
+        raise ValueError(
+            "Runtime dependency installation is disabled. "
+            "Use pre-built images or set allow_runtime_requirements=True."
+        )
+    if len(requirements) > max_requirements:
+        raise ValueError(f"Too many requirements ({len(requirements)} > {max_requirements})")
+
+    validated_reqs: List[str] = []
+    for req in requirements:
+        if not validate_pip_requirement(req):
+            raise ValueError(f"Invalid pip requirement: {req!r}")
+        validated_reqs.append(req)
+
+    requirements_file = input_dir / "_requirements.txt"
+    requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
+    requirements_file.chmod(0o444)
+    return validated_reqs
+
+
+def classify_docker_run_result(returncode: int, stderr: str) -> Tuple[bool, Optional[str]]:
+    """Decide whether a finished ``docker run`` failed in docker itself (infra).
+
+    ``docker run`` reserves exit code 125 for failures of docker itself (daemon
+    unreachable, image pull failure, bad flags); container exit codes pass
+    through unchanged otherwise, and our entrypoint never exits 125 in normal
+    operation. A non-zero exit whose stderr matches a known daemon-connectivity
+    phrasing is likewise an infrastructure failure. Such failures must never be
+    attributed to the user's code (e.g. by ``classify_error`` on daemon stderr).
+
+    Shared by the worker (which counts these against its circuit breaker and
+    marks them retriable) and the library Sandbox (which has no circuit breaker
+    but still surfaces them as a distinct infra failure rather than a code bug).
+
+    Args:
+        returncode: Exit code from ``subprocess.run`` of ``docker run``.
+        stderr: Captured stderr of the run.
+
+    Returns:
+        Tuple of ``(is_infra_failure, detail)``. ``detail`` is a short,
+        single-line description suitable for an error message (the first stderr
+        line, or a synthesized fallback), and is None when not an infra failure.
+    """
+    stderr_lower = (stderr or "").lower()
+    is_infra_failure = returncode == 125 or (
+        returncode != 0
+        and any(pattern in stderr_lower for pattern in _DOCKER_INFRA_STDERR_PATTERNS)
+    )
+    if not is_infra_failure:
+        return False, None
+
+    stderr_lines = (stderr or "").strip().splitlines()
+    detail = stderr_lines[0] if stderr_lines else f"docker run exited with code {returncode}"
+    return True, detail
+
+
+def classify_sigkill(container_name: str) -> Optional[bool]:
+    """Classify an exit-code-137 (SIGKILL) container as OOM or not.
+
+    Exit 137 is SIGKILL, but not necessarily the OOM killer: ``docker kill``
+    (cancel path), a pids-limit kill, or user code calling ``sys.exit(137)`` all
+    look identical. Only the exited container's ``State.OOMKilled`` distinguishes
+    them, so this must be called BEFORE the container is removed (the run must
+    use ``auto_remove=False``). In-container timeout kills are already remapped
+    to 124 by the entrypoint, so a 137 seen by callers is a genuine SIGKILL.
+
+    Thin wrapper over ``inspect_oom_killed`` so both the worker and the library
+    Sandbox apply the identical OOM policy:
+
+    Returns:
+        True if the kernel/cgroup OOM killer killed the process, False if it was
+        a non-OOM SIGKILL, or None if the inspect was inconclusive (container
+        already gone, daemon unreachable, timeout). Callers should treat None as
+        "assume OOM" so a flaky inspect never loses a true OOM.
+    """
+    return inspect_oom_killed(container_name)
+
+
+def read_result_json(output_dir: Path, ident: str) -> Optional[dict]:
+    """Read and parse ``output_dir/result.json``, symlink-safe.
+
+    Untrusted code in the container can point ``result.json`` at a host file to
+    exfiltrate it; this never follows a symlink. A present-but-unreadable or
+    unparseable file is logged and treated as "no JSON output" rather than
+    silently presented as None (the caller cannot tell the difference), so the
+    failure is surfaced in the log.
+
+    Shared by the worker and the library Sandbox so both parse the result file
+    identically.
+
+    Args:
+        output_dir: The job's output directory (bind-mounted at /output).
+        ident: Identifier for log messages (job/execution ID or container name).
+
+    Returns:
+        The parsed JSON object, or None if absent, a symlink, or unreadable.
+    """
+    output_file = output_dir / "result.json"
+    if output_file.is_symlink():
+        logger.warning("result.json for %s is a symlink, ignoring", ident)
+        return None
+    if not output_file.exists():
+        return None
+    try:
+        return json.loads(output_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        # Output existed but was unreadable/unparseable (truncated, non-UTF-8,
+        # device error). Surface it loudly instead of presenting None as "no
+        # output produced".
+        logger.warning("Failed to read/parse result.json for %s: %s", ident, e)
+        return None

--- a/tako_vm/execution/health.py
+++ b/tako_vm/execution/health.py
@@ -72,7 +72,13 @@ class DockerCircuitBreaker:
 
     @property
     def is_available(self) -> bool:
-        """Check if requests should be allowed through."""
+        """Check if requests should be allowed through.
+
+        Side effect: this getter is intentionally not pure. When the circuit is
+        OPEN and the recovery timeout has elapsed, reading it transitions the
+        breaker to HALF_OPEN (and resets the success count) so the next call is
+        allowed through as a recovery probe.
+        """
         with self._lock:
             if self._state == CircuitState.CLOSED:
                 return True
@@ -306,12 +312,16 @@ class DockerCleanup:
             return 0
 
     @classmethod
-    def cleanup_dangling_images(cls) -> int:
+    def cleanup_dangling_images(cls) -> bool:
         """
-        Remove dangling Docker images.
+        Remove dangling Docker images via ``docker image prune -f``.
+
+        Returns a bool rather than a count: ``docker image prune`` only reports
+        the total reclaimed space, not the number of images removed, so an
+        honest count is not available. The reclaimed-space summary is logged.
 
         Returns:
-            Number of images removed
+            True if the prune command ran successfully, False otherwise.
         """
         try:
             result = subprocess.run(
@@ -323,17 +333,18 @@ class DockerCleanup:
             )
 
             if result.returncode == 0:
-                # Parse output to count removed images
+                # Docker doesn't give a count, just the reclaimed space summary.
                 output = result.stdout
                 if "Total reclaimed space" in output:
                     logger.info(f"Image cleanup: {output.strip()}")
-                return 0  # Docker doesn't give count, just space
+                return True
 
-            return 0
+            logger.warning(f"Image cleanup returned non-zero: {result.stderr}")
+            return False
 
         except Exception as e:
             logger.warning(f"Image cleanup failed: {e}")
-            return 0
+            return False
 
 
 # Global circuit breaker instance

--- a/tako_vm/execution/retry.py
+++ b/tako_vm/execution/retry.py
@@ -1,15 +1,14 @@
 """
 Retry logic with exponential backoff for transient failures.
 
-Provides decorators and utilities for retrying operations that may fail temporarily.
+Provides utilities for retrying operations that may fail temporarily.
 """
 
-import functools
 import logging
 import random
 import time
 from dataclasses import dataclass
-from typing import Callable, Optional, Set, Tuple, Type
+from typing import Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -105,82 +104,6 @@ def calculate_delay(attempt: int, config: RetryConfig) -> float:
     return max(0, delay)
 
 
-def retry(
-    config: Optional[RetryConfig] = None,
-    retryable_exceptions: Optional[Tuple[Type[Exception], ...]] = None,
-    on_retry: Optional[Callable[[Exception, int], None]] = None,
-):
-    """
-    Decorator for retrying a function with exponential backoff.
-
-    Args:
-        config: Retry configuration (uses defaults if not provided)
-        retryable_exceptions: Tuple of exception types to retry on
-        on_retry: Callback called before each retry with (exception, attempt)
-
-    Returns:
-        Decorated function
-
-    Example:
-        @retry(RetryConfig(max_attempts=3))
-        def fetch_data():
-            return api.get("/data")
-    """
-    if config is None:
-        config = RetryConfig()
-
-    if retryable_exceptions is None:
-        retryable_exceptions = (Exception,)
-
-    def decorator(func: Callable):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            last_exception = None
-
-            for attempt in range(config.max_attempts):
-                try:
-                    return func(*args, **kwargs)
-
-                except retryable_exceptions as e:
-                    last_exception = e
-
-                    # Check if this is the last attempt
-                    if attempt == config.max_attempts - 1:
-                        logger.warning(
-                            f"Retry exhausted for {func.__name__} after "
-                            f"{config.max_attempts} attempts: {e}"
-                        )
-                        raise
-
-                    # Check if error is transient
-                    if not is_transient_error(e):
-                        logger.debug(f"Non-transient error in {func.__name__}, not retrying: {e}")
-                        raise
-
-                    # Calculate delay
-                    delay = calculate_delay(attempt, config)
-
-                    logger.info(
-                        f"Retry {attempt + 1}/{config.max_attempts} for "
-                        f"{func.__name__} after {delay:.2f}s: {e}"
-                    )
-
-                    # Call retry callback if provided
-                    if on_retry:
-                        on_retry(e, attempt + 1)
-
-                    # Wait before retry
-                    time.sleep(delay)
-
-            # Should not reach here, but just in case
-            if last_exception:
-                raise last_exception
-
-        return wrapper
-
-    return decorator
-
-
 class RetryContext:
     """
     Context manager for retry logic.
@@ -224,19 +147,13 @@ class RetryContext:
         self.last_error = error
         self.attempt += 1
 
+        # Side effect: when another (transient) attempt remains, this blocks via
+        # time.sleep for the backoff delay before returning. Callers run this in
+        # synchronous code or a thread pool (see the class docstring), never on
+        # an async event loop.
         if self.should_retry() and is_transient_error(error):
             delay = calculate_delay(self.attempt - 1, self.config)
             logger.info(
                 f"Retry {self.attempt}/{self.config.max_attempts} after {delay:.2f}s: {error}"
             )
             time.sleep(delay)
-
-    def record_success(self) -> None:
-        """Record a successful operation."""
-        self.attempt = 0
-        self.last_error = None
-
-    @property
-    def is_exhausted(self) -> bool:
-        """Check if all retry attempts have been used."""
-        return self.attempt >= self.config.max_attempts

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -22,18 +22,21 @@ from tako_vm.constants import (
     UV_CACHE_TMP_DIR,
     UV_CACHE_VOLUME,
     UV_CACHE_VOLUME_DIR,
-    WORKSPACE_DIR,
+    get_workspace_dir,
 )
 from tako_vm.execution.docker import (
     EXECUTOR_ENTRYPOINT,
     base_isolation_args,
+    classify_docker_run_result,
+    classify_sigkill,
     decode_subprocess_stream,
     generate_container_name,
     image_exists,
     image_has_executor_entrypoint,
-    inspect_oom_killed,
     is_native_linux,
     kill_container,
+    prepare_requirements_file,
+    read_result_json,
     remove_container,
     ulimit_args,
 )
@@ -61,21 +64,12 @@ from tako_vm.security import (
     validate_env_key,
     validate_env_value,
     validate_execution_id,
-    validate_pip_requirement,
 )
 
 logger = logging.getLogger(__name__)
 
 # Cache for runtime availability check
 _gvisor_available: Optional[bool] = None
-
-# stderr patterns that indicate the docker CLI could not reach the daemon.
-# These are infrastructure failures, never the fault of the user's code.
-_DOCKER_INFRA_STDERR_PATTERNS = (
-    "cannot connect to the docker daemon",
-    "error during connect",
-    "docker daemon is not running",
-)
 
 
 def _require_safe_execution_id(execution_id: str) -> str:
@@ -98,7 +92,7 @@ def _resolve_run_path(data_dir: Path, execution_id: str, *parts: str) -> Path:
 
 
 def prune_stale_workspaces(max_age_seconds: int) -> int:
-    """Remove stale per-run workspace dirs stranded under WORKSPACE_DIR.
+    """Remove stale per-run workspace dirs stranded under the workspace dir.
 
     Each execution creates a temp dir (``job-*`` / ``sandbox-*``) that is
     normally removed in a finally block, but a hard crash or an rmtree failure
@@ -107,7 +101,7 @@ def prune_stale_workspaces(max_age_seconds: int) -> int:
     sit well past any run's max timeout). Fail-soft: per-dir errors are logged
     and skipped. Returns the number of dirs removed.
     """
-    workspace_root = Path(WORKSPACE_DIR)
+    workspace_root = Path(get_workspace_dir())
     if not workspace_root.is_dir():
         return 0
     cutoff = time.time() - max_age_seconds
@@ -547,7 +541,7 @@ class CodeExecutor:
         startup_timeout = job.get("startup_timeout", job_type.startup_timeout)
 
         # Create temporary workspace
-        workspace = Path(tempfile.mkdtemp(prefix="job-", dir=WORKSPACE_DIR))
+        workspace = Path(tempfile.mkdtemp(prefix="job-", dir=get_workspace_dir()))
 
         try:
             # Prepare directories
@@ -685,7 +679,7 @@ class CodeExecutor:
         startup_timeout = job.get("startup_timeout", job_type.startup_timeout)
 
         # Create temporary workspace
-        workspace = Path(tempfile.mkdtemp(prefix="job-", dir=WORKSPACE_DIR))
+        workspace = Path(tempfile.mkdtemp(prefix="job-", dir=get_workspace_dir()))
 
         try:
             # Prepare directories
@@ -792,8 +786,11 @@ class CodeExecutor:
                     break  # Success or non-transient error
 
                 except subprocess.TimeoutExpired:
-                    # Safety net only: _run_container catches TimeoutExpired
-                    # itself and returns a dict with timed_out=True instead.
+                    # Defensive safety net, effectively unreachable: _run_container
+                    # catches TimeoutExpired itself and returns a dict with
+                    # timed_out=True instead, so this branch only fires if that
+                    # contract is ever broken. Kept so a future regression
+                    # surfaces as a timeout rather than an unhandled exception.
                     timed_out = True
                     result = {
                         "success": False,
@@ -821,20 +818,17 @@ class CodeExecutor:
             record.exit_code = result.get("exit_code")
 
             # Cap and sanitize outputs. cap_output truncates in-band (appends
-            # a notice), so also surface truncation on the record flags — the
-            # API must not report truncated output as complete. The flag
-            # mirrors cap_output's own truncation condition (UTF-8 encoded
-            # size vs the cap), which is robust against the notice text
-            # legitimately appearing in user output.
+            # a notice) and returns whether it truncated, so the record's
+            # truncation flags come from that single source of truth: the API
+            # must not report truncated output as complete, and the flag can
+            # never disagree with the in-band notice.
             raw_stdout = result.get("stdout", "")
             raw_stderr = result.get("stderr", "")
-            record.stdout = cap_output(raw_stdout, self.config.max_stdout_bytes)
-            record.stderr = cap_output(raw_stderr, self.config.max_stderr_bytes)
-            record.stdout_truncated = (
-                len(raw_stdout.encode("utf-8", errors="replace")) > self.config.max_stdout_bytes
+            record.stdout, record.stdout_truncated = cap_output(
+                raw_stdout, self.config.max_stdout_bytes
             )
-            record.stderr_truncated = (
-                len(raw_stderr.encode("utf-8", errors="replace")) > self.config.max_stderr_bytes
+            record.stderr, record.stderr_truncated = cap_output(
+                raw_stderr, self.config.max_stderr_bytes
             )
 
             # Resource usage
@@ -843,19 +837,10 @@ class CodeExecutor:
             # Collect artifacts from output directory
             record.artifacts = self._collect_artifacts(output_dir, job_id)
 
-            # Read main JSON result (if present)
-            output_file = output_dir / "result.json"
-            # Untrusted code could point result.json at a host file; never follow it.
-            if output_file.is_symlink():
-                logger.warning("result.json is a symlink, ignoring")
-            elif output_file.exists():
-                try:
-                    record.result_json = json.loads(output_file.read_text(encoding="utf-8"))
-                except (json.JSONDecodeError, OSError, ValueError) as e:
-                    # Output existed but was unreadable/unparseable (truncated,
-                    # non-UTF-8, device error). Surface it loudly instead of
-                    # presenting result_json=None as "no output produced".
-                    logger.warning("Failed to read/parse result.json for job %s: %s", job_id, e)
+            # Read main JSON result (if present). Symlink-safe and surfaces an
+            # unreadable/unparseable file via the shared helper so the worker
+            # and the library Sandbox parse it identically.
+            record.result_json = read_result_json(output_dir, job_id)
 
             # Parse phase timing file (written by entrypoint.sh). The
             # root-only meta_dir copy is preferred; the /output copy is a
@@ -863,11 +848,15 @@ class CodeExecutor:
             timing = parse_phase_file(output_dir, meta_dir)
             record.timing = timing
 
-            # Determine which phase timed out (if applicable)
-            internal_timeout = result.get("exit_code") == 124 and determine_timeout_phase(
-                timing, True
-            )
-            timeout_phase = determine_timeout_phase(timing, timed_out) or internal_timeout
+            # Exit 124 is the in-container timeout (entrypoint's timeout(1)
+            # remaps a timed-out phase to 124). It is a timeout regardless of
+            # whether a phase file exists to attribute it: a missing phase file
+            # must not demote a real timeout to a generic failure, so this is a
+            # plain boolean independent of determine_timeout_phase.
+            internal_timeout = result.get("exit_code") == 124
+            # phase attribution is best-effort and may be None when no timing
+            # data was written.
+            timeout_phase = determine_timeout_phase(timing, timed_out or internal_timeout)
 
             # Determine final status with phase-aware timeout handling
             if timed_out or internal_timeout:
@@ -1346,48 +1335,28 @@ class CodeExecutor:
         if extra_requirements:
             all_requirements.extend(extra_requirements)
 
-        if len(all_requirements) > MAX_REQUIREMENTS:
-            logger.error(
-                "Job has %s requirements (max %s). Use pre-built images for large dependency sets.",
-                len(all_requirements),
-                MAX_REQUIREMENTS,
+        # Validate, cap, gate, and persist runtime requirements via the shared
+        # helper so this path and the library Sandbox apply identical policy.
+        # The helper REJECTS an invalid requirement (raises ValueError) rather
+        # than silently skipping it: a typo or injection attempt now fails the
+        # job loudly instead of running with a different dependency set than the
+        # caller asked for.
+        try:
+            validated_reqs = prepare_requirements_file(
+                all_requirements,
+                input_dir,
+                allow_runtime_requirements=self.config.allow_runtime_requirements,
+                max_requirements=MAX_REQUIREMENTS,
             )
+        except ValueError as e:
+            logger.warning("Refusing job %s: %s", job_id, e)
             return {
                 "success": False,
-                "error": f"Too many requirements ({len(all_requirements)} > {MAX_REQUIREMENTS})",
+                "error": str(e),
                 "stdout": "",
-                "stderr": "Use pre-built images for jobs with many dependencies",
+                "stderr": str(e),
                 "exit_code": -1,
             }
-
-        validated_reqs = []
-        for req in all_requirements:
-            if validate_pip_requirement(req):
-                validated_reqs.append(req)
-            else:
-                logger.warning("Skipping invalid pip requirement: %s", req)
-
-        requirements_file = input_dir / "_requirements.txt"
-        if validated_reqs:
-            if not self.config.allow_runtime_requirements:
-                logger.warning(
-                    "Refusing job %s: %d runtime requirement(s) requested but "
-                    "allow_runtime_requirements=false",
-                    job_id,
-                    len(validated_reqs),
-                )
-                return {
-                    "success": False,
-                    "error": "Runtime dependency installation is disabled",
-                    "stdout": "",
-                    "stderr": (
-                        "Runtime dependency installation is disabled. "
-                        "Use pre-built images or set allow_runtime_requirements=true."
-                    ),
-                    "exit_code": -1,
-                }
-            requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
-            requirements_file.chmod(0o444)
 
         # Check if runtime deps require network access
         has_runtime_deps = bool(validated_reqs)
@@ -1512,26 +1481,16 @@ class CodeExecutor:
                 cmd, timeout=container_timeout, capture_output=True, text=True, check=False
             )
 
-            # `docker run` reserves exit code 125 for failures of docker itself
-            # (daemon unreachable, image pull failure, bad flags); container
-            # exit codes pass through unchanged otherwise, and our entrypoint
-            # never exits 125 in normal operation. Treat 125 — or daemon
-            # connectivity errors on stderr of a failed run — as infrastructure
-            # failures: they must count against the circuit breaker, be marked
-            # retriable via the "error" key, and never be attributed to the
-            # user's code by classify_error.
-            stderr_lower = (result.stderr or "").lower()
-            is_infra_failure = result.returncode == 125 or (
-                result.returncode != 0
-                and any(pattern in stderr_lower for pattern in _DOCKER_INFRA_STDERR_PATTERNS)
+            # Distinguish docker-itself failures (daemon unreachable, image
+            # pull failure, bad flags: exit 125 or daemon-connectivity stderr)
+            # from container exits via the shared classifier. Infra failures
+            # must count against the circuit breaker, be marked retriable via
+            # the "error" key, and never be attributed to the user's code by
+            # classify_error.
+            is_infra_failure, detail = classify_docker_run_result(
+                result.returncode, result.stderr or ""
             )
             if is_infra_failure:
-                stderr_lines = (result.stderr or "").strip().splitlines()
-                detail = (
-                    stderr_lines[0]
-                    if stderr_lines
-                    else f"docker run exited with code {result.returncode}"
-                )
                 circuit_breaker.record_failure(detail)
                 return {
                     "success": False,
@@ -1548,13 +1507,13 @@ class CodeExecutor:
 
             # Exit 137 is SIGKILL — could be the OOM killer, but also `docker
             # kill` (cancel path), a pids-limit kill, or user sys.exit(137).
-            # Only the exited container's State.OOMKilled distinguishes them;
-            # inspect before the finally block removes the container. Note:
-            # in-container timeout kills are already remapped to 124 by the
-            # entrypoint, so a 137 seen here is a genuine SIGKILL.
+            # classify_sigkill inspects the exited container's State.OOMKilled
+            # before the finally block removes it. Note: in-container timeout
+            # kills are already remapped to 124 by the entrypoint, so a 137 seen
+            # here is a genuine SIGKILL.
             oom_killed: Optional[bool] = None
             if result.returncode == 137:
-                oom_killed = inspect_oom_killed(container_name)
+                oom_killed = classify_sigkill(container_name)
 
             return {
                 "success": result.returncode == 0,

--- a/tako_vm/job_types.py
+++ b/tako_vm/job_types.py
@@ -149,6 +149,12 @@ class JobType:
         same pydantic constraints as the YAML config path. Raises
         pydantic.ValidationError on out-of-bounds or malformed values.
         """
+        # GPU config has a canonical nested form (the ``gpu`` object) which is
+        # the ONLY shape to_dict ever emits, so round-tripped registry files
+        # always use it. Flat top-level keys (gpu_enabled/gpu_vendor/gpu_count/
+        # gpu_device_ids) are accepted for backward compatibility with
+        # hand-written entries and take PRECEDENCE over the nested values when
+        # both are present (flat first, nested as the fallback default).
         gpu = data.get("gpu") or {}
 
         candidate = cls(

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -7,11 +7,42 @@ used throughout the system. Designed for SVG/artifact-based workflows.
 
 import hashlib
 import json
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
+
+# Full sha256 hexdigest: exactly 64 lowercase hex characters. Compiled once and
+# reused by every hash-field and sha256-field validator below.
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+def _validate_optional_sha256_hex(v: Optional[str]) -> Optional[str]:
+    """Validate a hash field is empty/None or a 64-char lowercase hex string.
+
+    Shared by ExecutionRecord and JobVersion hash-field validators so the rule
+    (and its error message) live in one place.
+    """
+    if v is None or v == "":
+        return v
+    if not _SHA256_RE.match(v):
+        raise ValueError("Hash must be empty or 64-character lowercase hex string")
+    return v
+
+
+def _validate_safe_filename(v: str) -> str:
+    """Validate a filename is safe (no path traversal).
+
+    Shared by InputArtifact and Artifact so the path-traversal rule lives in one
+    place.
+    """
+    if "/" in v or "\\" in v:
+        raise ValueError("Filename cannot contain path separators")
+    if v in ("..", "."):
+        raise ValueError("Invalid filename")
+    return v
 
 
 def sha256_json(obj: object) -> str:
@@ -102,7 +133,7 @@ class InputArtifact(BaseModel):
     size_bytes: int = Field(..., ge=0, le=1073741824)  # Max 1GB
     """File size in bytes."""
 
-    sha256: str = Field(..., min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$")
+    sha256: str = Field(..., min_length=64, max_length=64, pattern=_SHA256_RE.pattern)
     """SHA256 hash of file contents (hex-encoded)."""
 
     content_type: Optional[str] = Field(default=None, max_length=255)
@@ -115,11 +146,7 @@ class InputArtifact(BaseModel):
     @classmethod
     def validate_filename(cls, v: str) -> str:
         """Validate filename is safe (no path traversal)."""
-        if "/" in v or "\\" in v:
-            raise ValueError("Filename cannot contain path separators")
-        if v in ("..", "."):
-            raise ValueError("Invalid filename")
-        return v
+        return _validate_safe_filename(v)
 
 
 class Artifact(BaseModel):
@@ -133,7 +160,7 @@ class Artifact(BaseModel):
     size_bytes: int = Field(..., ge=0, le=1073741824)  # Max 1GB
     """File size in bytes."""
 
-    sha256: str = Field(..., min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$")
+    sha256: str = Field(..., min_length=64, max_length=64, pattern=_SHA256_RE.pattern)
     """SHA256 hash of file contents (hex-encoded)."""
 
     content_type: Optional[str] = Field(default=None, max_length=255)
@@ -146,11 +173,7 @@ class Artifact(BaseModel):
     @classmethod
     def validate_filename(cls, v: str) -> str:
         """Validate filename is safe (no path traversal)."""
-        if "/" in v or "\\" in v:
-            raise ValueError("Filename cannot contain path separators")
-        if v in ("..", "."):
-            raise ValueError("Invalid filename")
-        return v
+        return _validate_safe_filename(v)
 
 
 # Canonical error type values (from security.classify_error)
@@ -219,7 +242,16 @@ class ExecutionError(BaseModel):
     """Which phase the error occurred in (startup or execution)."""
 
 
-# Canonical job status values
+# Canonical job status values.
+#
+# JobStatus and ErrorType deliberately use DISTINCT vocabularies. The
+# phase-specific ErrorType values (startup_timeout, execution_timeout) and
+# 'interrupted' are NEVER assigned to a record's status: worker.py collapses
+# both timeout phases to status='timeout' and records the phase only on
+# error.type, and reconcile_stale_records sets status='failed' with
+# error.type='interrupted'. So this list does not need to be a superset of
+# ErrorType; every value worker.py writes to ExecutionRecord.status is present
+# here, which is what keeps stored records loadable.
 JobStatus = Literal[
     "queued",  # Submitted, waiting in queue
     "running",  # Currently executing
@@ -328,13 +360,7 @@ class ExecutionRecord(BaseModel):
     @classmethod
     def validate_hash_field(cls, v: Optional[str]) -> Optional[str]:
         """Validate hash fields are either empty/None or valid SHA256 hex strings."""
-        import re
-
-        if v is None or v == "":
-            return v
-        if len(v) != 64 or not re.match(r"^[a-f0-9]{64}$", v):
-            raise ValueError("Hash must be empty or 64-character lowercase hex string")
-        return v
+        return _validate_optional_sha256_hex(v)
 
     # Input artifacts (for file-based inputs like SVG)
     input_artifacts: List[InputArtifact] = Field(default_factory=list)
@@ -430,7 +456,7 @@ class JobVersion(BaseModel):
     version_tag: Optional[str] = Field(default=None, max_length=64)
     """Semantic version tag, e.g., 'v1.0.0'."""
 
-    digest: str = Field(..., min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$")
+    digest: str = Field(..., min_length=64, max_length=64, pattern=_SHA256_RE.pattern)
     """SHA256 digest of job type configuration (full hex string)."""
 
     # Build metadata
@@ -454,13 +480,7 @@ class JobVersion(BaseModel):
     @classmethod
     def validate_hash_field(cls, v: str) -> str:
         """Validate hash fields are either empty or valid SHA256 hex strings."""
-        import re
-
-        if v == "":
-            return v
-        if len(v) != 64 or not re.match(r"^[a-f0-9]{64}$", v):
-            raise ValueError("Hash must be empty or 64-character lowercase hex string")
-        return v
+        return _validate_optional_sha256_hex(v) or ""
 
     @property
     def full_ref(self) -> str:
@@ -502,6 +522,24 @@ class DeadLetterEntry(BaseModel):
     contain raw fields; new entries never do.
     """
 
+    error_type: ErrorType
+    """Type of error that caused failure."""
+
+    error_message: Optional[str] = Field(default=None, max_length=4096)
+    """Error message."""
+
+    retry_count: int = Field(default=0, ge=0, le=100)
+    """Number of retry attempts made."""
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    """When the entry was added to DLQ."""
+
+    client_ip: Optional[str] = Field(default=None, max_length=45)  # IPv6 max length
+    """Original client IP."""
+
+    correlation_id: Optional[str] = Field(default=None, max_length=64)
+    """Correlation ID for tracing."""
+
     @classmethod
     def build_job_summary(cls, job_data: Dict[str, Any]) -> Dict[str, Any]:
         """Build a redacted forensic summary from a raw job payload.
@@ -535,21 +573,3 @@ class DeadLetterEntry(BaseModel):
             if value is not None:
                 summary[key] = value
         return summary
-
-    error_type: ErrorType
-    """Type of error that caused failure."""
-
-    error_message: Optional[str] = Field(default=None, max_length=4096)
-    """Error message."""
-
-    retry_count: int = Field(default=0, ge=0, le=100)
-    """Number of retry attempts made."""
-
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    """When the entry was added to DLQ."""
-
-    client_ip: Optional[str] = Field(default=None, max_length=45)  # IPv6 max length
-    """Original client IP."""
-
-    correlation_id: Optional[str] = Field(default=None, max_length=64)
-    """Correlation ID for tracing."""

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -31,19 +31,22 @@ from tako_vm.constants import (
     UV_CACHE_TMP_DIR,
     UV_CACHE_VOLUME,
     UV_CACHE_VOLUME_DIR,
-    WORKSPACE_DIR,
+    get_workspace_dir,
 )
 from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import (
     base_isolation_args,
+    classify_docker_run_result,
+    classify_sigkill,
     decode_subprocess_stream,
     generate_container_name,
     image_exists,
-    inspect_oom_killed,
+    prepare_requirements_file,
+    read_result_json,
     remove_container,
     ulimit_args,
 )
-from tako_vm.security import validate_pip_requirement
+from tako_vm.security import validate_docker_run_args
 
 logger = logging.getLogger(__name__)
 
@@ -364,7 +367,7 @@ class Sandbox:
         input_data = input_data or {}
 
         # Create temporary workspace
-        workspace = Path(tempfile.mkdtemp(prefix="sandbox-", dir=WORKSPACE_DIR))
+        workspace = Path(tempfile.mkdtemp(prefix="sandbox-", dir=get_workspace_dir()))
 
         try:
             # Prepare directories
@@ -427,20 +430,34 @@ class Sandbox:
                     )
                     duration_ms = int((time.time() - start_time) * 1000)
 
-                    # Read output
-                    output_data = None
-                    output_file = output_dir / "result.json"
-                    if output_file.exists():
-                        try:
-                            output_data = json.loads(output_file.read_text())
-                        except (json.JSONDecodeError, OSError, ValueError) as e:
-                            # Output existed but was unreadable/unparseable.
-                            # Don't silently present None as "no output".
-                            logger.warning(
-                                "result.json for %s was not valid JSON, ignoring: %s",
-                                container_name,
-                                e,
-                            )
+                    # Distinguish docker-itself failures (daemon unreachable,
+                    # image pull failure, bad flags) from container exits via
+                    # the shared classifier. The library Sandbox has no circuit
+                    # breaker, but it must still surface an infra failure
+                    # distinctly rather than presenting daemon stderr as if the
+                    # user's code had failed.
+                    is_infra_failure, detail = classify_docker_run_result(
+                        proc.returncode, proc.stderr or ""
+                    )
+                    if is_infra_failure:
+                        logger.warning(
+                            "Sandbox %s hit a Docker infrastructure failure: %s",
+                            container_name,
+                            detail,
+                        )
+                        return SandboxResult(
+                            stdout=proc.stdout,
+                            stderr=proc.stderr,
+                            exit_code=proc.returncode,
+                            success=False,
+                            duration_ms=duration_ms,
+                            error=f"Docker infrastructure failure: {detail}",
+                        )
+
+                    # Read output (symlink-safe; surfaces an unreadable file)
+                    # via the shared helper so the library and worker paths
+                    # parse result.json identically.
+                    output_data = read_result_json(output_dir, container_name)
 
                     # The in-container timeout (TAKO_EXECUTION_TIMEOUT, enforced
                     # by entrypoint.sh via timeout(1)) exits 124 when the code
@@ -453,15 +470,14 @@ class Sandbox:
                     elif proc.returncode == 137:
                         # Exit 137 is SIGKILL — could be the OOM killer, but
                         # also `docker kill` or user code calling
-                        # sys.exit(137). Only the exited container's
-                        # State.OOMKilled distinguishes them; inspect before
-                        # the finally block removes the container. In-container
-                        # timeout kills are already remapped to 124 by the
-                        # entrypoint, so a 137 seen here is a genuine SIGKILL.
-                        # None (inspect failed) falls back to reporting OOM so
-                        # a flaky inspect never loses a true OOM — same policy
-                        # as the server-side CodeExecutor.
-                        oom_killed = inspect_oom_killed(container_name)
+                        # sys.exit(137). classify_sigkill inspects the exited
+                        # container's State.OOMKilled before the finally block
+                        # removes it. In-container timeout kills are already
+                        # remapped to 124 by the entrypoint, so a 137 seen here
+                        # is a genuine SIGKILL. None (inspect failed) falls back
+                        # to reporting OOM so a flaky inspect never loses a true
+                        # OOM (same policy as the server-side CodeExecutor).
+                        oom_killed = classify_sigkill(container_name)
                         if oom_killed is False:
                             error = "Process was killed (SIGKILL) but not by the memory limit"
                         else:
@@ -534,28 +550,15 @@ class Sandbox:
         Returns:
             Tuple of (command, container_name) for cleanup on timeout.
         """
-        validated_reqs = []
-        if requirements:
-            # Enforce the policy before validation so an all-invalid list
-            # cannot bypass the allow_runtime_requirements check.
-            if not self.config.allow_runtime_requirements:
-                raise ValueError(
-                    "Runtime dependency installation is disabled. "
-                    "Use pre-built images or set allow_runtime_requirements=True."
-                )
-            if len(requirements) > MAX_REQUIREMENTS:
-                raise ValueError(
-                    f"Too many requirements ({len(requirements)} > {MAX_REQUIREMENTS})"
-                )
-            for req in requirements:
-                if not validate_pip_requirement(req):
-                    raise ValueError(f"Invalid pip requirement: {req!r}")
-                validated_reqs.append(req)
-
-        if validated_reqs:
-            requirements_file = input_dir / "_requirements.txt"
-            requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
-            requirements_file.chmod(0o444)
+        # Validate, cap, gate, and persist requirements via the shared helper so
+        # the library path and the server worker apply identical policy (invalid
+        # requirements are rejected with ValueError, never silently skipped).
+        validated_reqs = prepare_requirements_file(
+            requirements,
+            input_dir,
+            allow_runtime_requirements=self.config.allow_runtime_requirements,
+            max_requirements=MAX_REQUIREMENTS,
+        )
 
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako-sandbox")
@@ -653,6 +656,13 @@ class Sandbox:
 
         # Image
         cmd.append(self.config.image)
+
+        # Defense-in-depth: validate the assembled argv before it is executed,
+        # mirroring the server worker (issue: library mode previously skipped
+        # this control). Raises so run() reports a failed SandboxResult instead
+        # of executing an argv that failed the safety check.
+        if not validate_docker_run_args(cmd):
+            raise ValueError("Unsafe Docker command rejected: arguments failed safety validation")
 
         return cmd, container_name
 

--- a/tako_vm/sdk/client.py
+++ b/tako_vm/sdk/client.py
@@ -506,7 +506,7 @@ class TakoVM:
 
         try:
             return cast(OutputT, output_cls(**cast(Dict[str, Any], result.output)))
-        except (TypeError, ValueError) as e:
+        except (TypeError, ValueError, KeyError) as e:
             raise ValidationError(
                 f"Failed to deserialize output to {output_cls.__name__}: {e}"
             ) from e
@@ -931,11 +931,18 @@ _execute()
             params["timeout"] = wait_timeout
         if view:
             params["view"] = view
+        # The server long-poll is capped at _MAX_RESULT_WAIT_SECONDS, so a wait
+        # never blocks longer than that regardless of the requested timeout. Clamp
+        # the requested wait to the same cap before adding the buffer margin, so
+        # the HTTP read timeout always outlives the server's poll plus a little
+        # slack (HTTP_TIMEOUT_BUFFER) for response transmission, without inflating
+        # the socket timeout past what the server can actually take.
+        wait_seconds = min(timeout, _MAX_RESULT_WAIT_SECONDS) if timeout else self.default_timeout
         return self._request(
             "GET",
             f"/jobs/{job_id}/result",
             params=params,
-            http_timeout=(timeout or self.default_timeout) + 10,
+            http_timeout=wait_seconds + HTTP_TIMEOUT_BUFFER,
         )
 
     def cancel(self, job_id: str) -> dict:

--- a/tako_vm/security.py
+++ b/tako_vm/security.py
@@ -82,25 +82,30 @@ def sanitize_error(error: str) -> str:
     return result
 
 
-def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> str:
+def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> Tuple[str, bool]:
     """
     Cap output to maximum byte size.
 
     Truncates at UTF-8 character boundary and adds truncation notice.
+
+    Single source of truth for the truncation decision: callers must use the
+    returned boolean rather than recomputing the encoded-size comparison, so
+    the in-band notice and the out-of-band flag can never disagree.
 
     Args:
         output: Raw output string
         max_bytes: Maximum size in bytes
 
     Returns:
-        Capped output with truncation notice if truncated
+        Tuple of (capped output with truncation notice if truncated, truncated
+        flag).
     """
     if not output:
-        return ""
+        return "", False
 
     encoded = output.encode("utf-8", errors="replace")
     if len(encoded) <= max_bytes:
-        return output
+        return output, False
 
     # Leave room for truncation message
     truncation_msg = f"\n\n[TRUNCATED: output exceeded {max_bytes} bytes]"
@@ -108,7 +113,7 @@ def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> str:
     available_bytes = max_bytes - truncation_bytes
 
     if available_bytes <= 0:
-        return truncation_msg
+        return truncation_msg, True
 
     # Truncate at byte boundary, then decode
     truncated_bytes = encoded[:available_bytes]
@@ -123,7 +128,7 @@ def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> str:
     else:
         truncated = ""
 
-    return truncated + truncation_msg
+    return truncated + truncation_msg, True
 
 
 def validate_artifact_size(

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -125,26 +125,40 @@ class IdempotencyLockManager:
 
     def __init__(self):
         self._locks: Dict[str, asyncio.Lock] = {}
+        # Number of coroutines currently holding or waiting on each key's lock.
+        # The lock is only evicted when this drops to zero, so a waiter that
+        # already grabbed a reference can never be left contending against a
+        # fresh lock created for the same key (which would break mutual
+        # exclusion).
+        self._waiters: Dict[str, int] = {}
         self._global_lock = asyncio.Lock()
 
     @asynccontextmanager
     async def acquire(self, key: str):
         """Acquire lock for a specific idempotency key."""
-        # Get or create lock for this key
+        # Get or create lock for this key and register as a waiter.
         async with self._global_lock:
-            if key not in self._locks:
-                self._locks[key] = asyncio.Lock()
-            lock = self._locks[key]
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            self._waiters[key] = self._waiters.get(key, 0) + 1
 
-        # Acquire the per-key lock
-        async with lock:
-            yield
-
-        # Cleanup unused locks (optional, prevents memory leak for many unique keys)
-        async with self._global_lock:
-            if key in self._locks and not self._locks[key].locked():
-                # Only delete if no other request is waiting
-                del self._locks[key]
+        try:
+            # Acquire the per-key lock
+            async with lock:
+                yield
+        finally:
+            # Deregister; evict the lock only when no other coroutine still
+            # references it, preventing the unbounded growth of _locks while
+            # keeping concurrent waiters on the same lock object.
+            async with self._global_lock:
+                remaining = self._waiters.get(key, 0) - 1
+                if remaining <= 0:
+                    self._waiters.pop(key, None)
+                    self._locks.pop(key, None)
+                else:
+                    self._waiters[key] = remaining
 
 
 # Application state (initialized in lifespan)
@@ -520,6 +534,22 @@ class JobTypeResponse(BaseModel):
     gpu_vendor: Optional[str] = None
     image_exists: bool
 
+    @classmethod
+    def from_job_type(cls, jt, builder) -> "JobTypeResponse":
+        """Build a response from a job type, resolving image availability."""
+        return cls(
+            name=jt.name,
+            requirements=jt.requirements,
+            python_version=jt.python_version,
+            memory_limit=jt.memory_limit,
+            cpu_limit=jt.cpu_limit,
+            timeout=jt.timeout,
+            session_enabled=jt.session_enabled,
+            gpu_enabled=jt.gpu_enabled,
+            gpu_vendor=jt.gpu_vendor,
+            image_exists=builder.image_exists(jt),
+        )
+
 
 class CircuitBreakerStatus(BaseModel):
     """Circuit breaker status for health monitoring."""
@@ -557,15 +587,9 @@ class HealthResponse(BaseModel):
     queue_stats: QueueStatsResponse
 
 
-class PoolStatsResponse(BaseModel):
-    """Response model for worker pool stats (deprecated, use QueueStatsResponse)."""
-
-    model_config = {"extra": "forbid"}
-
-    pending: int = Field(..., description="Number of jobs waiting in queue")
-    running: int = Field(..., description="Number of jobs currently executing")
-    max_workers: int = Field(..., description="Maximum concurrent workers")
-    max_queue_size: int = Field(..., description="Maximum queue capacity")
+# /pool/stats and /health.queue_stats return byte-identical shapes, so they
+# share a single model rather than maintaining two copies that can drift.
+PoolStatsResponse = QueueStatsResponse
 
 
 class PaginatedResponse(BaseModel):
@@ -1180,6 +1204,44 @@ def _get_replay_data(record: ExecutionRecord) -> tuple:
     return code, input_data, user_artifacts
 
 
+async def _submit_replay(
+    parent: ExecutionRecord,
+    *,
+    relationship: str,
+    code: str,
+    input_data: dict,
+    input_artifacts: list,
+    job_type: Optional[str],
+    timeout: Optional[int],
+    http_request: Request,
+) -> AsyncExecuteResponse:
+    """Build and submit a rerun/fork job that links back to ``parent``.
+
+    Shared by the rerun and fork endpoints, which differ only in which code
+    they replay and the relationship recorded on the new job.
+    """
+    job_data = {
+        "code": code,
+        "input_data": input_data,
+        "input_artifacts": input_artifacts,
+        "job_type": job_type or parent.job_type,
+        "parent_execution_id": parent.execution_id,
+        "relationship": relationship,
+        "correlation_id": get_correlation_id(),
+    }
+
+    if timeout:
+        job_data["timeout"] = timeout
+
+    new_job_id = await state.worker_pool.submit(
+        job_data=job_data, client_ip=http_request.client.host if http_request.client else None
+    )
+
+    logger.info(f"Job {new_job_id} created as {relationship} of {parent.execution_id}")
+
+    return AsyncExecuteResponse(job_id=new_job_id, status="queued")
+
+
 @app.post("/jobs/{job_id}/rerun", response_model=AsyncExecuteResponse)
 async def rerun_job(job_id: str, request: RerunRequest, http_request: Request):
     """
@@ -1213,27 +1275,16 @@ async def rerun_job(job_id: str, request: RerunRequest, http_request: Request):
         logger.error(f"Failed to get replay data for {job_id}: {e}")
         raise HTTPException(status_code=400, detail="Failed to retrieve replay data") from e
 
-    # Build job data with parent linkage
-    job_data = {
-        "code": code,
-        "input_data": input_data,
-        "input_artifacts": input_artifacts,
-        "job_type": request.job_type or parent.job_type,
-        "parent_execution_id": parent.execution_id,
-        "relationship": "rerun",
-        "correlation_id": get_correlation_id(),
-    }
-
-    if request.timeout:
-        job_data["timeout"] = request.timeout
-
-    new_job_id = await state.worker_pool.submit(
-        job_data=job_data, client_ip=http_request.client.host if http_request.client else None
+    return await _submit_replay(
+        parent,
+        relationship="rerun",
+        code=code,
+        input_data=input_data,
+        input_artifacts=input_artifacts,
+        job_type=request.job_type,
+        timeout=request.timeout,
+        http_request=http_request,
     )
-
-    logger.info(f"Job {new_job_id} created as rerun of {job_id}")
-
-    return AsyncExecuteResponse(job_id=new_job_id, status="queued")
 
 
 @app.post("/jobs/{job_id}/fork", response_model=AsyncExecuteResponse)
@@ -1265,27 +1316,16 @@ async def fork_job(job_id: str, request: ForkRequest, http_request: Request):
         logger.error(f"Failed to get replay data for {job_id}: {e}")
         raise HTTPException(status_code=400, detail="Failed to retrieve replay data") from e
 
-    # Build job data with new code and parent linkage
-    job_data = {
-        "code": request.code,
-        "input_data": input_data,
-        "input_artifacts": input_artifacts,
-        "job_type": request.job_type or parent.job_type,
-        "parent_execution_id": parent.execution_id,
-        "relationship": "fork",
-        "correlation_id": get_correlation_id(),
-    }
-
-    if request.timeout:
-        job_data["timeout"] = request.timeout
-
-    new_job_id = await state.worker_pool.submit(
-        job_data=job_data, client_ip=http_request.client.host if http_request.client else None
+    return await _submit_replay(
+        parent,
+        relationship="fork",
+        code=request.code,
+        input_data=input_data,
+        input_artifacts=input_artifacts,
+        job_type=request.job_type,
+        timeout=request.timeout,
+        http_request=http_request,
     )
-
-    logger.info(f"Job {new_job_id} created as fork of {job_id}")
-
-    return AsyncExecuteResponse(job_id=new_job_id, status="queued")
 
 
 @app.get("/jobs/{job_id}/artifacts/{artifact_name}")
@@ -1374,17 +1414,16 @@ async def list_executions(
     Returns paginated list of execution records with metadata for efficient client-side pagination.
     Use ?view=full to include artifacts, resource usage, content hashes, and lineage info.
     """
-    actual_limit = min(limit, 1000)
     records = await state.storage.list_records(
         status=status,
         job_type=job_type,
-        limit=actual_limit + 1,  # Fetch one extra to check has_more
+        limit=limit + 1,  # Fetch one extra to check has_more
         offset=offset,
     )
 
-    has_more = len(records) > actual_limit
+    has_more = len(records) > limit
     if has_more:
-        records = records[:actual_limit]
+        records = records[:limit]
 
     if view == "full":
         items = [ExecutionRecordFullResponse.from_record(r) for r in records]
@@ -1393,7 +1432,7 @@ async def list_executions(
 
     return PaginatedResponse(
         items=items,
-        limit=actual_limit,
+        limit=limit,
         offset=offset,
         has_more=has_more,
         count=len(records),
@@ -1439,23 +1478,7 @@ async def list_job_types():
 
     builder = ContainerBuilder()
 
-    result = []
-    for jt in state.registry.list():
-        result.append(
-            JobTypeResponse(
-                name=jt.name,
-                requirements=jt.requirements,
-                python_version=jt.python_version,
-                memory_limit=jt.memory_limit,
-                cpu_limit=jt.cpu_limit,
-                timeout=jt.timeout,
-                session_enabled=jt.session_enabled,
-                gpu_enabled=jt.gpu_enabled,
-                gpu_vendor=jt.gpu_vendor,
-                image_exists=builder.image_exists(jt),
-            )
-        )
-    return result
+    return [JobTypeResponse.from_job_type(jt, builder) for jt in state.registry.list()]
 
 
 @app.get("/job-types/{name}", response_model=JobTypeResponse)
@@ -1476,18 +1499,7 @@ async def get_job_type(name: str):
         raise HTTPException(status_code=404, detail=f"Job type '{name}' not found")
 
     builder = ContainerBuilder()
-    return JobTypeResponse(
-        name=jt.name,
-        requirements=jt.requirements,
-        python_version=jt.python_version,
-        memory_limit=jt.memory_limit,
-        cpu_limit=jt.cpu_limit,
-        timeout=jt.timeout,
-        session_enabled=jt.session_enabled,
-        gpu_enabled=jt.gpu_enabled,
-        gpu_vendor=jt.gpu_vendor,
-        image_exists=builder.image_exists(jt),
-    )
+    return JobTypeResponse.from_job_type(jt, builder)
 
 
 @app.post("/job-types/{name}/build", response_model=BuildResponse)
@@ -1569,20 +1581,19 @@ async def list_dlq_entries(
 
     Returns paginated list of failed jobs for debugging and reprocessing.
     """
-    actual_limit = min(limit, 1000)
     entries = await state.storage.list_dlq_entries(
         error_type=error_type,
-        limit=actual_limit + 1,  # Fetch one extra to check has_more
+        limit=limit + 1,  # Fetch one extra to check has_more
         offset=offset,
     )
 
-    has_more = len(entries) > actual_limit
+    has_more = len(entries) > limit
     if has_more:
-        entries = entries[:actual_limit]
+        entries = entries[:limit]
 
     return PaginatedResponse(
         items=[entry.model_dump() for entry in entries],
-        limit=actual_limit,
+        limit=limit,
         offset=offset,
         has_more=has_more,
         count=len(entries),

--- a/tako_vm/server/correlation.py
+++ b/tako_vm/server/correlation.py
@@ -133,23 +133,3 @@ def configure_logging_with_correlation():
         handler.addFilter(CorrelationIdFilter())
         handler.setFormatter(formatter)
         root_logger.addHandler(handler)
-
-
-# Convenience functions for logging with correlation ID
-
-
-def log_with_correlation(logger: logging.Logger, level: int, message: str, *args, **kwargs) -> None:
-    """
-    Log a message with correlation ID context.
-
-    Args:
-        logger: Logger instance
-        level: Log level (e.g., logging.INFO)
-        message: Log message
-        *args: Format arguments
-        **kwargs: Additional logging kwargs
-    """
-    correlation_id = get_correlation_id()
-    if correlation_id:
-        message = f"[{correlation_id}] {message}"
-    logger.log(level, message, *args, **kwargs)

--- a/tako_vm/server/limits.py
+++ b/tako_vm/server/limits.py
@@ -234,9 +234,8 @@ class ApiProtectionMiddleware:
 
                 if not message.get("more_body", False):
                     break
-            elif message_type == "http.disconnect":
-                break
             else:
+                # Any non-request message (e.g. http.disconnect) ends the body.
                 break
 
         return buffered_messages

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Terminal ExecutionRecord statuses: a record in one of these is a final result.
+# Anything else ("queued", "running") means the job is still in flight.
+_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "timeout", "oom", "cancelled"})
+
 
 @dataclass
 class QueuedJob:
@@ -187,7 +191,6 @@ class WorkerPool:
             RuntimeError: If queue is full
         """
         job_id = str(uuid.uuid4())
-        now = datetime.now(timezone.utc)
 
         # Create future in async context where event loop is running
         loop = asyncio.get_running_loop()
@@ -201,25 +204,7 @@ class WorkerPool:
 
         # Create preliminary "queued" record for idempotency tracking
         # This ensures concurrent requests with same idempotency_key see the record
-        job_type_name = job_data.get("job_type") or "default"
-        queued_record = ExecutionRecord(
-            execution_id=job_id,
-            status="queued",
-            job_type=job_type_name,
-            job_ref=f"{job_type_name}@latest",
-            created_at=now,
-            queued_at=now,
-            code_hash=sha256_content(job_data.get("code", "")),
-            input_hash=sha256_json(job_data.get("input_data", {})),
-            client_ip=client_ip,
-            correlation_id=job_data.get("correlation_id"),
-            idempotency_key=job_data.get("idempotency_key"),
-            idempotency_fingerprint=job_data.get("idempotency_fingerprint"),
-            parent_execution_id=job_data.get("parent_execution_id"),
-            relationship=job_data.get("relationship"),
-        )
-        if self._queue.full():
-            raise RuntimeError("Job queue is full, try again later")
+        queued_record = self._build_record(job, "queued")
 
         await self.storage.save_record(queued_record)
 
@@ -269,9 +254,12 @@ class WorkerPool:
             job = self._active_jobs.get(job_id) or self._running_jobs.get(job_id)
 
         if not job:
-            # Check if already completed in storage
+            # Check if already completed in storage. Only a terminal record is a
+            # final answer: a non-terminal "queued"/"running" row (e.g. the job
+            # is in-flight on another path) must not be returned as the result,
+            # so treat it as still-pending / not found here.
             record = await self.storage.get_record(job_id)
-            if record:
+            if record and record.status in _TERMINAL_STATUSES:
                 return record
             raise KeyError(f"Job {job_id} not found")
 
@@ -359,20 +347,41 @@ class WorkerPool:
         Returns:
             True if job was found and cancelled
         """
+        pending_job: Optional[QueuedJob] = None
         running_job: Optional[QueuedJob] = None
         async with self._jobs_lock:
             # Check pending jobs
             job = self._active_jobs.get(job_id)
             if job and job.future and not job.future.done():
                 job.cancelled = True
-                logger.info(f"Job {job_id} cancelled (was pending)")
-                return True
+                pending_job = job
+                # Remove from active tracking now: the future is resolved below,
+                # so a later get_job_status must not re-report it as pending. The
+                # job still sits in the asyncio.Queue and the worker skip path
+                # (which is a no-op upsert once the future is already done) reaps
+                # it when dequeued.
+                self._active_jobs.pop(job_id, None)
 
             # Check running jobs - send a kill to the tracked container.
-            job = self._running_jobs.get(job_id)
-            if job:
-                job.cancelled = True
-                running_job = job
+            else:
+                job = self._running_jobs.get(job_id)
+                if job:
+                    job.cancelled = True
+                    running_job = job
+
+        if pending_job is not None:
+            # Persist the cancelled record and resolve the waiter synchronously
+            # (mirror the worker skip path) so cancellation is observable now
+            # instead of only after a worker eventually dequeues the job.
+            record = self._build_cancelled_record(pending_job)
+            await self.storage.save_record(record)
+            if pending_job.future and not pending_job.future.done():
+                try:
+                    pending_job.future.set_result(record)
+                except asyncio.InvalidStateError:
+                    logger.debug(f"Future already done for cancelled job {job_id}")
+            logger.info(f"Job {job_id} cancelled (was pending)")
+            return True
 
         if not running_job:
             return False
@@ -392,27 +401,53 @@ class WorkerPool:
 
         return True
 
-    def _build_cancelled_record(
-        self, job: QueuedJob, message: str = "Execution was cancelled by user"
+    @staticmethod
+    def _build_record(
+        job: QueuedJob,
+        status: str,
+        *,
+        error: Optional[ExecutionError] = None,
+        queued_at: Optional[datetime] = None,
     ) -> ExecutionRecord:
-        """Create a final cancelled record for a job."""
+        """Build an ExecutionRecord for a job in a given terminal/queued state.
+
+        Single construction site for every record the worker pool persists, so
+        the idempotency, lineage, and content-hash fields are propagated
+        consistently. (A prior hand-rolled record in the outer-except path
+        dropped the idempotency and lineage fields; routing through here fixes
+        that.)
+
+        Args:
+            job: Job the record describes
+            status: ExecutionRecord status (e.g. "queued", "cancelled", "failed")
+            error: Optional ExecutionError to attach
+            queued_at: Override for queued_at (defaults to job.created_at)
+        """
         job_type_name = job.job_data.get("job_type") or "default"
         return ExecutionRecord(
             execution_id=job.job_id,
-            status="cancelled",
+            status=status,
             job_type=job_type_name,
             job_ref=f"{job_type_name}@latest",
             created_at=job.created_at,
-            queued_at=job.created_at,
+            queued_at=queued_at if queued_at is not None else job.created_at,
             code_hash=sha256_content(job.job_data.get("code", "")),
             input_hash=sha256_json(job.job_data.get("input_data", {})),
             client_ip=job.client_ip,
             correlation_id=job.job_data.get("correlation_id"),
-            error=ExecutionError(type="cancelled", message=message),
+            error=error,
             idempotency_key=job.job_data.get("idempotency_key"),
             idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
             parent_execution_id=job.job_data.get("parent_execution_id"),
             relationship=job.job_data.get("relationship"),
+        )
+
+    def _build_cancelled_record(
+        self, job: QueuedJob, message: str = "Execution was cancelled by user"
+    ) -> ExecutionRecord:
+        """Create a final cancelled record for a job."""
+        return self._build_record(
+            job, "cancelled", error=ExecutionError(type="cancelled", message=message)
         )
 
     def _estimate_queue_position_unlocked(self, job_id: str) -> int:
@@ -432,31 +467,6 @@ class WorkerPool:
         return {
             "pending": self._queue.qsize(),
             "running": running_count,
-            "max_workers": self.max_workers,
-            "max_queue_size": self.max_queue_size,
-        }
-
-    @property
-    def stats(self) -> dict:
-        """Get current pool statistics (sync version for backward compatibility).
-
-        DEPRECATED: This property doesn't use lock protection for running count,
-        which can cause race conditions. Use get_stats() for async code paths.
-
-        Returns:
-            Dict with pending, running, max_workers, max_queue_size
-        """
-        import warnings
-
-        warnings.warn(
-            "WorkerPool.stats property is deprecated due to race condition. "
-            "Use 'await worker_pool.get_stats()' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return {
-            "pending": self._queue.qsize(),
-            "running": len(self._running_jobs),
             "max_workers": self.max_workers,
             "max_queue_size": self.max_queue_size,
         }
@@ -566,25 +576,11 @@ class WorkerPool:
 
                     error_type = "internal_error"
                     error_msg = sanitize_error(str(e))
-                    job_type_name = job.job_data.get("job_type") or "default"
 
-                    record = ExecutionRecord(
-                        execution_id=job.job_id,
-                        status="failed",
-                        job_type=job_type_name,
-                        job_ref=f"{job_type_name}@latest",
-                        created_at=job.created_at,
-                        queued_at=job.created_at,
-                        code_hash=sha256_content(job.job_data.get("code", "")),
-                        input_hash=sha256_json(job.job_data.get("input_data", {})),
-                        client_ip=job.client_ip,
-                        correlation_id=job.job_data.get("correlation_id"),
+                    record = self._build_record(
+                        job,
+                        "failed",
                         error=ExecutionError(type=error_type, message=error_msg),
-                        # Propagate idempotency and lineage fields
-                        idempotency_key=job.job_data.get("idempotency_key"),
-                        idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
-                        parent_execution_id=job.job_data.get("parent_execution_id"),
-                        relationship=job.job_data.get("relationship"),
                     )
                     await self.storage.save_record(record)
 
@@ -612,12 +608,6 @@ class WorkerPool:
                         except asyncio.InvalidStateError:
                             logger.debug(f"Future already done for failed job {job.job_id}")
 
-                finally:
-                    # Cleanup with lock protection
-                    async with self._jobs_lock:
-                        self._active_jobs.pop(job.job_id, None)
-                        self._running_jobs.pop(job.job_id, None)
-
             except Exception as e:
                 logger.error(f"Worker {worker_id} unexpected error: {e}", exc_info=True)
                 # Ensure job future is resolved even on unexpected errors
@@ -626,17 +616,12 @@ class WorkerPool:
                     try:
                         from tako_vm.security import sanitize_error
 
-                        error_record = ExecutionRecord(
-                            execution_id=job.job_id,
-                            status="failed",
-                            job_type=job.job_data.get("job_type") or "default",
-                            job_ref=f"{job.job_data.get('job_type') or 'default'}@latest",
-                            created_at=job.created_at,
-                            queued_at=job.created_at,
-                            code_hash=sha256_content(job.job_data.get("code", "")),
-                            input_hash=sha256_json(job.job_data.get("input_data", {})),
-                            client_ip=job.client_ip,
-                            correlation_id=job.job_data.get("correlation_id"),
+                        # Route through _build_record so this path also persists
+                        # the idempotency and lineage fields it previously
+                        # dropped (data-loss bug).
+                        error_record = self._build_record(
+                            job,
+                            "failed",
                             error=ExecutionError(
                                 type="internal_error", message=sanitize_error(str(e))
                             ),
@@ -653,11 +638,11 @@ class WorkerPool:
                             pass
                 await asyncio.sleep(1)  # Prevent tight loop on errors
             finally:
-                # Backstop cleanup: the inner try's finally handles the normal
-                # path, but an exception raised after a job is placed in
-                # _running_jobs (line ~502) but before the inner try is entered
-                # would otherwise strand it as 'running' forever. pop() is
-                # idempotent, so double-cleanup is harmless.
+                # Single cleanup site for every per-iteration exit path: even an
+                # exception raised after a job is placed in _running_jobs but
+                # before/while the inner try runs must not strand it as 'running'
+                # forever. pop() is idempotent, so this is safe regardless of how
+                # the iteration ended.
                 if job is not None:
                     async with self._jobs_lock:
                         self._active_jobs.pop(job.job_id, None)
@@ -769,18 +754,9 @@ class WorkerPool:
             "timeout backstop fires; the worker slot is freed now"
         )
 
-        job_type_name = job.job_data.get("job_type") or "default"
-        return ExecutionRecord(
-            execution_id=job.job_id,
-            status="timeout",
-            job_type=job_type_name,
-            job_ref=f"{job_type_name}@latest",
-            created_at=job.created_at,
-            queued_at=job.created_at,
-            code_hash=sha256_content(job.job_data.get("code", "")),
-            input_hash=sha256_json(job.job_data.get("input_data", {})),
-            client_ip=job.client_ip,
-            correlation_id=job.job_data.get("correlation_id"),
+        return self._build_record(
+            job,
+            "timeout",
             error=ExecutionError(
                 type="execution_timeout",
                 message=(
@@ -788,10 +764,6 @@ class WorkerPool:
                     "(startup + execution + orchestration buffer); container was killed"
                 ),
             ),
-            idempotency_key=job.job_data.get("idempotency_key"),
-            idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
-            parent_execution_id=job.job_data.get("parent_execution_id"),
-            relationship=job.job_data.get("relationship"),
         )
 
     def _run_job_sync(self, job: QueuedJob) -> ExecutionRecord:

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -187,15 +187,6 @@ MIGRATIONS: list[tuple[str, str]] = [
 ]
 
 
-def _decode_json_field(value: Any) -> Any:
-    """Normalize JSONB values returned by psycopg."""
-    if value is None:
-        return None
-    if isinstance(value, (dict, list)):
-        return value
-    return value
-
-
 # --- execution_records upsert: single source of truth for the column set ------
 #
 # The INSERT column list, the `%s` placeholder run, the value tuple, AND the
@@ -297,6 +288,33 @@ _INSERT_COLUMN_SQL = ", ".join(name for name, _, _ in _EXECUTION_COLUMNS)
 _INSERT_PLACEHOLDER_SQL = ", ".join(["%s"] * len(_EXECUTION_COLUMNS))
 _UPDATE_SET_SQL = ",\n                    ".join(
     _set_clause_for(name, policy) for name, policy, _ in _EXECUTION_COLUMNS if policy != _SET_KEY
+)
+
+
+# --- job_versions upsert: single source of truth for the column set -----------
+#
+# Same pattern as _EXECUTION_COLUMNS above: the INSERT column list, placeholder
+# run, value tuple, and ON CONFLICT ... SET clause are all derived from this one
+# list, so adding/removing a column is a single edit instead of four hand-synced
+# ones. (digest, value_extractor(version)). digest is the ON CONFLICT key and
+# carries no SET line; every other column takes EXCLUDED (a re-save replaces the
+# stored metadata).
+_VERSION_KEY_COLUMN = "digest"
+_VERSION_COLUMNS: list = [
+    ("digest", lambda v: v.digest),
+    ("job_type_name", lambda v: v.job_type_name),
+    ("version_tag", lambda v: v.version_tag),
+    ("built_at", lambda v: v.built_at),
+    ("built_by", lambda v: v.built_by),
+    ("dockerfile_hash", lambda v: v.dockerfile_hash),
+    ("requirements_hash", lambda v: v.requirements_hash),
+    ("image_ref", lambda v: v.image_ref),
+]
+
+_VERSION_INSERT_COLUMN_SQL = ", ".join(name for name, _ in _VERSION_COLUMNS)
+_VERSION_INSERT_PLACEHOLDER_SQL = ", ".join(["%s"] * len(_VERSION_COLUMNS))
+_VERSION_UPDATE_SET_SQL = ",\n                    ".join(
+    f"{name} = EXCLUDED.{name}" for name, _ in _VERSION_COLUMNS if name != _VERSION_KEY_COLUMN
 )
 
 
@@ -446,7 +464,9 @@ class ExecutionStorage:
             "timing_json": record.timing.model_dump() if record.timing else None,
         }
 
-        terminal_list = ", ".join(f"'{s}'" for s in TERMINAL_STATUSES)
+        # Bound placeholders for the terminal-status guard, so the status
+        # literals are passed as parameters (no string interpolation into SQL).
+        terminal_placeholders = ", ".join(["%s"] * len(TERMINAL_STATUSES))
 
         # Upsert column policy:
         # - Submission-identity fields (created_at, queued_at, code_hash,
@@ -482,9 +502,12 @@ class ExecutionStorage:
                 )
                 ON CONFLICT (execution_id) DO UPDATE SET
                     {_UPDATE_SET_SQL}
-                WHERE execution_records.status NOT IN ({terminal_list})
+                WHERE execution_records.status NOT IN ({terminal_placeholders})
                 """,
-                tuple(extract(record, blobs) for _, _, extract in _EXECUTION_COLUMNS),
+                (
+                    *(extract(record, blobs) for _, _, extract in _EXECUTION_COLUMNS),
+                    *TERMINAL_STATUSES,
+                ),
             )
             return cursor.rowcount
 
@@ -558,6 +581,11 @@ class ExecutionStorage:
         so no other live server process can legitimately own in-flight records
         when this runs at startup.
 
+        The generic 'interrupted' error is only applied where error_json is
+        still NULL (COALESCE keeps any existing value), so a crashing worker
+        that already persisted the real error before exit is not overwritten by
+        this coarser reconciliation message.
+
         Returns:
             Number of records transitioned to 'failed'.
         """
@@ -574,7 +602,7 @@ class ExecutionStorage:
                 UPDATE execution_records
                 SET status = 'failed',
                     ended_at = %s,
-                    error_json = %s
+                    error_json = COALESCE(error_json, %s)
                 WHERE status IN ('queued', 'running')
                 """,
                 (now, Jsonb(error_json)),
@@ -634,7 +662,7 @@ class ExecutionStorage:
             )
 
         input_artifacts = []
-        input_artifacts_data = _decode_json_field(row.get("input_artifacts_json"))
+        input_artifacts_data = row.get("input_artifacts_json")
         if input_artifacts_data:
             try:
                 input_artifacts = [InputArtifact(**a) for a in input_artifacts_data]
@@ -647,7 +675,7 @@ class ExecutionStorage:
                 )
 
         artifacts = []
-        artifacts_data = _decode_json_field(row.get("artifacts_json"))
+        artifacts_data = row.get("artifacts_json")
         if artifacts_data:
             try:
                 artifacts = [Artifact(**a) for a in artifacts_data]
@@ -660,7 +688,7 @@ class ExecutionStorage:
                 )
 
         error = None
-        error_data = _decode_json_field(row.get("error_json"))
+        error_data = row.get("error_json")
         if error_data:
             try:
                 error = ExecutionError(**error_data)
@@ -679,10 +707,10 @@ class ExecutionStorage:
                     message="stored error payload could not be decoded",
                 )
 
-        result_json = _decode_json_field(row.get("result_json"))
+        result_json = row.get("result_json")
 
         timing = None
-        timing_data = _decode_json_field(row.get("timing_json"))
+        timing_data = row.get("timing_json")
         if timing_data:
             try:
                 timing = ExecutionTiming(**timing_data)
@@ -736,31 +764,16 @@ class ExecutionStorage:
         pool = self._get_pool()
         async with pool.connection() as conn:
             await conn.execute(
-                """
+                f"""
                 INSERT INTO job_versions (
-                    digest, job_type_name, version_tag,
-                    built_at, built_by, dockerfile_hash,
-                    requirements_hash, image_ref
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (digest) DO UPDATE SET
-                    job_type_name = EXCLUDED.job_type_name,
-                    version_tag = EXCLUDED.version_tag,
-                    built_at = EXCLUDED.built_at,
-                    built_by = EXCLUDED.built_by,
-                    dockerfile_hash = EXCLUDED.dockerfile_hash,
-                    requirements_hash = EXCLUDED.requirements_hash,
-                    image_ref = EXCLUDED.image_ref
+                    {_VERSION_INSERT_COLUMN_SQL}
+                ) VALUES (
+                    {_VERSION_INSERT_PLACEHOLDER_SQL}
+                )
+                ON CONFLICT ({_VERSION_KEY_COLUMN}) DO UPDATE SET
+                    {_VERSION_UPDATE_SET_SQL}
                 """,
-                (
-                    version.digest,
-                    version.job_type_name,
-                    version.version_tag,
-                    version.built_at,
-                    version.built_by,
-                    version.dockerfile_hash,
-                    version.requirements_hash,
-                    version.image_ref,
-                ),
+                tuple(extract(version) for _, extract in _VERSION_COLUMNS),
             )
 
     async def get_version_by_digest(self, job_type_name: str, digest: str) -> Optional[JobVersion]:
@@ -999,7 +1012,7 @@ class ExecutionStorage:
 
     def _row_to_dlq_entry(self, row: RowMapping) -> DeadLetterEntry:
         """Convert database row to DeadLetterEntry."""
-        job_data = _decode_json_field(row.get("job_data_json")) or {}
+        job_data = row.get("job_data_json") or {}
         return DeadLetterEntry(
             id=row["id"],
             job_id=row["job_id"],

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -25,8 +25,10 @@ def make_record(job_id: str, status: str = "succeeded", **kwargs) -> ExecutionRe
 
 @pytest.mark.asyncio
 async def test_cancel_pending_job_leaves_future_resolvable():
-    """Pending-job cancellation should not poison the waiter future."""
-    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    """Pending-job cancellation resolves the waiter future synchronously."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    pool = WorkerPool(executor=MagicMock(), storage=storage)
     loop = asyncio.get_running_loop()
     job = QueuedJob(
         job_id="job-123",
@@ -44,6 +46,11 @@ async def test_cancel_pending_job_leaves_future_resolvable():
     assert job.cancelled is True
     assert job.future is not None
     assert job.future.cancelled() is False
+    # Cancellation is now observable immediately: the cancelled record is
+    # persisted and the future is resolved without waiting for a worker.
+    storage.save_record.assert_awaited_once()
+    assert job.future.done()
+    assert job.future.result().status == "cancelled"
 
 
 @pytest.mark.asyncio
@@ -630,10 +637,21 @@ async def test_submit_queue_full_race_releases_idempotency_key():
 
 
 @pytest.mark.asyncio
-async def test_submit_queue_full_precheck_rejects_without_db_write():
-    """The cheap full() pre-check rejects before any record is persisted."""
+async def test_submit_queue_full_rejects_and_cleans_up_record():
+    """A full queue is rejected solely by the put_nowait/QueueFull handler.
+
+    The redundant full() pre-check was removed (it left a TOCTOU window where a
+    queued record was persisted before the insert was attempted). The single
+    handler still cleans up: it rewrites the preliminary record as failed and
+    releases the idempotency key.
+    """
     storage = MagicMock()
-    storage.save_record = AsyncMock()
+    saves = []
+
+    async def capture_save(record):
+        saves.append((record.status, record.idempotency_key))
+
+    storage.save_record = AsyncMock(side_effect=capture_save)
     pool = WorkerPool(executor=MagicMock(), storage=storage, max_queue_size=1)
     loop = asyncio.get_running_loop()
     pool._queue.put_nowait(
@@ -651,7 +669,11 @@ async def test_submit_queue_full_precheck_rejects_without_db_write():
             client_ip=None,
         )
 
-    storage.save_record.assert_not_awaited()
+    # Preliminary queued record, then the failed rewrite that frees the key.
+    assert saves == [
+        ("queued", "idem-456"),
+        ("failed", None),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -540,7 +540,7 @@ class TestSandboxOOMDetection:
             lambda self, **kwargs: (["docker", "run", "fake"], "fake-container"),
         )
         monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
-        monkeypatch.setattr("tako_vm.sandbox.inspect_oom_killed", fake_inspect)
+        monkeypatch.setattr("tako_vm.sandbox.classify_sigkill", fake_inspect)
         monkeypatch.setattr("tako_vm.sandbox.remove_container", fake_remove)
         return sb
 

--- a/tests/test_workspace_prune.py
+++ b/tests/test_workspace_prune.py
@@ -10,7 +10,6 @@ No Docker required.
 import os
 import time
 
-import tako_vm.execution.worker as worker
 from tako_vm.execution.worker import prune_old_run_dirs, prune_stale_workspaces
 
 
@@ -21,7 +20,7 @@ def _age(path, seconds_old: int) -> None:
 
 class TestPruneStaleWorkspaces:
     def test_removes_only_old_run_dirs(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(worker, "WORKSPACE_DIR", str(tmp_path))
+        monkeypatch.setenv("TAKO_VM_WORKSPACE", str(tmp_path))
         old_job = tmp_path / "job-old"
         old_job.mkdir()
         (old_job / "f").write_text("x")
@@ -44,12 +43,12 @@ class TestPruneStaleWorkspaces:
         assert unrelated.exists()  # wrong prefix, untouched
 
     def test_missing_workspace_dir_is_noop(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(worker, "WORKSPACE_DIR", str(tmp_path / "nope"))
+        monkeypatch.setenv("TAKO_VM_WORKSPACE", str(tmp_path / "nope"))
         assert prune_stale_workspaces(max_age_seconds=1) == 0
 
     def test_symlinked_entry_is_skipped(self, tmp_path, monkeypatch):
         # A workspace-named symlink must never be followed/removed by the sweep.
-        monkeypatch.setattr(worker, "WORKSPACE_DIR", str(tmp_path))
+        monkeypatch.setenv("TAKO_VM_WORKSPACE", str(tmp_path))
         target = tmp_path / "target_dir"
         target.mkdir()
         (target / "keep").write_text("x")


### PR DESCRIPTION
Whole-package review pass over `tako_vm/`, applying 35 findings from a multi-agent review grouped into four themes. Each fix was implemented by a file-partitioned agent and independently verified; the test suite is green.

## Verification
- `ruff check tako_vm/` clean, package imports clean.
- **532 passed, 0 failed, 95 skipped** excluding `test_sandbox.py` / `test_proc_exposure.py`, which require real container bind-mounts that Docker Desktop on macOS cannot provide (they pass on a Linux/Lima host). The 6 `test_security` failures seen in a full local run are circuit-breaker pollution from those environmental Docker failures and pass 58/58 in isolation.

## Durability / correctness
- sandbox now runs `validate_docker_run_args` and fails closed (was skipped in library mode)
- exit code 124 with no phase file is recorded as `timeout`, not a generic failure
- queue outer-except path no longer drops idempotency/lineage fields (one `_build_record` helper)
- cancelling a pending job writes the cancelled record and resolves the future synchronously
- `IdempotencyLockManager` ref-counts waiters, evicting a key's lock only at zero
- terminal-status SQL is parameterized (was f-string interpolated)
- `reconcile_stale_records` uses `COALESCE` so a worker's real error is not clobbered
- docker build timeout, build-context copy raises `BuildError`, queue TOCTOU/fallback fixes, SDK `send` KeyError parity, CLI verify `TimeoutExpired` handling

## Verbose errors (no more silent swallows)
- `remove_image`, `remove_container`, `kill_container` now log real failures
- `load_config` logs the exception type without echoing raw payloads

## Consolidation
- `sandbox.py` and `worker.py` share `prepare_requirements_file`, `classify_docker_run_result`, `classify_sigkill`, `read_result_json` in `docker.py`
- single-source `save_version` columns, shared sha256/filename validators and size parser, `docker_image` references the constant, `from_job_type`/`_submit_replay`/stats alias, CLI helpers

## Simplify / dead code
- delete unused `@retry` decorator and dead `RetryContext` methods
- remove no-op `_decode_json_field`, deprecated sync `stats` property, unused `log_with_correlation`
- `WORKSPACE_DIR` is now a live `get_workspace_dir()`

## Behavior change to note
The server worker now **rejects** a job whose requirements contain any invalid pip requirement (previously it silently skipped the entry and ran with a reduced dependency set), unifying it with the sandbox's existing reject policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)