### PR TITLE
refactor(consolidate): share container, validator, and SQL logic

### DIFF
--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -40,6 +40,34 @@ MANAGED_POSTGRES_CONTAINER = "tako-vm-postgres"
 MANAGED_POSTGRES_VOLUME = "tako-vm-postgres-data"
 
 
+def _mask_database_url(url: str) -> str:
+    """Mask the password in a database URL for display, keeping the username."""
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    creds, host = parts.netloc.rsplit("@", 1)
+    username = creds.split(":", 1)[0] if creds else ""
+    masked_creds = f"{username}:***" if username else "***"
+    return urlunsplit(
+        (parts.scheme, f"{masked_creds}@{host}", parts.path, parts.query, parts.fragment)
+    )
+
+
+def _postgres_container_running() -> bool:
+    """Probe whether the managed PostgreSQL container is in the running state.
+
+    Assumes the container exists (caller has already inspected it). Returns
+    True only when `docker inspect` reports State.Running == true.
+    """
+    running_proc = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", MANAGED_POSTGRES_CONTAINER],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return running_proc.stdout.strip().lower() == "true"
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="tako-vm",
@@ -363,13 +391,7 @@ def _ensure_managed_postgres() -> None:
     )
 
     if inspect_proc.returncode == 0:
-        running_proc = subprocess.run(
-            ["docker", "inspect", "-f", "{{.State.Running}}", MANAGED_POSTGRES_CONTAINER],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        if running_proc.stdout.strip().lower() != "true":
+        if not _postgres_container_running():
             subprocess.run(
                 ["docker", "start", MANAGED_POSTGRES_CONTAINER],
                 check=True,
@@ -426,13 +448,7 @@ def _managed_postgres_state() -> str:
     if inspect_proc.returncode != 0:
         return "missing"
 
-    running_proc = subprocess.run(
-        ["docker", "inspect", "-f", "{{.State.Running}}", MANAGED_POSTGRES_CONTAINER],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return "running" if running_proc.stdout.strip().lower() == "true" else "stopped"
+    return "running" if _postgres_container_running() else "stopped"
 
 
 def _auto_start_local_postgres_if_needed(config) -> None:
@@ -626,17 +642,6 @@ def show_config(args):
         sys.exit(1)
 
     config_file = get_config_path()
-
-    def _mask_database_url(url: str) -> str:
-        parts = urlsplit(url)
-        if "@" not in parts.netloc:
-            return url
-        creds, host = parts.netloc.rsplit("@", 1)
-        username = creds.split(":", 1)[0] if creds else ""
-        masked_creds = f"{username}:***" if username else "***"
-        return urlunsplit(
-            (parts.scheme, f"{masked_creds}@{host}", parts.path, parts.query, parts.fragment)
-        )
 
     if args.json:
         import json

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -15,6 +15,8 @@ from urllib.parse import parse_qsl, urlsplit, urlunsplit
 import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
+from tako_vm.constants import DEFAULT_IMAGE
+
 logger = logging.getLogger(__name__)
 
 # Default config file locations (searched in order)
@@ -44,6 +46,27 @@ def _sanitize_validation_error(e: ValidationError) -> str:
         loc = ".".join(str(part) for part in err.get("loc", ())) or "config"
         lines.append(f"field {loc}: {err.get('msg', 'invalid value')}")
     return "; ".join(lines) or "validation failed"
+
+
+def _parse_size_to_mb(v: str, *, allow_k_and_bytes: bool) -> int:
+    """Parse a size string ('512m', '1g', etc.) to whole megabytes.
+
+    Shared by tmpfs_size and memory_limit validation. ``v`` must already be
+    lowercased and stripped. When ``allow_k_and_bytes`` is True a 'k' suffix or
+    a bare integer (bytes) is accepted (tmpfs); otherwise only 'm'/'g' are
+    allowed (memory_limit) and anything else raises ValueError. Integer parse
+    failures propagate as ValueError so pydantic reports them.
+    """
+    if v.endswith("g"):
+        return int(v[:-1]) * 1024
+    if v.endswith("m"):
+        return int(v[:-1])
+    if allow_k_and_bytes:
+        if v.endswith("k"):
+            return int(v[:-1]) // 1024
+        # Assume bytes.
+        return int(v) // (1024 * 1024)
+    raise ValueError("memory_limit must end with 'm' or 'g'")
 
 
 def get_default_data_dir() -> Path:
@@ -89,16 +112,7 @@ class ContainerLimits(BaseModel):
         if not v:
             raise ValueError("tmpfs_size cannot be empty")
 
-        # Parse size
-        if v.endswith("g"):
-            size_mb = int(v[:-1]) * 1024
-        elif v.endswith("m"):
-            size_mb = int(v[:-1])
-        elif v.endswith("k"):
-            size_mb = int(v[:-1]) // 1024
-        else:
-            # Assume bytes
-            size_mb = int(v) // (1024 * 1024)
+        size_mb = _parse_size_to_mb(v, allow_k_and_bytes=True)
 
         # Validate bounds (10MB to 2GB)
         if size_mb < 10:
@@ -221,13 +235,7 @@ class JobTypeConfig(BaseModel):
         if not v:
             raise ValueError("memory_limit cannot be empty")
 
-        # Parse and validate
-        if v.endswith("g"):
-            size_mb = int(v[:-1]) * 1024
-        elif v.endswith("m"):
-            size_mb = int(v[:-1])
-        else:
-            raise ValueError("memory_limit must end with 'm' or 'g'")
+        size_mb = _parse_size_to_mb(v, allow_k_and_bytes=False)
 
         if size_mb < 64:
             raise ValueError("memory_limit must be at least 64m")
@@ -433,7 +441,7 @@ class TakoVMConfig(BaseModel):
     )
 
     # Docker
-    docker_image: str = Field(default="code-executor:latest")
+    docker_image: str = Field(default=DEFAULT_IMAGE)
     enable_seccomp: bool = Field(default=True)
     enable_cap_restrictions: bool = Field(
         default=True,

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -10,9 +10,22 @@ import platform
 import subprocess
 import time
 import uuid
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from tako_vm.security import validate_pip_requirement
 
 logger = logging.getLogger(__name__)
+
+# stderr substrings that indicate the docker CLI could not reach the daemon.
+# These are infrastructure failures, never the fault of the user's code. Shared
+# by classify_docker_run_result so the worker and the library Sandbox detect
+# daemon/infra failures identically.
+_DOCKER_INFRA_STDERR_PATTERNS = (
+    "cannot connect to the docker daemon",
+    "error during connect",
+    "docker daemon is not running",
+)
 
 # Default executor base image. Built from docker/Dockerfile.executor; carries
 # uv, gosu, the sandbox user, and the /entrypoint.sh contract (see
@@ -423,3 +436,164 @@ def base_isolation_args(
         args.append(f"--runtime={runtime}")
 
     return args
+
+
+def prepare_requirements_file(
+    requirements: Optional[Sequence[str]],
+    input_dir: Path,
+    *,
+    allow_runtime_requirements: bool,
+    max_requirements: int,
+) -> List[str]:
+    """Validate runtime requirements and write the ``_requirements.txt`` file.
+
+    Single source of truth for the runtime-requirements policy shared by the
+    server ``CodeExecutor`` and the library ``Sandbox``, so the two paths cannot
+    drift on how they cap, validate, gate, and persist requirements.
+
+    Policy (fail closed):
+
+    - An empty/None list is a no-op and returns ``[]`` (no file written).
+    - If requirements are present but ``allow_runtime_requirements`` is False,
+      raise ``ValueError`` (runtime installs are disabled).
+    - More than ``max_requirements`` entries raises ``ValueError``.
+    - Any entry failing ``validate_pip_requirement`` raises ``ValueError``:
+      invalid requirements are REJECTED, never silently skipped, so a typo or an
+      injection attempt fails loudly instead of running with a different
+      dependency set than the caller asked for.
+    - The validated list is written to ``input_dir/_requirements.txt`` and
+      chmod 0o444 (read-only) for the entrypoint to install.
+
+    The policy is checked before validation so an all-invalid list cannot bypass
+    the ``allow_runtime_requirements`` gate.
+
+    Args:
+        requirements: Requested pip requirements (may be None/empty).
+        input_dir: Directory mounted read-only at /input where the entrypoint
+            looks for ``_requirements.txt``.
+        allow_runtime_requirements: Whether runtime installs are permitted.
+        max_requirements: Maximum number of requirements allowed.
+
+    Returns:
+        The validated requirements list (empty when none were requested).
+
+    Raises:
+        ValueError: policy violation (installs disabled, too many, or an invalid
+            requirement).
+    """
+    if not requirements:
+        return []
+
+    # Enforce the policy before validation so an all-invalid list cannot bypass
+    # the allow_runtime_requirements check.
+    if not allow_runtime_requirements:
+        raise ValueError(
+            "Runtime dependency installation is disabled. "
+            "Use pre-built images or set allow_runtime_requirements=True."
+        )
+    if len(requirements) > max_requirements:
+        raise ValueError(f"Too many requirements ({len(requirements)} > {max_requirements})")
+
+    validated_reqs: List[str] = []
+    for req in requirements:
+        if not validate_pip_requirement(req):
+            raise ValueError(f"Invalid pip requirement: {req!r}")
+        validated_reqs.append(req)
+
+    requirements_file = input_dir / "_requirements.txt"
+    requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
+    requirements_file.chmod(0o444)
+    return validated_reqs
+
+
+def classify_docker_run_result(returncode: int, stderr: str) -> Tuple[bool, Optional[str]]:
+    """Decide whether a finished ``docker run`` failed in docker itself (infra).
+
+    ``docker run`` reserves exit code 125 for failures of docker itself (daemon
+    unreachable, image pull failure, bad flags); container exit codes pass
+    through unchanged otherwise, and our entrypoint never exits 125 in normal
+    operation. A non-zero exit whose stderr matches a known daemon-connectivity
+    phrasing is likewise an infrastructure failure. Such failures must never be
+    attributed to the user's code (e.g. by ``classify_error`` on daemon stderr).
+
+    Shared by the worker (which counts these against its circuit breaker and
+    marks them retriable) and the library Sandbox (which has no circuit breaker
+    but still surfaces them as a distinct infra failure rather than a code bug).
+
+    Args:
+        returncode: Exit code from ``subprocess.run`` of ``docker run``.
+        stderr: Captured stderr of the run.
+
+    Returns:
+        Tuple of ``(is_infra_failure, detail)``. ``detail`` is a short,
+        single-line description suitable for an error message (the first stderr
+        line, or a synthesized fallback), and is None when not an infra failure.
+    """
+    stderr_lower = (stderr or "").lower()
+    is_infra_failure = returncode == 125 or (
+        returncode != 0
+        and any(pattern in stderr_lower for pattern in _DOCKER_INFRA_STDERR_PATTERNS)
+    )
+    if not is_infra_failure:
+        return False, None
+
+    stderr_lines = (stderr or "").strip().splitlines()
+    detail = stderr_lines[0] if stderr_lines else f"docker run exited with code {returncode}"
+    return True, detail
+
+
+def classify_sigkill(container_name: str) -> Optional[bool]:
+    """Classify an exit-code-137 (SIGKILL) container as OOM or not.
+
+    Exit 137 is SIGKILL, but not necessarily the OOM killer: ``docker kill``
+    (cancel path), a pids-limit kill, or user code calling ``sys.exit(137)`` all
+    look identical. Only the exited container's ``State.OOMKilled`` distinguishes
+    them, so this must be called BEFORE the container is removed (the run must
+    use ``auto_remove=False``). In-container timeout kills are already remapped
+    to 124 by the entrypoint, so a 137 seen by callers is a genuine SIGKILL.
+
+    Thin wrapper over ``inspect_oom_killed`` so both the worker and the library
+    Sandbox apply the identical OOM policy:
+
+    Returns:
+        True if the kernel/cgroup OOM killer killed the process, False if it was
+        a non-OOM SIGKILL, or None if the inspect was inconclusive (container
+        already gone, daemon unreachable, timeout). Callers should treat None as
+        "assume OOM" so a flaky inspect never loses a true OOM.
+    """
+    return inspect_oom_killed(container_name)
+
+
+def read_result_json(output_dir: Path, ident: str) -> Optional[dict]:
+    """Read and parse ``output_dir/result.json``, symlink-safe.
+
+    Untrusted code in the container can point ``result.json`` at a host file to
+    exfiltrate it; this never follows a symlink. A present-but-unreadable or
+    unparseable file is logged and treated as "no JSON output" rather than
+    silently presented as None (the caller cannot tell the difference), so the
+    failure is surfaced in the log.
+
+    Shared by the worker and the library Sandbox so both parse the result file
+    identically.
+
+    Args:
+        output_dir: The job's output directory (bind-mounted at /output).
+        ident: Identifier for log messages (job/execution ID or container name).
+
+    Returns:
+        The parsed JSON object, or None if absent, a symlink, or unreadable.
+    """
+    output_file = output_dir / "result.json"
+    if output_file.is_symlink():
+        logger.warning("result.json for %s is a symlink, ignoring", ident)
+        return None
+    if not output_file.exists():
+        return None
+    try:
+        return json.loads(output_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        # Output existed but was unreadable/unparseable (truncated, non-UTF-8,
+        # device error). Surface it loudly instead of presenting None as "no
+        # output produced".
+        logger.warning("Failed to read/parse result.json for %s: %s", ident, e)
+        return None

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -27,13 +27,16 @@ from tako_vm.constants import (
 from tako_vm.execution.docker import (
     EXECUTOR_ENTRYPOINT,
     base_isolation_args,
+    classify_docker_run_result,
+    classify_sigkill,
     decode_subprocess_stream,
     generate_container_name,
     image_exists,
     image_has_executor_entrypoint,
-    inspect_oom_killed,
     is_native_linux,
     kill_container,
+    prepare_requirements_file,
+    read_result_json,
     remove_container,
     ulimit_args,
 )
@@ -61,21 +64,12 @@ from tako_vm.security import (
     validate_env_key,
     validate_env_value,
     validate_execution_id,
-    validate_pip_requirement,
 )
 
 logger = logging.getLogger(__name__)
 
 # Cache for runtime availability check
 _gvisor_available: Optional[bool] = None
-
-# stderr patterns that indicate the docker CLI could not reach the daemon.
-# These are infrastructure failures, never the fault of the user's code.
-_DOCKER_INFRA_STDERR_PATTERNS = (
-    "cannot connect to the docker daemon",
-    "error during connect",
-    "docker daemon is not running",
-)
 
 
 def _require_safe_execution_id(execution_id: str) -> str:
@@ -824,20 +818,17 @@ class CodeExecutor:
             record.exit_code = result.get("exit_code")
 
             # Cap and sanitize outputs. cap_output truncates in-band (appends
-            # a notice), so also surface truncation on the record flags — the
-            # API must not report truncated output as complete. The flag
-            # mirrors cap_output's own truncation condition (UTF-8 encoded
-            # size vs the cap), which is robust against the notice text
-            # legitimately appearing in user output.
+            # a notice) and returns whether it truncated, so the record's
+            # truncation flags come from that single source of truth: the API
+            # must not report truncated output as complete, and the flag can
+            # never disagree with the in-band notice.
             raw_stdout = result.get("stdout", "")
             raw_stderr = result.get("stderr", "")
-            record.stdout = cap_output(raw_stdout, self.config.max_stdout_bytes)
-            record.stderr = cap_output(raw_stderr, self.config.max_stderr_bytes)
-            record.stdout_truncated = (
-                len(raw_stdout.encode("utf-8", errors="replace")) > self.config.max_stdout_bytes
+            record.stdout, record.stdout_truncated = cap_output(
+                raw_stdout, self.config.max_stdout_bytes
             )
-            record.stderr_truncated = (
-                len(raw_stderr.encode("utf-8", errors="replace")) > self.config.max_stderr_bytes
+            record.stderr, record.stderr_truncated = cap_output(
+                raw_stderr, self.config.max_stderr_bytes
             )
 
             # Resource usage
@@ -846,19 +837,10 @@ class CodeExecutor:
             # Collect artifacts from output directory
             record.artifacts = self._collect_artifacts(output_dir, job_id)
 
-            # Read main JSON result (if present)
-            output_file = output_dir / "result.json"
-            # Untrusted code could point result.json at a host file; never follow it.
-            if output_file.is_symlink():
-                logger.warning("result.json is a symlink, ignoring")
-            elif output_file.exists():
-                try:
-                    record.result_json = json.loads(output_file.read_text(encoding="utf-8"))
-                except (json.JSONDecodeError, OSError, ValueError) as e:
-                    # Output existed but was unreadable/unparseable (truncated,
-                    # non-UTF-8, device error). Surface it loudly instead of
-                    # presenting result_json=None as "no output produced".
-                    logger.warning("Failed to read/parse result.json for job %s: %s", job_id, e)
+            # Read main JSON result (if present). Symlink-safe and surfaces an
+            # unreadable/unparseable file via the shared helper so the worker
+            # and the library Sandbox parse it identically.
+            record.result_json = read_result_json(output_dir, job_id)
 
             # Parse phase timing file (written by entrypoint.sh). The
             # root-only meta_dir copy is preferred; the /output copy is a
@@ -1349,48 +1331,28 @@ class CodeExecutor:
         if extra_requirements:
             all_requirements.extend(extra_requirements)
 
-        if len(all_requirements) > MAX_REQUIREMENTS:
-            logger.error(
-                "Job has %s requirements (max %s). Use pre-built images for large dependency sets.",
-                len(all_requirements),
-                MAX_REQUIREMENTS,
+        # Validate, cap, gate, and persist runtime requirements via the shared
+        # helper so this path and the library Sandbox apply identical policy.
+        # The helper REJECTS an invalid requirement (raises ValueError) rather
+        # than silently skipping it: a typo or injection attempt now fails the
+        # job loudly instead of running with a different dependency set than the
+        # caller asked for.
+        try:
+            validated_reqs = prepare_requirements_file(
+                all_requirements,
+                input_dir,
+                allow_runtime_requirements=self.config.allow_runtime_requirements,
+                max_requirements=MAX_REQUIREMENTS,
             )
+        except ValueError as e:
+            logger.warning("Refusing job %s: %s", job_id, e)
             return {
                 "success": False,
-                "error": f"Too many requirements ({len(all_requirements)} > {MAX_REQUIREMENTS})",
+                "error": str(e),
                 "stdout": "",
-                "stderr": "Use pre-built images for jobs with many dependencies",
+                "stderr": str(e),
                 "exit_code": -1,
             }
-
-        validated_reqs = []
-        for req in all_requirements:
-            if validate_pip_requirement(req):
-                validated_reqs.append(req)
-            else:
-                logger.warning("Skipping invalid pip requirement: %s", req)
-
-        requirements_file = input_dir / "_requirements.txt"
-        if validated_reqs:
-            if not self.config.allow_runtime_requirements:
-                logger.warning(
-                    "Refusing job %s: %d runtime requirement(s) requested but "
-                    "allow_runtime_requirements=false",
-                    job_id,
-                    len(validated_reqs),
-                )
-                return {
-                    "success": False,
-                    "error": "Runtime dependency installation is disabled",
-                    "stdout": "",
-                    "stderr": (
-                        "Runtime dependency installation is disabled. "
-                        "Use pre-built images or set allow_runtime_requirements=true."
-                    ),
-                    "exit_code": -1,
-                }
-            requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
-            requirements_file.chmod(0o444)
 
         # Check if runtime deps require network access
         has_runtime_deps = bool(validated_reqs)
@@ -1515,26 +1477,16 @@ class CodeExecutor:
                 cmd, timeout=container_timeout, capture_output=True, text=True, check=False
             )
 
-            # `docker run` reserves exit code 125 for failures of docker itself
-            # (daemon unreachable, image pull failure, bad flags); container
-            # exit codes pass through unchanged otherwise, and our entrypoint
-            # never exits 125 in normal operation. Treat 125 — or daemon
-            # connectivity errors on stderr of a failed run — as infrastructure
-            # failures: they must count against the circuit breaker, be marked
-            # retriable via the "error" key, and never be attributed to the
-            # user's code by classify_error.
-            stderr_lower = (result.stderr or "").lower()
-            is_infra_failure = result.returncode == 125 or (
-                result.returncode != 0
-                and any(pattern in stderr_lower for pattern in _DOCKER_INFRA_STDERR_PATTERNS)
+            # Distinguish docker-itself failures (daemon unreachable, image
+            # pull failure, bad flags: exit 125 or daemon-connectivity stderr)
+            # from container exits via the shared classifier. Infra failures
+            # must count against the circuit breaker, be marked retriable via
+            # the "error" key, and never be attributed to the user's code by
+            # classify_error.
+            is_infra_failure, detail = classify_docker_run_result(
+                result.returncode, result.stderr or ""
             )
             if is_infra_failure:
-                stderr_lines = (result.stderr or "").strip().splitlines()
-                detail = (
-                    stderr_lines[0]
-                    if stderr_lines
-                    else f"docker run exited with code {result.returncode}"
-                )
                 circuit_breaker.record_failure(detail)
                 return {
                     "success": False,
@@ -1551,13 +1503,13 @@ class CodeExecutor:
 
             # Exit 137 is SIGKILL — could be the OOM killer, but also `docker
             # kill` (cancel path), a pids-limit kill, or user sys.exit(137).
-            # Only the exited container's State.OOMKilled distinguishes them;
-            # inspect before the finally block removes the container. Note:
-            # in-container timeout kills are already remapped to 124 by the
-            # entrypoint, so a 137 seen here is a genuine SIGKILL.
+            # classify_sigkill inspects the exited container's State.OOMKilled
+            # before the finally block removes it. Note: in-container timeout
+            # kills are already remapped to 124 by the entrypoint, so a 137 seen
+            # here is a genuine SIGKILL.
             oom_killed: Optional[bool] = None
             if result.returncode == 137:
-                oom_killed = inspect_oom_killed(container_name)
+                oom_killed = classify_sigkill(container_name)
 
             return {
                 "success": result.returncode == 0,

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -7,11 +7,42 @@ used throughout the system. Designed for SVG/artifact-based workflows.
 
 import hashlib
 import json
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
+
+# Full sha256 hexdigest: exactly 64 lowercase hex characters. Compiled once and
+# reused by every hash-field and sha256-field validator below.
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+def _validate_optional_sha256_hex(v: Optional[str]) -> Optional[str]:
+    """Validate a hash field is empty/None or a 64-char lowercase hex string.
+
+    Shared by ExecutionRecord and JobVersion hash-field validators so the rule
+    (and its error message) live in one place.
+    """
+    if v is None or v == "":
+        return v
+    if not _SHA256_RE.match(v):
+        raise ValueError("Hash must be empty or 64-character lowercase hex string")
+    return v
+
+
+def _validate_safe_filename(v: str) -> str:
+    """Validate a filename is safe (no path traversal).
+
+    Shared by InputArtifact and Artifact so the path-traversal rule lives in one
+    place.
+    """
+    if "/" in v or "\\" in v:
+        raise ValueError("Filename cannot contain path separators")
+    if v in ("..", "."):
+        raise ValueError("Invalid filename")
+    return v
 
 
 def sha256_json(obj: object) -> str:
@@ -102,7 +133,7 @@ class InputArtifact(BaseModel):
     size_bytes: int = Field(..., ge=0, le=1073741824)  # Max 1GB
     """File size in bytes."""
 
-    sha256: str = Field(..., min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$")
+    sha256: str = Field(..., min_length=64, max_length=64, pattern=_SHA256_RE.pattern)
     """SHA256 hash of file contents (hex-encoded)."""
 
     content_type: Optional[str] = Field(default=None, max_length=255)
@@ -115,11 +146,7 @@ class InputArtifact(BaseModel):
     @classmethod
     def validate_filename(cls, v: str) -> str:
         """Validate filename is safe (no path traversal)."""
-        if "/" in v or "\\" in v:
-            raise ValueError("Filename cannot contain path separators")
-        if v in ("..", "."):
-            raise ValueError("Invalid filename")
-        return v
+        return _validate_safe_filename(v)
 
 
 class Artifact(BaseModel):
@@ -133,7 +160,7 @@ class Artifact(BaseModel):
     size_bytes: int = Field(..., ge=0, le=1073741824)  # Max 1GB
     """File size in bytes."""
 
-    sha256: str = Field(..., min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$")
+    sha256: str = Field(..., min_length=64, max_length=64, pattern=_SHA256_RE.pattern)
     """SHA256 hash of file contents (hex-encoded)."""
 
     content_type: Optional[str] = Field(default=None, max_length=255)
@@ -146,11 +173,7 @@ class Artifact(BaseModel):
     @classmethod
     def validate_filename(cls, v: str) -> str:
         """Validate filename is safe (no path traversal)."""
-        if "/" in v or "\\" in v:
-            raise ValueError("Filename cannot contain path separators")
-        if v in ("..", "."):
-            raise ValueError("Invalid filename")
-        return v
+        return _validate_safe_filename(v)
 
 
 # Canonical error type values (from security.classify_error)
@@ -328,13 +351,7 @@ class ExecutionRecord(BaseModel):
     @classmethod
     def validate_hash_field(cls, v: Optional[str]) -> Optional[str]:
         """Validate hash fields are either empty/None or valid SHA256 hex strings."""
-        import re
-
-        if v is None or v == "":
-            return v
-        if len(v) != 64 or not re.match(r"^[a-f0-9]{64}$", v):
-            raise ValueError("Hash must be empty or 64-character lowercase hex string")
-        return v
+        return _validate_optional_sha256_hex(v)
 
     # Input artifacts (for file-based inputs like SVG)
     input_artifacts: List[InputArtifact] = Field(default_factory=list)
@@ -430,7 +447,7 @@ class JobVersion(BaseModel):
     version_tag: Optional[str] = Field(default=None, max_length=64)
     """Semantic version tag, e.g., 'v1.0.0'."""
 
-    digest: str = Field(..., min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$")
+    digest: str = Field(..., min_length=64, max_length=64, pattern=_SHA256_RE.pattern)
     """SHA256 digest of job type configuration (full hex string)."""
 
     # Build metadata
@@ -454,13 +471,7 @@ class JobVersion(BaseModel):
     @classmethod
     def validate_hash_field(cls, v: str) -> str:
         """Validate hash fields are either empty or valid SHA256 hex strings."""
-        import re
-
-        if v == "":
-            return v
-        if len(v) != 64 or not re.match(r"^[a-f0-9]{64}$", v):
-            raise ValueError("Hash must be empty or 64-character lowercase hex string")
-        return v
+        return _validate_optional_sha256_hex(v) or ""
 
     @property
     def full_ref(self) -> str:

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -36,14 +36,16 @@ from tako_vm.constants import (
 from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import (
     base_isolation_args,
+    classify_docker_run_result,
+    classify_sigkill,
     decode_subprocess_stream,
     generate_container_name,
     image_exists,
-    inspect_oom_killed,
+    prepare_requirements_file,
+    read_result_json,
     remove_container,
     ulimit_args,
 )
-from tako_vm.security import validate_pip_requirement
 
 logger = logging.getLogger(__name__)
 
@@ -427,20 +429,34 @@ class Sandbox:
                     )
                     duration_ms = int((time.time() - start_time) * 1000)
 
-                    # Read output
-                    output_data = None
-                    output_file = output_dir / "result.json"
-                    if output_file.exists():
-                        try:
-                            output_data = json.loads(output_file.read_text())
-                        except (json.JSONDecodeError, OSError, ValueError) as e:
-                            # Output existed but was unreadable/unparseable.
-                            # Don't silently present None as "no output".
-                            logger.warning(
-                                "result.json for %s was not valid JSON, ignoring: %s",
-                                container_name,
-                                e,
-                            )
+                    # Distinguish docker-itself failures (daemon unreachable,
+                    # image pull failure, bad flags) from container exits via
+                    # the shared classifier. The library Sandbox has no circuit
+                    # breaker, but it must still surface an infra failure
+                    # distinctly rather than presenting daemon stderr as if the
+                    # user's code had failed.
+                    is_infra_failure, detail = classify_docker_run_result(
+                        proc.returncode, proc.stderr or ""
+                    )
+                    if is_infra_failure:
+                        logger.warning(
+                            "Sandbox %s hit a Docker infrastructure failure: %s",
+                            container_name,
+                            detail,
+                        )
+                        return SandboxResult(
+                            stdout=proc.stdout,
+                            stderr=proc.stderr,
+                            exit_code=proc.returncode,
+                            success=False,
+                            duration_ms=duration_ms,
+                            error=f"Docker infrastructure failure: {detail}",
+                        )
+
+                    # Read output (symlink-safe; surfaces an unreadable file)
+                    # via the shared helper so the library and worker paths
+                    # parse result.json identically.
+                    output_data = read_result_json(output_dir, container_name)
 
                     # The in-container timeout (TAKO_EXECUTION_TIMEOUT, enforced
                     # by entrypoint.sh via timeout(1)) exits 124 when the code
@@ -453,15 +469,14 @@ class Sandbox:
                     elif proc.returncode == 137:
                         # Exit 137 is SIGKILL — could be the OOM killer, but
                         # also `docker kill` or user code calling
-                        # sys.exit(137). Only the exited container's
-                        # State.OOMKilled distinguishes them; inspect before
-                        # the finally block removes the container. In-container
-                        # timeout kills are already remapped to 124 by the
-                        # entrypoint, so a 137 seen here is a genuine SIGKILL.
-                        # None (inspect failed) falls back to reporting OOM so
-                        # a flaky inspect never loses a true OOM — same policy
-                        # as the server-side CodeExecutor.
-                        oom_killed = inspect_oom_killed(container_name)
+                        # sys.exit(137). classify_sigkill inspects the exited
+                        # container's State.OOMKilled before the finally block
+                        # removes it. In-container timeout kills are already
+                        # remapped to 124 by the entrypoint, so a 137 seen here
+                        # is a genuine SIGKILL. None (inspect failed) falls back
+                        # to reporting OOM so a flaky inspect never loses a true
+                        # OOM (same policy as the server-side CodeExecutor).
+                        oom_killed = classify_sigkill(container_name)
                         if oom_killed is False:
                             error = "Process was killed (SIGKILL) but not by the memory limit"
                         else:
@@ -534,28 +549,15 @@ class Sandbox:
         Returns:
             Tuple of (command, container_name) for cleanup on timeout.
         """
-        validated_reqs = []
-        if requirements:
-            # Enforce the policy before validation so an all-invalid list
-            # cannot bypass the allow_runtime_requirements check.
-            if not self.config.allow_runtime_requirements:
-                raise ValueError(
-                    "Runtime dependency installation is disabled. "
-                    "Use pre-built images or set allow_runtime_requirements=True."
-                )
-            if len(requirements) > MAX_REQUIREMENTS:
-                raise ValueError(
-                    f"Too many requirements ({len(requirements)} > {MAX_REQUIREMENTS})"
-                )
-            for req in requirements:
-                if not validate_pip_requirement(req):
-                    raise ValueError(f"Invalid pip requirement: {req!r}")
-                validated_reqs.append(req)
-
-        if validated_reqs:
-            requirements_file = input_dir / "_requirements.txt"
-            requirements_file.write_text("\n".join(validated_reqs) + "\n", encoding="utf-8")
-            requirements_file.chmod(0o444)
+        # Validate, cap, gate, and persist requirements via the shared helper so
+        # the library path and the server worker apply identical policy (invalid
+        # requirements are rejected with ValueError, never silently skipped).
+        validated_reqs = prepare_requirements_file(
+            requirements,
+            input_dir,
+            allow_runtime_requirements=self.config.allow_runtime_requirements,
+            max_requirements=MAX_REQUIREMENTS,
+        )
 
         # Generate container name for tracking (allows cleanup on timeout)
         container_name = generate_container_name("tako-sandbox")

--- a/tako_vm/security.py
+++ b/tako_vm/security.py
@@ -82,25 +82,30 @@ def sanitize_error(error: str) -> str:
     return result
 
 
-def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> str:
+def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> Tuple[str, bool]:
     """
     Cap output to maximum byte size.
 
     Truncates at UTF-8 character boundary and adds truncation notice.
+
+    Single source of truth for the truncation decision: callers must use the
+    returned boolean rather than recomputing the encoded-size comparison, so
+    the in-band notice and the out-of-band flag can never disagree.
 
     Args:
         output: Raw output string
         max_bytes: Maximum size in bytes
 
     Returns:
-        Capped output with truncation notice if truncated
+        Tuple of (capped output with truncation notice if truncated, truncated
+        flag).
     """
     if not output:
-        return ""
+        return "", False
 
     encoded = output.encode("utf-8", errors="replace")
     if len(encoded) <= max_bytes:
-        return output
+        return output, False
 
     # Leave room for truncation message
     truncation_msg = f"\n\n[TRUNCATED: output exceeded {max_bytes} bytes]"
@@ -108,7 +113,7 @@ def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> str:
     available_bytes = max_bytes - truncation_bytes
 
     if available_bytes <= 0:
-        return truncation_msg
+        return truncation_msg, True
 
     # Truncate at byte boundary, then decode
     truncated_bytes = encoded[:available_bytes]
@@ -123,7 +128,7 @@ def cap_output(output: str, max_bytes: int = DEFAULT_MAX_STDOUT_BYTES) -> str:
     else:
         truncated = ""
 
-    return truncated + truncation_msg
+    return truncated + truncation_msg, True
 
 
 def validate_artifact_size(

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -520,6 +520,22 @@ class JobTypeResponse(BaseModel):
     gpu_vendor: Optional[str] = None
     image_exists: bool
 
+    @classmethod
+    def from_job_type(cls, jt, builder) -> "JobTypeResponse":
+        """Build a response from a job type, resolving image availability."""
+        return cls(
+            name=jt.name,
+            requirements=jt.requirements,
+            python_version=jt.python_version,
+            memory_limit=jt.memory_limit,
+            cpu_limit=jt.cpu_limit,
+            timeout=jt.timeout,
+            session_enabled=jt.session_enabled,
+            gpu_enabled=jt.gpu_enabled,
+            gpu_vendor=jt.gpu_vendor,
+            image_exists=builder.image_exists(jt),
+        )
+
 
 class CircuitBreakerStatus(BaseModel):
     """Circuit breaker status for health monitoring."""
@@ -557,15 +573,9 @@ class HealthResponse(BaseModel):
     queue_stats: QueueStatsResponse
 
 
-class PoolStatsResponse(BaseModel):
-    """Response model for worker pool stats (deprecated, use QueueStatsResponse)."""
-
-    model_config = {"extra": "forbid"}
-
-    pending: int = Field(..., description="Number of jobs waiting in queue")
-    running: int = Field(..., description="Number of jobs currently executing")
-    max_workers: int = Field(..., description="Maximum concurrent workers")
-    max_queue_size: int = Field(..., description="Maximum queue capacity")
+# /pool/stats and /health.queue_stats return byte-identical shapes, so they
+# share a single model rather than maintaining two copies that can drift.
+PoolStatsResponse = QueueStatsResponse
 
 
 class PaginatedResponse(BaseModel):
@@ -1180,6 +1190,44 @@ def _get_replay_data(record: ExecutionRecord) -> tuple:
     return code, input_data, user_artifacts
 
 
+async def _submit_replay(
+    parent: ExecutionRecord,
+    *,
+    relationship: str,
+    code: str,
+    input_data: dict,
+    input_artifacts: list,
+    job_type: Optional[str],
+    timeout: Optional[int],
+    http_request: Request,
+) -> AsyncExecuteResponse:
+    """Build and submit a rerun/fork job that links back to ``parent``.
+
+    Shared by the rerun and fork endpoints, which differ only in which code
+    they replay and the relationship recorded on the new job.
+    """
+    job_data = {
+        "code": code,
+        "input_data": input_data,
+        "input_artifacts": input_artifacts,
+        "job_type": job_type or parent.job_type,
+        "parent_execution_id": parent.execution_id,
+        "relationship": relationship,
+        "correlation_id": get_correlation_id(),
+    }
+
+    if timeout:
+        job_data["timeout"] = timeout
+
+    new_job_id = await state.worker_pool.submit(
+        job_data=job_data, client_ip=http_request.client.host if http_request.client else None
+    )
+
+    logger.info(f"Job {new_job_id} created as {relationship} of {parent.execution_id}")
+
+    return AsyncExecuteResponse(job_id=new_job_id, status="queued")
+
+
 @app.post("/jobs/{job_id}/rerun", response_model=AsyncExecuteResponse)
 async def rerun_job(job_id: str, request: RerunRequest, http_request: Request):
     """
@@ -1213,27 +1261,16 @@ async def rerun_job(job_id: str, request: RerunRequest, http_request: Request):
         logger.error(f"Failed to get replay data for {job_id}: {e}")
         raise HTTPException(status_code=400, detail="Failed to retrieve replay data") from e
 
-    # Build job data with parent linkage
-    job_data = {
-        "code": code,
-        "input_data": input_data,
-        "input_artifacts": input_artifacts,
-        "job_type": request.job_type or parent.job_type,
-        "parent_execution_id": parent.execution_id,
-        "relationship": "rerun",
-        "correlation_id": get_correlation_id(),
-    }
-
-    if request.timeout:
-        job_data["timeout"] = request.timeout
-
-    new_job_id = await state.worker_pool.submit(
-        job_data=job_data, client_ip=http_request.client.host if http_request.client else None
+    return await _submit_replay(
+        parent,
+        relationship="rerun",
+        code=code,
+        input_data=input_data,
+        input_artifacts=input_artifacts,
+        job_type=request.job_type,
+        timeout=request.timeout,
+        http_request=http_request,
     )
-
-    logger.info(f"Job {new_job_id} created as rerun of {job_id}")
-
-    return AsyncExecuteResponse(job_id=new_job_id, status="queued")
 
 
 @app.post("/jobs/{job_id}/fork", response_model=AsyncExecuteResponse)
@@ -1265,27 +1302,16 @@ async def fork_job(job_id: str, request: ForkRequest, http_request: Request):
         logger.error(f"Failed to get replay data for {job_id}: {e}")
         raise HTTPException(status_code=400, detail="Failed to retrieve replay data") from e
 
-    # Build job data with new code and parent linkage
-    job_data = {
-        "code": request.code,
-        "input_data": input_data,
-        "input_artifacts": input_artifacts,
-        "job_type": request.job_type or parent.job_type,
-        "parent_execution_id": parent.execution_id,
-        "relationship": "fork",
-        "correlation_id": get_correlation_id(),
-    }
-
-    if request.timeout:
-        job_data["timeout"] = request.timeout
-
-    new_job_id = await state.worker_pool.submit(
-        job_data=job_data, client_ip=http_request.client.host if http_request.client else None
+    return await _submit_replay(
+        parent,
+        relationship="fork",
+        code=request.code,
+        input_data=input_data,
+        input_artifacts=input_artifacts,
+        job_type=request.job_type,
+        timeout=request.timeout,
+        http_request=http_request,
     )
-
-    logger.info(f"Job {new_job_id} created as fork of {job_id}")
-
-    return AsyncExecuteResponse(job_id=new_job_id, status="queued")
 
 
 @app.get("/jobs/{job_id}/artifacts/{artifact_name}")
@@ -1374,17 +1400,16 @@ async def list_executions(
     Returns paginated list of execution records with metadata for efficient client-side pagination.
     Use ?view=full to include artifacts, resource usage, content hashes, and lineage info.
     """
-    actual_limit = min(limit, 1000)
     records = await state.storage.list_records(
         status=status,
         job_type=job_type,
-        limit=actual_limit + 1,  # Fetch one extra to check has_more
+        limit=limit + 1,  # Fetch one extra to check has_more
         offset=offset,
     )
 
-    has_more = len(records) > actual_limit
+    has_more = len(records) > limit
     if has_more:
-        records = records[:actual_limit]
+        records = records[:limit]
 
     if view == "full":
         items = [ExecutionRecordFullResponse.from_record(r) for r in records]
@@ -1393,7 +1418,7 @@ async def list_executions(
 
     return PaginatedResponse(
         items=items,
-        limit=actual_limit,
+        limit=limit,
         offset=offset,
         has_more=has_more,
         count=len(records),
@@ -1439,23 +1464,7 @@ async def list_job_types():
 
     builder = ContainerBuilder()
 
-    result = []
-    for jt in state.registry.list():
-        result.append(
-            JobTypeResponse(
-                name=jt.name,
-                requirements=jt.requirements,
-                python_version=jt.python_version,
-                memory_limit=jt.memory_limit,
-                cpu_limit=jt.cpu_limit,
-                timeout=jt.timeout,
-                session_enabled=jt.session_enabled,
-                gpu_enabled=jt.gpu_enabled,
-                gpu_vendor=jt.gpu_vendor,
-                image_exists=builder.image_exists(jt),
-            )
-        )
-    return result
+    return [JobTypeResponse.from_job_type(jt, builder) for jt in state.registry.list()]
 
 
 @app.get("/job-types/{name}", response_model=JobTypeResponse)
@@ -1476,18 +1485,7 @@ async def get_job_type(name: str):
         raise HTTPException(status_code=404, detail=f"Job type '{name}' not found")
 
     builder = ContainerBuilder()
-    return JobTypeResponse(
-        name=jt.name,
-        requirements=jt.requirements,
-        python_version=jt.python_version,
-        memory_limit=jt.memory_limit,
-        cpu_limit=jt.cpu_limit,
-        timeout=jt.timeout,
-        session_enabled=jt.session_enabled,
-        gpu_enabled=jt.gpu_enabled,
-        gpu_vendor=jt.gpu_vendor,
-        image_exists=builder.image_exists(jt),
-    )
+    return JobTypeResponse.from_job_type(jt, builder)
 
 
 @app.post("/job-types/{name}/build", response_model=BuildResponse)
@@ -1569,20 +1567,19 @@ async def list_dlq_entries(
 
     Returns paginated list of failed jobs for debugging and reprocessing.
     """
-    actual_limit = min(limit, 1000)
     entries = await state.storage.list_dlq_entries(
         error_type=error_type,
-        limit=actual_limit + 1,  # Fetch one extra to check has_more
+        limit=limit + 1,  # Fetch one extra to check has_more
         offset=offset,
     )
 
-    has_more = len(entries) > actual_limit
+    has_more = len(entries) > limit
     if has_more:
-        entries = entries[:actual_limit]
+        entries = entries[:limit]
 
     return PaginatedResponse(
         items=[entry.model_dump() for entry in entries],
-        limit=actual_limit,
+        limit=limit,
         offset=offset,
         has_more=has_more,
         count=len(entries),

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -291,6 +291,33 @@ _UPDATE_SET_SQL = ",\n                    ".join(
 )
 
 
+# --- job_versions upsert: single source of truth for the column set -----------
+#
+# Same pattern as _EXECUTION_COLUMNS above: the INSERT column list, placeholder
+# run, value tuple, and ON CONFLICT ... SET clause are all derived from this one
+# list, so adding/removing a column is a single edit instead of four hand-synced
+# ones. (digest, value_extractor(version)). digest is the ON CONFLICT key and
+# carries no SET line; every other column takes EXCLUDED (a re-save replaces the
+# stored metadata).
+_VERSION_KEY_COLUMN = "digest"
+_VERSION_COLUMNS: list = [
+    ("digest", lambda v: v.digest),
+    ("job_type_name", lambda v: v.job_type_name),
+    ("version_tag", lambda v: v.version_tag),
+    ("built_at", lambda v: v.built_at),
+    ("built_by", lambda v: v.built_by),
+    ("dockerfile_hash", lambda v: v.dockerfile_hash),
+    ("requirements_hash", lambda v: v.requirements_hash),
+    ("image_ref", lambda v: v.image_ref),
+]
+
+_VERSION_INSERT_COLUMN_SQL = ", ".join(name for name, _ in _VERSION_COLUMNS)
+_VERSION_INSERT_PLACEHOLDER_SQL = ", ".join(["%s"] * len(_VERSION_COLUMNS))
+_VERSION_UPDATE_SET_SQL = ",\n                    ".join(
+    f"{name} = EXCLUDED.{name}" for name, _ in _VERSION_COLUMNS if name != _VERSION_KEY_COLUMN
+)
+
+
 class ExecutionStorage:
     """PostgreSQL storage for execution records."""
 
@@ -727,31 +754,16 @@ class ExecutionStorage:
         pool = self._get_pool()
         async with pool.connection() as conn:
             await conn.execute(
-                """
+                f"""
                 INSERT INTO job_versions (
-                    digest, job_type_name, version_tag,
-                    built_at, built_by, dockerfile_hash,
-                    requirements_hash, image_ref
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (digest) DO UPDATE SET
-                    job_type_name = EXCLUDED.job_type_name,
-                    version_tag = EXCLUDED.version_tag,
-                    built_at = EXCLUDED.built_at,
-                    built_by = EXCLUDED.built_by,
-                    dockerfile_hash = EXCLUDED.dockerfile_hash,
-                    requirements_hash = EXCLUDED.requirements_hash,
-                    image_ref = EXCLUDED.image_ref
+                    {_VERSION_INSERT_COLUMN_SQL}
+                ) VALUES (
+                    {_VERSION_INSERT_PLACEHOLDER_SQL}
+                )
+                ON CONFLICT ({_VERSION_KEY_COLUMN}) DO UPDATE SET
+                    {_VERSION_UPDATE_SET_SQL}
                 """,
-                (
-                    version.digest,
-                    version.job_type_name,
-                    version.version_tag,
-                    version.built_at,
-                    version.built_by,
-                    version.dockerfile_hash,
-                    version.requirements_hash,
-                    version.image_ref,
-                ),
+                tuple(extract(version) for _, extract in _VERSION_COLUMNS),
             )
 
     async def get_version_by_digest(self, job_type_name: str, digest: str) -> Optional[JobVersion]:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -540,7 +540,7 @@ class TestSandboxOOMDetection:
             lambda self, **kwargs: (["docker", "run", "fake"], "fake-container"),
         )
         monkeypatch.setattr("tako_vm.sandbox.subprocess.run", fake_run)
-        monkeypatch.setattr("tako_vm.sandbox.inspect_oom_killed", fake_inspect)
+        monkeypatch.setattr("tako_vm.sandbox.classify_sigkill", fake_inspect)
         monkeypatch.setattr("tako_vm.sandbox.remove_container", fake_remove)
         return sb
 


### PR DESCRIPTION
Stack 2/4. Consolidation / dedup. **Base: rf/1-simplify** (review after 1/4).

- extract `prepare_requirements_file`, `classify_docker_run_result`, `classify_sigkill`, `read_result_json` into docker.py; route both the worker and the library Sandbox through them
- single-source `save_version` columns; shared sha256/filename validators and size parser
- `cap_output` returns its own truncation flag; `docker_image` references the constant
- `from_job_type` / `_submit_replay` / `PoolStatsResponse` alias; CLI mask + postgres-probe helpers

Stack: 1/4 simplify -> **2/4 consolidate** -> 3/4 durable -> 4/4 verbose-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)