### PR TITLE
fix(durable): correctness and reliability fixes

### DIFF
--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -275,13 +275,21 @@ def run_setup(args):
 
     # Verify with a quick test
     print("Verifying...")
-    result = subprocess.run(
-        ["docker", "run", "--rm", "--entrypoint", "python", DEFAULT_IMAGE, "-c", "print('ok')"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["docker", "run", "--rm", "--entrypoint", "python", DEFAULT_IMAGE, "-c", "print('ok')"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        # A hung verification means the image is unusable; exit non-zero so
+        # `tako-vm setup && ...` doesn't proceed on a broken image and report
+        # success.
+        print("Error: Image pulled but verification failed.", file=sys.stderr)
+        print("  Verification timed out after 30s.", file=sys.stderr)
+        sys.exit(1)
     if result.returncode == 0 and "ok" in result.stdout:
         print("  Executor image works")
     else:

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -531,10 +531,21 @@ class TakoVMConfig(BaseModel):
         return self
 
     def resolve_paths(self) -> "TakoVMConfig":
-        """Resolve all paths and create directories."""
-        # Data directory
+        """Resolve all paths and create the data directory.
+
+        Pure path resolution lives in ``_resolve_path_strings``; the data
+        directory creation is the one explicit, idempotent side effect and is
+        kept in ``_ensure_data_dir`` so callers (and the ``data_dir`` property)
+        can be reasoned about clearly. Behavior is unchanged: this still
+        resolves every path and mkdir's the data dir.
+        """
+        self._resolve_path_strings()
+        self._ensure_data_dir()
+        return self
+
+    def _resolve_path_strings(self) -> None:
+        """Resolve configured path strings to Path objects (no filesystem writes)."""
         self._resolved_data_dir = Path(self.data_dir_str)
-        self._resolved_data_dir.mkdir(parents=True, exist_ok=True)
 
         # Seccomp profile
         if self.seccomp_profile_path_str:
@@ -544,14 +555,23 @@ class TakoVMConfig(BaseModel):
                 str(_resource_files("tako_vm").joinpath("seccomp_profile.json"))
             )
 
-        return self
+    def _ensure_data_dir(self) -> None:
+        """Create the resolved data directory if missing (idempotent mkdir)."""
+        if self._resolved_data_dir is None:
+            self._resolve_path_strings()
+        self._resolved_data_dir.mkdir(parents=True, exist_ok=True)  # type: ignore
 
     # Backward-compatible properties that return Path objects
     @property
     def data_dir(self) -> Path:
-        """Get data directory as Path (backward compatible)."""
+        """Get data directory as Path (backward compatible).
+
+        Reading this property ensures the data directory exists, preserving the
+        historical mkdir-on-access behavior that existing callers rely on.
+        """
         if self._resolved_data_dir is None:
-            self.resolve_paths()
+            self._resolve_path_strings()
+        self._ensure_data_dir()
         return self._resolved_data_dir  # type: ignore
 
     @property
@@ -750,7 +770,13 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
         # which can leak secrets (e.g. database_url passwords) into logs/CLI output.
         raise ConfigurationError(f"Invalid configuration: {_sanitize_validation_error(e)}") from e
     except Exception as e:
-        raise ConfigurationError(f"Invalid configuration: {e}") from e
+        # Do not interpolate the raw exception text: like ValidationError it can
+        # echo arbitrary config payloads (e.g. database_url passwords) into logs
+        # and CLI output. Log the type for diagnosis and surface only the type.
+        logger.error("Configuration load failed with %s", type(e).__name__, exc_info=True)
+        raise ConfigurationError(
+            f"Invalid configuration: {type(e).__name__} (see logs for details)"
+        ) from e
 
     for warning in config.security_warnings():
         logger.warning(warning)

--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -210,34 +210,43 @@ WORKDIR /app
             dockerfile_path = build_path / "Dockerfile"
             dockerfile_path.write_text(dockerfile_content, encoding="utf-8")
 
-            # Copy custom_libs
-            custom_libs_dest = build_path / "custom_libs"
-            custom_libs_dest.mkdir()
-            if self.custom_libs_path.exists():
-                for item in self.custom_libs_path.iterdir():
-                    if item.is_file():
-                        shutil.copy2(item, custom_libs_dest)
+            # Prepare the build context (copy custom_libs / shared_code). Wrap
+            # the filesystem work so an OSError here surfaces as a BuildError,
+            # letting build_all record a single failure for this job type
+            # instead of aborting the whole batch.
+            try:
+                # Copy custom_libs
+                custom_libs_dest = build_path / "custom_libs"
+                custom_libs_dest.mkdir()
+                if self.custom_libs_path.exists():
+                    for item in self.custom_libs_path.iterdir():
+                        if item.is_file():
+                            shutil.copy2(item, custom_libs_dest)
 
-            # Copy shared code with path validation
-            shared_code_dest = build_path / "shared_code"
-            shared_code_dest.mkdir()
-            # Get current working directory as the allowed base for shared_code
-            allowed_base = Path.cwd().resolve()
-            for code_path in job_type.shared_code:
-                src = Path(code_path).resolve()
-                # Security: Ensure shared_code paths don't escape the allowed directory
-                try:
-                    src.relative_to(allowed_base)
-                except ValueError:
-                    logger.warning(
-                        "Skipping shared_code path that escapes allowed directory: %s", code_path
-                    )
-                    continue
-                if src.exists():
-                    if src.is_file():
-                        shutil.copy2(src, shared_code_dest)
-                    else:
-                        shutil.copytree(src, shared_code_dest / src.name)
+                # Copy shared code with path validation
+                shared_code_dest = build_path / "shared_code"
+                shared_code_dest.mkdir()
+                # Get current working directory as the allowed base for shared_code
+                allowed_base = Path.cwd().resolve()
+                for code_path in job_type.shared_code:
+                    src = Path(code_path).resolve()
+                    # Security: Ensure shared_code paths don't escape the allowed directory
+                    try:
+                        src.relative_to(allowed_base)
+                    except ValueError:
+                        logger.warning(
+                            "Skipping shared_code path that escapes allowed directory: %s",
+                            code_path,
+                        )
+                        continue
+                    if src.exists():
+                        if src.is_file():
+                            shutil.copy2(src, shared_code_dest)
+                        else:
+                            shutil.copytree(src, shared_code_dest / src.name)
+            except OSError as e:
+                logger.error("Failed to prepare build context for %s: %s", job_type.name, e)
+                raise BuildError(f"Failed to prepare build context for {job_type.name}: {e}") from e
 
             # Build the image
             cmd = ["docker", "build", "-t", job_type.image_name]
@@ -246,7 +255,9 @@ WORKDIR /app
             cmd.append(str(build_path))
 
             try:
-                subprocess.run(cmd, capture_output=not quiet, text=True, check=True)
+                # Generous timeout: image builds can install many deps, but an
+                # unbounded subprocess.run could hang the caller forever.
+                subprocess.run(cmd, capture_output=not quiet, text=True, check=True, timeout=1800)
                 logger.info("Successfully built image: %s", job_type.image_name)
                 # The tag now points at new content: drop any cached inspect
                 # results so the worker re-verifies the rebuilt image.
@@ -266,6 +277,11 @@ WORKDIR /app
                         job_type.name,
                     )
                 return True
+            except subprocess.TimeoutExpired as e:
+                logger.error("Build timed out for %s after %ss", job_type.name, e.timeout)
+                raise BuildError(
+                    f"Failed to build {job_type.name}: docker build timed out after {e.timeout}s"
+                ) from e
             except subprocess.CalledProcessError as e:
                 error_msg = e.stderr if e.stderr else str(e)
                 logger.error("Failed to build image: %s", error_msg)

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -848,11 +848,15 @@ class CodeExecutor:
             timing = parse_phase_file(output_dir, meta_dir)
             record.timing = timing
 
-            # Determine which phase timed out (if applicable)
-            internal_timeout = result.get("exit_code") == 124 and determine_timeout_phase(
-                timing, True
-            )
-            timeout_phase = determine_timeout_phase(timing, timed_out) or internal_timeout
+            # Exit 124 is the in-container timeout (entrypoint's timeout(1)
+            # remaps a timed-out phase to 124). It is a timeout regardless of
+            # whether a phase file exists to attribute it: a missing phase file
+            # must not demote a real timeout to a generic failure, so this is a
+            # plain boolean independent of determine_timeout_phase.
+            internal_timeout = result.get("exit_code") == 124
+            # phase attribution is best-effort and may be None when no timing
+            # data was written.
+            timeout_phase = determine_timeout_phase(timing, timed_out or internal_timeout)
 
             # Determine final status with phase-aware timeout handling
             if timed_out or internal_timeout:

--- a/tako_vm/job_types.py
+++ b/tako_vm/job_types.py
@@ -149,6 +149,12 @@ class JobType:
         same pydantic constraints as the YAML config path. Raises
         pydantic.ValidationError on out-of-bounds or malformed values.
         """
+        # GPU config has a canonical nested form (the ``gpu`` object) which is
+        # the ONLY shape to_dict ever emits, so round-tripped registry files
+        # always use it. Flat top-level keys (gpu_enabled/gpu_vendor/gpu_count/
+        # gpu_device_ids) are accepted for backward compatibility with
+        # hand-written entries and take PRECEDENCE over the nested values when
+        # both are present (flat first, nested as the fallback default).
         gpu = data.get("gpu") or {}
 
         candidate = cls(

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -242,7 +242,16 @@ class ExecutionError(BaseModel):
     """Which phase the error occurred in (startup or execution)."""
 
 
-# Canonical job status values
+# Canonical job status values.
+#
+# JobStatus and ErrorType deliberately use DISTINCT vocabularies. The
+# phase-specific ErrorType values (startup_timeout, execution_timeout) and
+# 'interrupted' are NEVER assigned to a record's status: worker.py collapses
+# both timeout phases to status='timeout' and records the phase only on
+# error.type, and reconcile_stale_records sets status='failed' with
+# error.type='interrupted'. So this list does not need to be a superset of
+# ErrorType; every value worker.py writes to ExecutionRecord.status is present
+# here, which is what keeps stored records loadable.
 JobStatus = Literal[
     "queued",  # Submitted, waiting in queue
     "running",  # Currently executing

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -46,6 +46,7 @@ from tako_vm.execution.docker import (
     remove_container,
     ulimit_args,
 )
+from tako_vm.security import validate_docker_run_args
 
 logger = logging.getLogger(__name__)
 
@@ -655,6 +656,13 @@ class Sandbox:
 
         # Image
         cmd.append(self.config.image)
+
+        # Defense-in-depth: validate the assembled argv before it is executed,
+        # mirroring the server worker (issue: library mode previously skipped
+        # this control). Raises so run() reports a failed SandboxResult instead
+        # of executing an argv that failed the safety check.
+        if not validate_docker_run_args(cmd):
+            raise ValueError("Unsafe Docker command rejected: arguments failed safety validation")
 
         return cmd, container_name
 

--- a/tako_vm/sdk/client.py
+++ b/tako_vm/sdk/client.py
@@ -506,7 +506,7 @@ class TakoVM:
 
         try:
             return cast(OutputT, output_cls(**cast(Dict[str, Any], result.output)))
-        except (TypeError, ValueError) as e:
+        except (TypeError, ValueError, KeyError) as e:
             raise ValidationError(
                 f"Failed to deserialize output to {output_cls.__name__}: {e}"
             ) from e
@@ -931,11 +931,18 @@ _execute()
             params["timeout"] = wait_timeout
         if view:
             params["view"] = view
+        # The server long-poll is capped at _MAX_RESULT_WAIT_SECONDS, so a wait
+        # never blocks longer than that regardless of the requested timeout. Clamp
+        # the requested wait to the same cap before adding the buffer margin, so
+        # the HTTP read timeout always outlives the server's poll plus a little
+        # slack (HTTP_TIMEOUT_BUFFER) for response transmission, without inflating
+        # the socket timeout past what the server can actually take.
+        wait_seconds = min(timeout, _MAX_RESULT_WAIT_SECONDS) if timeout else self.default_timeout
         return self._request(
             "GET",
             f"/jobs/{job_id}/result",
             params=params,
-            http_timeout=(timeout or self.default_timeout) + 10,
+            http_timeout=wait_seconds + HTTP_TIMEOUT_BUFFER,
         )
 
     def cancel(self, job_id: str) -> dict:

--- a/tako_vm/server/app.py
+++ b/tako_vm/server/app.py
@@ -125,26 +125,40 @@ class IdempotencyLockManager:
 
     def __init__(self):
         self._locks: Dict[str, asyncio.Lock] = {}
+        # Number of coroutines currently holding or waiting on each key's lock.
+        # The lock is only evicted when this drops to zero, so a waiter that
+        # already grabbed a reference can never be left contending against a
+        # fresh lock created for the same key (which would break mutual
+        # exclusion).
+        self._waiters: Dict[str, int] = {}
         self._global_lock = asyncio.Lock()
 
     @asynccontextmanager
     async def acquire(self, key: str):
         """Acquire lock for a specific idempotency key."""
-        # Get or create lock for this key
+        # Get or create lock for this key and register as a waiter.
         async with self._global_lock:
-            if key not in self._locks:
-                self._locks[key] = asyncio.Lock()
-            lock = self._locks[key]
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            self._waiters[key] = self._waiters.get(key, 0) + 1
 
-        # Acquire the per-key lock
-        async with lock:
-            yield
-
-        # Cleanup unused locks (optional, prevents memory leak for many unique keys)
-        async with self._global_lock:
-            if key in self._locks and not self._locks[key].locked():
-                # Only delete if no other request is waiting
-                del self._locks[key]
+        try:
+            # Acquire the per-key lock
+            async with lock:
+                yield
+        finally:
+            # Deregister; evict the lock only when no other coroutine still
+            # references it, preventing the unbounded growth of _locks while
+            # keeping concurrent waiters on the same lock object.
+            async with self._global_lock:
+                remaining = self._waiters.get(key, 0) - 1
+                if remaining <= 0:
+                    self._waiters.pop(key, None)
+                    self._locks.pop(key, None)
+                else:
+                    self._waiters[key] = remaining
 
 
 # Application state (initialized in lifespan)

--- a/tako_vm/server/queue.py
+++ b/tako_vm/server/queue.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Terminal ExecutionRecord statuses: a record in one of these is a final result.
+# Anything else ("queued", "running") means the job is still in flight.
+_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "timeout", "oom", "cancelled"})
+
 
 @dataclass
 class QueuedJob:
@@ -187,7 +191,6 @@ class WorkerPool:
             RuntimeError: If queue is full
         """
         job_id = str(uuid.uuid4())
-        now = datetime.now(timezone.utc)
 
         # Create future in async context where event loop is running
         loop = asyncio.get_running_loop()
@@ -201,25 +204,7 @@ class WorkerPool:
 
         # Create preliminary "queued" record for idempotency tracking
         # This ensures concurrent requests with same idempotency_key see the record
-        job_type_name = job_data.get("job_type") or "default"
-        queued_record = ExecutionRecord(
-            execution_id=job_id,
-            status="queued",
-            job_type=job_type_name,
-            job_ref=f"{job_type_name}@latest",
-            created_at=now,
-            queued_at=now,
-            code_hash=sha256_content(job_data.get("code", "")),
-            input_hash=sha256_json(job_data.get("input_data", {})),
-            client_ip=client_ip,
-            correlation_id=job_data.get("correlation_id"),
-            idempotency_key=job_data.get("idempotency_key"),
-            idempotency_fingerprint=job_data.get("idempotency_fingerprint"),
-            parent_execution_id=job_data.get("parent_execution_id"),
-            relationship=job_data.get("relationship"),
-        )
-        if self._queue.full():
-            raise RuntimeError("Job queue is full, try again later")
+        queued_record = self._build_record(job, "queued")
 
         await self.storage.save_record(queued_record)
 
@@ -269,9 +254,12 @@ class WorkerPool:
             job = self._active_jobs.get(job_id) or self._running_jobs.get(job_id)
 
         if not job:
-            # Check if already completed in storage
+            # Check if already completed in storage. Only a terminal record is a
+            # final answer: a non-terminal "queued"/"running" row (e.g. the job
+            # is in-flight on another path) must not be returned as the result,
+            # so treat it as still-pending / not found here.
             record = await self.storage.get_record(job_id)
-            if record:
+            if record and record.status in _TERMINAL_STATUSES:
                 return record
             raise KeyError(f"Job {job_id} not found")
 
@@ -359,20 +347,41 @@ class WorkerPool:
         Returns:
             True if job was found and cancelled
         """
+        pending_job: Optional[QueuedJob] = None
         running_job: Optional[QueuedJob] = None
         async with self._jobs_lock:
             # Check pending jobs
             job = self._active_jobs.get(job_id)
             if job and job.future and not job.future.done():
                 job.cancelled = True
-                logger.info(f"Job {job_id} cancelled (was pending)")
-                return True
+                pending_job = job
+                # Remove from active tracking now: the future is resolved below,
+                # so a later get_job_status must not re-report it as pending. The
+                # job still sits in the asyncio.Queue and the worker skip path
+                # (which is a no-op upsert once the future is already done) reaps
+                # it when dequeued.
+                self._active_jobs.pop(job_id, None)
 
             # Check running jobs - send a kill to the tracked container.
-            job = self._running_jobs.get(job_id)
-            if job:
-                job.cancelled = True
-                running_job = job
+            else:
+                job = self._running_jobs.get(job_id)
+                if job:
+                    job.cancelled = True
+                    running_job = job
+
+        if pending_job is not None:
+            # Persist the cancelled record and resolve the waiter synchronously
+            # (mirror the worker skip path) so cancellation is observable now
+            # instead of only after a worker eventually dequeues the job.
+            record = self._build_cancelled_record(pending_job)
+            await self.storage.save_record(record)
+            if pending_job.future and not pending_job.future.done():
+                try:
+                    pending_job.future.set_result(record)
+                except asyncio.InvalidStateError:
+                    logger.debug(f"Future already done for cancelled job {job_id}")
+            logger.info(f"Job {job_id} cancelled (was pending)")
+            return True
 
         if not running_job:
             return False
@@ -392,27 +401,53 @@ class WorkerPool:
 
         return True
 
-    def _build_cancelled_record(
-        self, job: QueuedJob, message: str = "Execution was cancelled by user"
+    @staticmethod
+    def _build_record(
+        job: QueuedJob,
+        status: str,
+        *,
+        error: Optional[ExecutionError] = None,
+        queued_at: Optional[datetime] = None,
     ) -> ExecutionRecord:
-        """Create a final cancelled record for a job."""
+        """Build an ExecutionRecord for a job in a given terminal/queued state.
+
+        Single construction site for every record the worker pool persists, so
+        the idempotency, lineage, and content-hash fields are propagated
+        consistently. (A prior hand-rolled record in the outer-except path
+        dropped the idempotency and lineage fields; routing through here fixes
+        that.)
+
+        Args:
+            job: Job the record describes
+            status: ExecutionRecord status (e.g. "queued", "cancelled", "failed")
+            error: Optional ExecutionError to attach
+            queued_at: Override for queued_at (defaults to job.created_at)
+        """
         job_type_name = job.job_data.get("job_type") or "default"
         return ExecutionRecord(
             execution_id=job.job_id,
-            status="cancelled",
+            status=status,
             job_type=job_type_name,
             job_ref=f"{job_type_name}@latest",
             created_at=job.created_at,
-            queued_at=job.created_at,
+            queued_at=queued_at if queued_at is not None else job.created_at,
             code_hash=sha256_content(job.job_data.get("code", "")),
             input_hash=sha256_json(job.job_data.get("input_data", {})),
             client_ip=job.client_ip,
             correlation_id=job.job_data.get("correlation_id"),
-            error=ExecutionError(type="cancelled", message=message),
+            error=error,
             idempotency_key=job.job_data.get("idempotency_key"),
             idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
             parent_execution_id=job.job_data.get("parent_execution_id"),
             relationship=job.job_data.get("relationship"),
+        )
+
+    def _build_cancelled_record(
+        self, job: QueuedJob, message: str = "Execution was cancelled by user"
+    ) -> ExecutionRecord:
+        """Create a final cancelled record for a job."""
+        return self._build_record(
+            job, "cancelled", error=ExecutionError(type="cancelled", message=message)
         )
 
     def _estimate_queue_position_unlocked(self, job_id: str) -> int:
@@ -541,25 +576,11 @@ class WorkerPool:
 
                     error_type = "internal_error"
                     error_msg = sanitize_error(str(e))
-                    job_type_name = job.job_data.get("job_type") or "default"
 
-                    record = ExecutionRecord(
-                        execution_id=job.job_id,
-                        status="failed",
-                        job_type=job_type_name,
-                        job_ref=f"{job_type_name}@latest",
-                        created_at=job.created_at,
-                        queued_at=job.created_at,
-                        code_hash=sha256_content(job.job_data.get("code", "")),
-                        input_hash=sha256_json(job.job_data.get("input_data", {})),
-                        client_ip=job.client_ip,
-                        correlation_id=job.job_data.get("correlation_id"),
+                    record = self._build_record(
+                        job,
+                        "failed",
                         error=ExecutionError(type=error_type, message=error_msg),
-                        # Propagate idempotency and lineage fields
-                        idempotency_key=job.job_data.get("idempotency_key"),
-                        idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
-                        parent_execution_id=job.job_data.get("parent_execution_id"),
-                        relationship=job.job_data.get("relationship"),
                     )
                     await self.storage.save_record(record)
 
@@ -595,17 +616,12 @@ class WorkerPool:
                     try:
                         from tako_vm.security import sanitize_error
 
-                        error_record = ExecutionRecord(
-                            execution_id=job.job_id,
-                            status="failed",
-                            job_type=job.job_data.get("job_type") or "default",
-                            job_ref=f"{job.job_data.get('job_type') or 'default'}@latest",
-                            created_at=job.created_at,
-                            queued_at=job.created_at,
-                            code_hash=sha256_content(job.job_data.get("code", "")),
-                            input_hash=sha256_json(job.job_data.get("input_data", {})),
-                            client_ip=job.client_ip,
-                            correlation_id=job.job_data.get("correlation_id"),
+                        # Route through _build_record so this path also persists
+                        # the idempotency and lineage fields it previously
+                        # dropped (data-loss bug).
+                        error_record = self._build_record(
+                            job,
+                            "failed",
                             error=ExecutionError(
                                 type="internal_error", message=sanitize_error(str(e))
                             ),
@@ -738,18 +754,9 @@ class WorkerPool:
             "timeout backstop fires; the worker slot is freed now"
         )
 
-        job_type_name = job.job_data.get("job_type") or "default"
-        return ExecutionRecord(
-            execution_id=job.job_id,
-            status="timeout",
-            job_type=job_type_name,
-            job_ref=f"{job_type_name}@latest",
-            created_at=job.created_at,
-            queued_at=job.created_at,
-            code_hash=sha256_content(job.job_data.get("code", "")),
-            input_hash=sha256_json(job.job_data.get("input_data", {})),
-            client_ip=job.client_ip,
-            correlation_id=job.job_data.get("correlation_id"),
+        return self._build_record(
+            job,
+            "timeout",
             error=ExecutionError(
                 type="execution_timeout",
                 message=(
@@ -757,10 +764,6 @@ class WorkerPool:
                     "(startup + execution + orchestration buffer); container was killed"
                 ),
             ),
-            idempotency_key=job.job_data.get("idempotency_key"),
-            idempotency_fingerprint=job.job_data.get("idempotency_fingerprint"),
-            parent_execution_id=job.job_data.get("parent_execution_id"),
-            relationship=job.job_data.get("relationship"),
         )
 
     def _run_job_sync(self, job: QueuedJob) -> ExecutionRecord:

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -464,7 +464,9 @@ class ExecutionStorage:
             "timing_json": record.timing.model_dump() if record.timing else None,
         }
 
-        terminal_list = ", ".join(f"'{s}'" for s in TERMINAL_STATUSES)
+        # Bound placeholders for the terminal-status guard, so the status
+        # literals are passed as parameters (no string interpolation into SQL).
+        terminal_placeholders = ", ".join(["%s"] * len(TERMINAL_STATUSES))
 
         # Upsert column policy:
         # - Submission-identity fields (created_at, queued_at, code_hash,
@@ -500,9 +502,12 @@ class ExecutionStorage:
                 )
                 ON CONFLICT (execution_id) DO UPDATE SET
                     {_UPDATE_SET_SQL}
-                WHERE execution_records.status NOT IN ({terminal_list})
+                WHERE execution_records.status NOT IN ({terminal_placeholders})
                 """,
-                tuple(extract(record, blobs) for _, _, extract in _EXECUTION_COLUMNS),
+                (
+                    *(extract(record, blobs) for _, _, extract in _EXECUTION_COLUMNS),
+                    *TERMINAL_STATUSES,
+                ),
             )
             return cursor.rowcount
 
@@ -576,6 +581,11 @@ class ExecutionStorage:
         so no other live server process can legitimately own in-flight records
         when this runs at startup.
 
+        The generic 'interrupted' error is only applied where error_json is
+        still NULL (COALESCE keeps any existing value), so a crashing worker
+        that already persisted the real error before exit is not overwritten by
+        this coarser reconciliation message.
+
         Returns:
             Number of records transitioned to 'failed'.
         """
@@ -592,7 +602,7 @@ class ExecutionStorage:
                 UPDATE execution_records
                 SET status = 'failed',
                     ended_at = %s,
-                    error_json = %s
+                    error_json = COALESCE(error_json, %s)
                 WHERE status IN ('queued', 'running')
                 """,
                 (now, Jsonb(error_json)),

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -25,8 +25,10 @@ def make_record(job_id: str, status: str = "succeeded", **kwargs) -> ExecutionRe
 
 @pytest.mark.asyncio
 async def test_cancel_pending_job_leaves_future_resolvable():
-    """Pending-job cancellation should not poison the waiter future."""
-    pool = WorkerPool(executor=MagicMock(), storage=MagicMock())
+    """Pending-job cancellation resolves the waiter future synchronously."""
+    storage = MagicMock()
+    storage.save_record = AsyncMock()
+    pool = WorkerPool(executor=MagicMock(), storage=storage)
     loop = asyncio.get_running_loop()
     job = QueuedJob(
         job_id="job-123",
@@ -44,6 +46,11 @@ async def test_cancel_pending_job_leaves_future_resolvable():
     assert job.cancelled is True
     assert job.future is not None
     assert job.future.cancelled() is False
+    # Cancellation is now observable immediately: the cancelled record is
+    # persisted and the future is resolved without waiting for a worker.
+    storage.save_record.assert_awaited_once()
+    assert job.future.done()
+    assert job.future.result().status == "cancelled"
 
 
 @pytest.mark.asyncio
@@ -630,10 +637,21 @@ async def test_submit_queue_full_race_releases_idempotency_key():
 
 
 @pytest.mark.asyncio
-async def test_submit_queue_full_precheck_rejects_without_db_write():
-    """The cheap full() pre-check rejects before any record is persisted."""
+async def test_submit_queue_full_rejects_and_cleans_up_record():
+    """A full queue is rejected solely by the put_nowait/QueueFull handler.
+
+    The redundant full() pre-check was removed (it left a TOCTOU window where a
+    queued record was persisted before the insert was attempted). The single
+    handler still cleans up: it rewrites the preliminary record as failed and
+    releases the idempotency key.
+    """
     storage = MagicMock()
-    storage.save_record = AsyncMock()
+    saves = []
+
+    async def capture_save(record):
+        saves.append((record.status, record.idempotency_key))
+
+    storage.save_record = AsyncMock(side_effect=capture_save)
     pool = WorkerPool(executor=MagicMock(), storage=storage, max_queue_size=1)
     loop = asyncio.get_running_loop()
     pool._queue.put_nowait(
@@ -651,7 +669,11 @@ async def test_submit_queue_full_precheck_rejects_without_db_write():
             client_ip=None,
         )
 
-    storage.save_record.assert_not_awaited()
+    # Preliminary queued record, then the failed rewrite that frees the key.
+    assert saves == [
+        ("queued", "idem-456"),
+        ("failed", None),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Stack 3/4. The actual bug fixes. **Base: rf/2-consolidate** (review after 2/4).

- sandbox runs `validate_docker_run_args` and fails closed (was skipped in library mode)
- exit 124 with no phase file is recorded as `timeout`
- queue outer-except no longer drops idempotency/lineage fields; pending-job cancel resolves synchronously; idempotency lock ref-counts waiters; queue TOCTOU/fallback fixes
- terminal-status SQL parameterized; `reconcile` uses `COALESCE`
- docker build timeout; build-context copy raises `BuildError`; SDK `send` KeyError parity; CLI verify `TimeoutExpired` handling

**Behavior change:** the worker now rejects jobs whose requirements contain an invalid pip requirement (was: silently skip), matching the sandbox policy.

Stack: 1/4 simplify -> 2/4 consolidate -> **3/4 durable** -> 4/4 verbose-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)