### PR TITLE
chore: strip em-dashes repo-wide, replace with natural punctuation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the report! **If this is a security vulnerability, do not file it here** — use
+        Thanks for the report! **If this is a security vulnerability, do not file it here**. Use
         [private vulnerability reporting](https://github.com/Tako-Research/TakoVM/security/advisories/new) instead.
   - type: input
     id: version
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Server logs
       description: >
-        Tako VM logs every failure verbosely — the server log around the time of the error
+        Tako VM logs every failure verbosely, so the server log around the time of the error
         is usually the fastest path to a diagnosis. Paste the relevant lines (redact anything sensitive).
       render: text
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
     url: https://github.com/Tako-Research/TakoVM/security/advisories/new
-    about: Report security issues privately — never in a public issue.
+    about: Report security issues privately, never in a public issue.
   - name: Questions & ideas
     url: https://github.com/Tako-Research/TakoVM/discussions
     about: Ask questions, share what you're building, or discuss ideas before they become issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@
 - [ ] `pre-commit run --all-files` passes (ruff lint/format + pyright)
 - [ ] `TAKO_VM_SECURITY_MODE=permissive pytest tests/` passes locally
 - [ ] Docs updated if behavior changed (`docs/`, README)
-- [ ] PR title uses conventional-commit style (`feat:`, `fix:`, `docs:`, `chore:`) — it becomes the squash commit message
+- [ ] PR title uses conventional-commit style (`feat:`, `fix:`, `docs:`, `chore:`); it becomes the squash commit message
 - [ ] New failure paths log and surface errors verbosely (no silent swallowing)

--- a/.github/vulnerability_report_template.md
+++ b/.github/vulnerability_report_template.md
@@ -1,7 +1,7 @@
 <!--
 Place at .github/vulnerability_report_template.md and reference it from your
 GitHub Security Advisory settings, or paste it into the advisory description so
-reporters have a structure to follow. This is NOT a public issue template —
+reporters have a structure to follow. This is NOT a public issue template;
 security reports should go through private vulnerability reporting.
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ end-to-end for durability, traceability, and security.
 
 ### Added
 
-- **Python SDK — full API parity** (#62): asynchronous submission
+- **Python SDK, full API parity** (#62): asynchronous submission
   (`submit`/`submit_code`), the complete job lifecycle (`get_status`,
   `get_result`, `cancel`, `rerun`, `fork`), artifact download, paginated
   execution history, and job-type metadata.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # Tako VM
 
-A secure file system and Python execution layer for AI agents. Lets agents and platforms run untrusted code safely in gVisor-backed, isolated containers — each with its own workspace — backed by job queues, retries, and execution history. REST API for sync/async job execution, plus a Python SDK for library-mode usage.
+A secure file system and Python execution layer for AI agents. Lets agents and platforms run untrusted code safely in gVisor-backed, isolated containers (each with its own workspace) backed by job queues, retries, and execution history. REST API for sync/async job execution, plus a Python SDK for library-mode usage.
 
-**Direction:** evolving toward a "serverless filesystem for agents" — durable, per-agent workspaces that persist and rehydrate across runs (object-store-backed, content-addressed snapshots, hydrate/flush at run boundary). Today each container is single-use; persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
+**Direction:** evolving toward a "serverless filesystem for agents": durable, per-agent workspaces that persist and rehydrate across runs (object-store-backed, content-addressed snapshots, hydrate/flush at run boundary). Today each container is single-use; persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
 
 ## Why gVisor?
 
-Docker alone shares the host kernel — a container escape gives root. gVisor intercepts syscalls in a userspace kernel (`runsc`), so even a kernel exploit stays inside the sandbox. This is the core security promise of Tako VM.
+Docker alone shares the host kernel, so a container escape gives root. gVisor intercepts syscalls in a userspace kernel (`runsc`), so even a kernel exploit stays inside the sandbox. This is the core security promise of Tako VM.
 
 ## Architecture
 
@@ -45,7 +45,7 @@ lima-gvisor.yaml           # Lima VM config for macOS dev with gVisor
 - **Security modes**: `permissive` (default) falls back to runc; `strict` fails if gVisor unavailable
 - **ExecutionRecord** status: `queued`, `running`, `succeeded`, `failed`, `timeout`, `oom`, `cancelled`
 - **Queue job** status: `pending`, `running`, `completed` (different from ExecutionRecord)
-- **Timeouts**: `startup_timeout` (dep install) vs `timeout` (code execution) — configured separately
+- **Timeouts**: `startup_timeout` (dep install) vs `timeout` (code execution), configured separately
 - **Runtime deps**: Installed via `uv pip install` at container startup; `UV_CACHE_VOLUME` speeds repeats
 - Tests use temp database via `TAKO_VM_DATA_DIR` env var for isolation
 
@@ -73,8 +73,8 @@ ruff format tako_vm/ tests/
 
 ## References
 
-- [docs/development/troubleshooting.md](docs/development/troubleshooting.md) — Dependency flow, common issues, debugging endpoints
-- [docs/api/rest.md](docs/api/rest.md) — API reference
-- [docs/api/sdk.md](docs/api/sdk.md) — Python SDK reference
-- [tako_vm.yaml.example](tako_vm.yaml.example) — Config options
-- [README.md](README.md) — Full docs, CLI commands, job types
+- [docs/development/troubleshooting.md](docs/development/troubleshooting.md): Dependency flow, common issues, debugging endpoints
+- [docs/api/rest.md](docs/api/rest.md): API reference
+- [docs/api/sdk.md](docs/api/sdk.md): Python SDK reference
+- [tako_vm.yaml.example](tako_vm.yaml.example): Config options
+- [README.md](README.md): Full docs, CLI commands, job types

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@ Thanks for your interest in contributing! This guide covers everything you need 
 ## Where to start
 
 - Issues labeled [`good first issue`](https://github.com/Tako-Research/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are well-scoped entry points.
-- Issues labeled [`help wanted`](https://github.com/Tako-Research/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are larger pieces where design input is welcome — comment on the issue before starting.
+- Issues labeled [`help wanted`](https://github.com/Tako-Research/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are larger pieces where design input is welcome; comment on the issue before starting.
 - Questions and ideas: [GitHub Discussions](https://github.com/Tako-Research/TakoVM/discussions).
 
-**Security issues are the exception: never open a public issue.** Report privately via the [Security tab](https://github.com/Tako-Research/TakoVM/security/advisories/new) — see [SECURITY.md](SECURITY.md).
+**Security issues are the exception: never open a public issue.** Report privately via the [Security tab](https://github.com/Tako-Research/TakoVM/security/advisories/new). See [SECURITY.md](SECURITY.md).
 
 ## Development setup
 
@@ -30,7 +30,7 @@ tako-vm dev up
 
 ### macOS notes
 
-- [colima](https://github.com/abiosoft/colima) works fine as the Docker runtime for development (no gVisor — tests requiring it auto-skip).
+- [colima](https://github.com/abiosoft/colima) works fine as the Docker runtime for development (no gVisor, so tests requiring it auto-skip).
 - Set `TAKO_VM_WORKSPACE` to a directory under `$HOME`. The default macOS temp dir (`/var/folders/...`) cannot be bind-mounted into the colima VM, and executions fail with `bind source path does not exist`.
 - To test against real gVisor on macOS, use the Lima VM config in [`lima-gvisor.yaml`](lima-gvisor.yaml).
 
@@ -65,7 +65,7 @@ ruff format tako_vm/ tests/
 ## Pull requests
 
 - Use conventional-commit style titles: `feat:`, `fix:`, `docs:`, `chore:`, with an optional scope like `feat(sdk):`.
-- PRs are squash-merged, so the PR title becomes the commit message — make it descriptive.
+- PRs are squash-merged, so the PR title becomes the commit message, so make it descriptive.
 - CI must pass: ruff, the test matrix (3.10–3.12), and CodeQL.
 - Update docs (`docs/`, README) when behavior changes.
 - One of the failure-handling principles of this project: **failures are logged and surfaced verbosely, never silently swallowed**. New code paths should follow suit.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 </p>
 
 **A secure file system for your agents to execute code.** Every job runs in its own
-isolated Docker container — with an ephemeral workspace, optional gVisor sandboxing, job
+isolated Docker container, with an ephemeral workspace, optional gVisor sandboxing, job
 queues, retries, and execution history included.
 
 > **Where this is headed:** durable, per-agent workspaces that persist and rehydrate
-> across runs — a serverless filesystem for agents. Today each container is single-use;
+> across runs, a serverless filesystem for agents. Today each container is single-use;
 > persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
 
 <p align="center">
@@ -48,7 +48,7 @@ curl -X POST http://localhost:8000/execute \
 
 ## Why Tako VM?
 
-Sandbox solutions like [e2b](https://e2b.dev), [daytona](https://daytona.dev) and [microsandbox](https://github.com/microsandbox/microsandbox) give you isolated code execution—but that's it. You still need to build:
+Sandbox solutions like [e2b](https://e2b.dev), [daytona](https://daytona.dev) and [microsandbox](https://github.com/microsandbox/microsandbox) give you isolated code execution, but that's it. You still need to build:
 
 | You build | With sandbox-only | With Tako VM |
 |-----------|-------------------|--------------|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,11 +14,11 @@ Please do not open public issues, pull requests, or discussion threads for suspe
 A useful report includes:
 
 - The version, commit SHA, or PyPI release you tested.
-- Your configuration relevant to the finding — in particular `container_runtime`, `security_mode`, `enable_seccomp`, and any job types with `network_enabled: true`.
+- Your configuration relevant to the finding, in particular `container_runtime`, `security_mode`, `enable_seccomp`, and any job types with `network_enabled: true`.
 - A minimal reproduction: the submitted code or request, and the observed versus expected behavior.
 - The impact you believe it has (container escape, host access, data exfiltration, denial of service, information disclosure).
 
-Reports that demonstrate a sandbox escape — host filesystem access, code execution outside the executor container, reaching the Docker daemon, or bypassing network isolation — are the most valuable and will be prioritized accordingly.
+Reports that demonstrate a sandbox escape (host filesystem access, code execution outside the executor container, reaching the Docker daemon, or bypassing network isolation) are the most valuable and will be prioritized accordingly.
 
 ### What to expect
 
@@ -52,11 +52,11 @@ Tako VM uses layered isolation. No single layer is treated as sufficient on its 
 
 **Syscall filtering (seccomp).** A default-deny seccomp profile (`SCMP_ACT_ERRNO`) allows only a whitelist of syscalls and blocks dangerous ones including `ptrace`, `mount`, `reboot`, `sethostname`, and `init_module`. Controlled by `enable_seccomp`.
 
-**Network isolation.** Containers run with `--network=none` by default, which blocks data exfiltration, command-and-control traffic, and access to internal services. Network access is opt-in per job type via `network_enabled: true`, and when enabled it permits access to any external host — egress filtering is your responsibility (host firewall or Kubernetes NetworkPolicy). Runtime dependency installation and the shared dependency cache are disabled by default to prevent untrusted jobs from fetching and executing package setup code.
+**Network isolation.** Containers run with `--network=none` by default, which blocks data exfiltration, command-and-control traffic, and access to internal services. Network access is opt-in per job type via `network_enabled: true`, and when enabled it permits access to any external host: egress filtering is your responsibility (host firewall or Kubernetes NetworkPolicy). Runtime dependency installation and the shared dependency cache are disabled by default to prevent untrusted jobs from fetching and executing package setup code.
 
 **Resource limits.** Memory, CPU, PID, file-descriptor, file-size, and `/tmp` size limits, plus enforced execution timeouts, bound the damage from runaway or deliberately abusive code (fork bombs, memory exhaustion, disk filling).
 
-**Input validation.** Submitted code and inputs are size-capped (100KB code, 1MB input, 300s max timeout by default). Container build inputs — base image, Python version, pip requirements, environment variables, and shared code paths — are validated to reject shell metacharacters, newlines, URL and path specifiers, and directory traversal. Output artifact filenames are checked to block path separators, parent-directory references, and hidden files.
+**Input validation.** Submitted code and inputs are size-capped (100KB code, 1MB input, 300s max timeout by default). Container build inputs (base image, Python version, pip requirements, environment variables, and shared code paths) are validated to reject shell metacharacters, newlines, URL and path specifiers, and directory traversal. Output artifact filenames are checked to block path separators, parent-directory references, and hidden files.
 
 **Output handling.** stdout, stderr, and artifacts are size-capped, and stack traces are rewritten to strip internal host paths before they are returned.
 
@@ -101,7 +101,7 @@ For stronger isolation than gVisor provides, run Tako VM on dedicated hosts or p
 
 Several defaults in the shipped example configuration favor ease of first-run over maximum hardening. If you are exposing Tako VM to untrusted code in production, do not run with the example defaults unchanged. At minimum:
 
-- Set `security_mode: strict`. The default is `permissive`, which silently falls back to standard `runc` if gVisor is unavailable — meaning untrusted code can end up running without the userspace-kernel boundary you expect. `strict` fails closed instead.
+- Set `security_mode: strict`. The default is `permissive`, which silently falls back to standard `runc` if gVisor is unavailable, meaning untrusted code can end up running without the userspace-kernel boundary you expect. `strict` fails closed instead.
 - Install and verify gVisor (`docker run --runtime=runsc --rm hello-world`) and keep `container_runtime: runsc`.
 - Keep `enable_seccomp: true`.
 - Terminate TLS in front of the API and keep rate limiting enabled.

--- a/assets/demo.tape
+++ b/assets/demo.tape
@@ -1,4 +1,4 @@
-# Tako VM README demo — records real requests against a live local server
+# Tako VM README demo: records real requests against a live local server
 Output assets/demo.gif
 
 Set Shell "bash"

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM REST API reference — endpoints for synchronous and asynchronous Python code execution, job status, results, and artifact downloads."
+description: "Tako VM REST API reference: endpoints for synchronous and asynchronous Python code execution, job status, results, and artifact downloads."
 ---
 
 # REST API Reference
@@ -55,7 +55,7 @@ curl -X POST http://localhost:8000/execute \
 
 The Python SDK forwards custom headers on every request: `TakoVM(headers={"X-API-Key": "..."})` or `tako_vm.configure(..., headers={...})`.
 
-Built-in rate limiting is **enabled by default** (120 requests per 60s window, configurable via `api_rate_limit_*`). For internet-facing deployments, additionally terminate TLS at a reverse proxy — see [Securing the API](../deployment/security.md#api-security) in the hardening guide.
+Built-in rate limiting is **enabled by default** (120 requests per 60s window, configurable via `api_rate_limit_*`). For internet-facing deployments, additionally terminate TLS at a reverse proxy. See [Securing the API](../deployment/security.md#api-security) in the hardening guide.
 
 ## Headers
 

--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM Python SDK reference — the TakoVM HTTP client (server mode) and the Sandbox class (library mode) for running code in isolated containers."
+description: "Tako VM Python SDK reference: the TakoVM HTTP client (server mode) and the Sandbox class (library mode) for running code in isolated containers."
 ---
 
 # Python SDK Reference
@@ -47,7 +47,7 @@ result = tako_vm.send(add, Input(10, 20))
 print(result.result)  # 30
 ```
 
-The module-level helpers use a default client configured via `tako_vm.configure()`, and mirror the full `TakoVM` surface — typed execution (`send`, `send_raw`), the async job lifecycle (`submit`, `submit_code`, `get_status`, `get_result`, `cancel`, `rerun`, `fork`, `download_artifact`), history (`list_executions`, `get_execution`), and metadata (`list_job_types`, `get_job_type`, `build_job_type`, `pool_stats`, `dlq_stats`, `health`). `configure()` accepts the same arguments as `TakoVM` (`headers`, `session`, `connect_timeout`, `correlation_id`). Instantiate `TakoVM` directly when you need multiple independently-configured clients in one process.
+The module-level helpers use a default client configured via `tako_vm.configure()`, and mirror the full `TakoVM` surface: typed execution (`send`, `send_raw`), the async job lifecycle (`submit`, `submit_code`, `get_status`, `get_result`, `cancel`, `rerun`, `fork`, `download_artifact`), history (`list_executions`, `get_execution`), and metadata (`list_job_types`, `get_job_type`, `build_job_type`, `pool_stats`, `dlq_stats`, `health`). `configure()` accepts the same arguments as `TakoVM` (`headers`, `session`, `connect_timeout`, `correlation_id`). Instantiate `TakoVM` directly when you need multiple independently-configured clients in one process.
 
 ```python
 import tako_vm
@@ -80,7 +80,7 @@ client = TakoVM(
 
 ### Authentication
 
-The SDK does **not** implement authentication — it forwards whatever headers you give it, verbatim, on every request. Supply the credential your deployment requires (the server's API key, a bearer token from your gateway, etc.), or use a `session` for transport-level auth (mTLS).
+The SDK does **not** implement authentication. It forwards whatever headers you give it, verbatim, on every request. Supply the credential your deployment requires (the server's API key, a bearer token from your gateway, etc.), or use a `session` for transport-level auth (mTLS).
 
 ```python
 # API key (matches the server's api_auth_header, default "X-API-Key")
@@ -101,11 +101,11 @@ client = TakoVM("https://tako.internal", session=sess)
 
 The client ships with a reliability layer; all of it is automatic:
 
-- **Transport retries (GETs only).** The default session retries idempotent GETs (status/result polling, job types, health) on 502/503/504 with backoff. POSTs are never retried at the transport layer — the sync `POST /execute` is not idempotent, so a blind retry could run code twice. Passing your own `session=` replaces this adapter.
+- **Transport retries (GETs only).** The default session retries idempotent GETs (status/result polling, job types, health) on 502/503/504 with backoff. POSTs are never retried at the transport layer: the sync `POST /execute` is not idempotent, so a blind retry could run code twice. Passing your own `session=` replaces this adapter.
 - **Retry-safe async submission.** `submit()`/`submit_code()` auto-generate a server-compatible `idempotency_key` when you don't pass one and retry transient failures (connection errors, 502/503/504) with the *same* key, so the server returns the existing job instead of re-executing.
 - **Correlation IDs.** Every request carries an `X-Correlation-ID` header (auto-generated, or fixed via `TakoVM(correlation_id=...)`). The id is exposed as `.correlation_id` on `ExecutionResult` and on SDK exceptions for end-to-end tracing.
-- **Structured errors.** HTTP failures raise `TransportError` (connection/timeout), `ServerError` (5xx, with `.retryable` set for 502/503/504), or `ClientError` (4xx) — all subclasses of `TakoVMError` carrying `.status_code`, `.detail` (parsed from the server's error body), and `.correlation_id`. The sync `send()`/`send_raw()` path keeps its legacy contract and reports these as a failed `ExecutionResult` instead of raising them.
-- **Client-side timeouts that outlive the server.** When `timeout` is omitted, the HTTP read timeout is resolved from the job type's default (`GET /job-types/{name}`, cached per client) plus the startup budget, with a generous fallback — so long-running jobs are never killed client-side while they would still complete server-side. If the job-type lookup fails, the client logs a warning and falls back to the maximum read timeout.
+- **Structured errors.** HTTP failures raise `TransportError` (connection/timeout), `ServerError` (5xx, with `.retryable` set for 502/503/504), or `ClientError` (4xx), all subclasses of `TakoVMError` carrying `.status_code`, `.detail` (parsed from the server's error body), and `.correlation_id`. The sync `send()`/`send_raw()` path keeps its legacy contract and reports these as a failed `ExecutionResult` instead of raising them.
+- **Client-side timeouts that outlive the server.** When `timeout` is omitted, the HTTP read timeout is resolved from the job type's default (`GET /job-types/{name}`, cached per client) plus the startup budget, with a generous fallback, so long-running jobs are never killed client-side while they would still complete server-side. If the job-type lookup fails, the client logs a warning and falls back to the maximum read timeout.
 - **Verbose on failure.** Every failure path logs at `WARNING`/`ERROR` on the `tako_vm.sdk.client` logger with the correlation id, status, and server detail. A non-JSON 2xx body and an output that doesn't fit the return dataclass are both logged and surfaced (a failed `ExecutionResult` and the raw dict, respectively) rather than swallowed silently. Enable it with `logging.getLogger("tako_vm.sdk.client").setLevel(logging.DEBUG)`.
 
 ---
@@ -182,7 +182,7 @@ client.dlq_stats()                   # dead-letter-queue stats
 `list_executions()` returns a paginated response (`{"items": [...], "limit", "offset", "has_more", "count"}`).
 
 !!! note "Sessions"
-    A long-lived **session** API is in development — neither the REST endpoints nor SDK support have shipped yet. This note will link to both once the API stabilizes.
+    A long-lived **session** API is in development; neither the REST endpoints nor SDK support have shipped yet. This note will link to both once the API stabilizes.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM release history — what changed in each version."
+description: "Tako VM release history: what changed in each version."
 ---
 
 --8<-- "CHANGELOG.md"

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,10 +1,10 @@
 ---
-description: "Tako VM vs E2B vs Daytona — compare secure code execution platforms on deployment, isolation, job queues, pricing, and self-hosting."
+description: "Tako VM vs E2B vs Daytona: compare secure code execution platforms on deployment, isolation, job queues, pricing, and self-hosting."
 ---
 
 # Tako VM vs E2B vs Daytona
 
-Comparison of secure code execution platforms (last reviewed June 2026 — competitor details change quickly; verify against their current docs)
+Comparison of secure code execution platforms (last reviewed June 2026; competitor details change quickly; verify against their current docs)
 
 ## Quick Comparison
 

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM operations runbook — diagnostic endpoints and procedures to detect and recover from common production failures."
+description: "Tako VM operations runbook: diagnostic endpoints and procedures to detect and recover from common production failures."
 ---
 
 # Operations Runbook
@@ -74,7 +74,7 @@ curl -s http://localhost:8000/dlq/stats | python3 -m json.tool
 **Recovery:**
 1. Review DLQ entries for common failure patterns
 2. Fix the root cause (usually Docker issues or resource exhaustion)
-3. DLQ entries are informational — they indicate jobs that failed due to infrastructure errors (not user code errors)
+3. DLQ entries are informational: they indicate jobs that failed due to infrastructure errors (not user code errors)
 
 ### Database Connection Failures
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -1,5 +1,5 @@
 ---
-description: "Production deployment guide for Tako VM — hardened configuration, persistence, and operational settings for running at scale."
+description: "Production deployment guide for Tako VM: hardened configuration, persistence, and operational settings for running at scale."
 ---
 
 # Production Deployment
@@ -41,7 +41,7 @@ curl -X POST http://localhost:8000/job-types/data-processing/build
 docker images | grep tako-vm
 ```
 
-!!! note "CLI support for building images is planned — see [GitHub #30](https://github.com/Tako-Research/TakoVM/issues/30)."
+!!! note "CLI support for building images is planned. See [GitHub #30](https://github.com/Tako-Research/TakoVM/issues/30)."
 
 ## Running with Systemd
 

--- a/docs/deployment/scaling.md
+++ b/docs/deployment/scaling.md
@@ -1,5 +1,5 @@
 ---
-description: "Scale Tako VM with single-node vertical scaling — tuning workers and queue size today, plus planned horizontal scaling features."
+description: "Scale Tako VM with single-node vertical scaling: tuning workers and queue size today, plus planned horizontal scaling features."
 ---
 
 # Tako VM Scaling Guide

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM security: defense-in-depth layers — input validation, container isolation, gVisor syscall sandboxing, and seccomp — for untrusted code."
+description: "Tako VM security: defense-in-depth layers (input validation, container isolation, gVisor syscall sandboxing, and seccomp) for untrusted code."
 ---
 
 # Hardening Guide
@@ -310,7 +310,7 @@ server {
 }
 ```
 
-With Caddy the equivalent is two lines (`reverse_proxy 127.0.0.1:8000` under a site block — TLS is automatic). For OIDC/SSO, put an auth-proxy (oauth2-proxy, Pomerium) in front instead of API keys.
+With Caddy the equivalent is two lines (`reverse_proxy 127.0.0.1:8000` under a site block; TLS is automatic). For OIDC/SSO, put an auth-proxy (oauth2-proxy, Pomerium) in front instead of API keys.
 
 ## Threat Model
 

--- a/docs/design/dind-support.md
+++ b/docs/design/dind-support.md
@@ -1,5 +1,5 @@
 ---
-description: "Docker-in-Docker (DinD) with Tako VM — how containers are spawned today and what would be required to support nested Docker execution."
+description: "Docker-in-Docker (DinD) with Tako VM: how containers are spawned today and what would be required to support nested Docker execution."
 ---
 
 # Docker-in-Docker (DinD) Support

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM development and troubleshooting — the runtime dependency flow, debugging endpoints, and fixes for common issues."
+description: "Tako VM development and troubleshooting: the runtime dependency flow, debugging endpoints, and fixes for common issues."
 ---
 
 # Development Guide

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,5 +1,5 @@
 ---
-description: "Configure Tako VM with YAML — security modes, timeouts, worker pools, resource limits, and runtime dependencies, with sensible defaults explained."
+description: "Configure Tako VM with YAML: security modes, timeouts, worker pools, resource limits, and runtime dependencies, with sensible defaults explained."
 ---
 
 # Configuration

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,5 +1,5 @@
 ---
-description: "Get started with Tako VM in minutes — install, pull the executor image, start the server, and run your first sandboxed Python job."
+description: "Get started with Tako VM in minutes: install, pull the executor image, start the server, and run your first sandboxed Python job."
 ---
 
 # Quick Start
@@ -24,7 +24,7 @@ tako-vm server --port 9000
     Tako VM defaults to `permissive` mode, which falls back to runc if gVisor is not installed. For production, set `security_mode: strict` to require gVisor. See [Security](../deployment/security.md#gvisor-runtime) for installation instructions.
 
 !!! warning "Security: Secrets"
-    Do not pass secrets (API keys, tokens, passwords) as job type environment variables — user code can read them via `/proc/self/environ`. For **trusted code**, `input_data` is acceptable for sensitive inputs (scoped to a single job). For **untrusted or AI-generated code**, keep secrets out of the job entirely: anything in `input_data` or the environment is readable by the code — use an external secret manager and have trusted infrastructure, not the sandboxed code, hold credentials. See [Security Mitigations](../security/mitigations.md).
+    Do not pass secrets (API keys, tokens, passwords) as job type environment variables: user code can read them via `/proc/self/environ`. For **trusted code**, `input_data` is acceptable for sensitive inputs (scoped to a single job). For **untrusted or AI-generated code**, keep secrets out of the job entirely: anything in `input_data` or the environment is readable by the code. Use an external secret manager and have trusted infrastructure, not the sandboxed code, hold credentials. See [Security Mitigations](../security/mitigations.md).
 
 ## Execute Code
 

--- a/docs/guide/agent-tools.md
+++ b/docs/guide/agent-tools.md
@@ -1,5 +1,5 @@
 ---
-description: "Use Tako VM as a code-execution tool for AI agents — LangChain and OpenAI tool-calling integrations with sandboxed Python execution."
+description: "Use Tako VM as a code-execution tool for AI agents: LangChain and OpenAI tool-calling integrations with sandboxed Python execution."
 ---
 
 # Agent Integration
@@ -10,13 +10,13 @@ The pattern is identical in every framework:
 
 1. Expose one tool, e.g. `run_python(code, requirements)`.
 2. The tool submits the model-generated code to Tako VM and waits for the result.
-3. Return stdout on success and **return the error text on failure** — the model uses tracebacks to fix its own code, so never raise them away.
+3. Return stdout on success and **return the error text on failure**: the model uses tracebacks to fix its own code, so never raise them away.
 
 !!! warning "Treat AI-generated code as untrusted"
-    Run agent workloads with `security_mode: strict` so jobs fail rather than silently falling back from gVisor to plain `runc`, and never pass secrets in `input_data` — anything the job receives is readable by the code. See the [threat model](../security/honest-assessment.md).
+    Run agent workloads with `security_mode: strict` so jobs fail rather than silently falling back from gVisor to plain `runc`, and never pass secrets in `input_data`: anything the job receives is readable by the code. See the [threat model](../security/honest-assessment.md).
 
 !!! note "Letting agents install packages"
-    The `requirements` parameter needs `allow_runtime_requirements: true` in `tako_vm.yaml` (off by default), and a job that installs packages runs **with network access** — the container attaches to the bridge network for the install and stays attached for the run. For untrusted code, prefer [pre-built job types](environments.md) with the packages your agents need: that keeps `--network=none` and drops the parameter entirely.
+    The `requirements` parameter needs `allow_runtime_requirements: true` in `tako_vm.yaml` (off by default), and a job that installs packages runs **with network access**: the container attaches to the bridge network for the install and stays attached for the run. For untrusted code, prefer [pre-built job types](environments.md) with the packages your agents need: that keeps `--network=none` and drops the parameter entirely.
 
 ## The core tool function
 
@@ -39,7 +39,7 @@ def run_python(code: str, requirements: list[str] | None = None) -> str:
 
     if record["status"] == "succeeded":
         return record["stdout"] or "(no output)"
-    # Surface the failure to the model — tracebacks are how agents self-correct.
+    # Surface the failure to the model. Tracebacks are how agents self-correct.
     return (
         f"Execution {record['status']}.\n"
         f"stderr:\n{record.get('stderr', '')}\n"
@@ -96,7 +96,7 @@ print(result["messages"][-1].content)
 
 ### Using it from asyncio
 
-The SDK is `requests`-based and blocking, so don't call `run_python` directly inside an async agent loop — wrap it so the event loop stays free:
+The SDK is `requests`-based and blocking, so don't call `run_python` directly inside an async agent loop. Wrap it so the event loop stays free:
 
 ```python
 import asyncio
@@ -106,7 +106,7 @@ async def arun_python(code: str, requirements: list[str] | None = None) -> str:
     return await asyncio.to_thread(run_python, code, requirements)
 ```
 
-Register `arun_python` as the tool's coroutine (LangChain's `StructuredTool.from_function(coroutine=arun_python, ...)`) and `ainvoke` works without blocking. The block happens in `get_result`, which long-polls the server — cheap to park on a thread.
+Register `arun_python` as the tool's coroutine (LangChain's `StructuredTool.from_function(coroutine=arun_python, ...)`) and `ainvoke` works without blocking. The block happens in `get_result`, which long-polls the server: cheap to park on a thread.
 
 ## OpenAI tool calling
 
@@ -146,17 +146,17 @@ messages += [response.choices[0].message,
 final = client.chat.completions.create(model="gpt-5", messages=messages, tools=TOOLS)
 ```
 
-The same shape works for Anthropic tool use — define one `run_python` tool and feed `record["stdout"]`/`stderr` back as the `tool_result`.
+The same shape works for Anthropic tool use: define one `run_python` tool and feed `record["stdout"]`/`stderr` back as the `tool_result`.
 
 ## Concurrency and history
 
-- **Parallel agents**: jobs queue automatically; the worker pool (default 4) drains them. Submit from as many agent sessions as you like — `submit_code()` returns immediately with a `job_id`.
-- **Audit trail**: every execution an agent ever ran is persisted with code, stdout/stderr, and timing — `tako_vm.list_executions()` or `GET /executions`. Invaluable when an agent did something surprising last Tuesday.
+- **Parallel agents**: jobs queue automatically; the worker pool (default 4) drains them. Submit from as many agent sessions as you like; `submit_code()` returns immediately with a `job_id`.
+- **Audit trail**: every execution an agent ever ran is persisted with code, stdout/stderr, and timing: `tako_vm.list_executions()` or `GET /executions`. Invaluable when an agent did something surprising last Tuesday.
 - **Replay**: re-run an agent's past execution exactly (`tako_vm.rerun(job_id)`) or fork it with modified code (`fork`) while debugging.
 - **No webhooks yet**: poll `get_result(job_id, timeout=...)` (it long-polls server-side via `?wait=true`, so this is cheap).
 
 ## Next steps
 
-- [Async Jobs](async-jobs.md) — job lifecycle and status reference
-- [Environments](environments.md) — pre-built job types so agents skip dependency install
-- [Hardening Guide](../deployment/security.md) — production settings for untrusted code
+- [Async Jobs](async-jobs.md): job lifecycle and status reference
+- [Environments](environments.md): pre-built job types so agents skip dependency install
+- [Hardening Guide](../deployment/security.md): production settings for untrusted code

--- a/docs/guide/async-jobs.md
+++ b/docs/guide/async-jobs.md
@@ -1,5 +1,5 @@
 ---
-description: "Run long tasks with Tako VM async jobs — submit work to the queue, poll job status, and retrieve results without blocking the request."
+description: "Run long tasks with Tako VM async jobs: submit work to the queue, poll job status, and retrieve results without blocking the request."
 ---
 
 # Async Jobs

--- a/docs/guide/basic-execution.md
+++ b/docs/guide/basic-execution.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn the Tako VM execution model — how containers are created, files mounted read-only, code run, and results captured for each job."
+description: "Learn the Tako VM execution model: how containers are created, files mounted read-only, code run, and results captured for each job."
 ---
 
 # Basic Execution

--- a/docs/guide/custom-libraries.md
+++ b/docs/guide/custom-libraries.md
@@ -1,5 +1,5 @@
 ---
-description: "Pre-install custom Python libraries into Tako VM executor images — internal packages, patched builds, and complex build-time dependencies."
+description: "Pre-install custom Python libraries into Tako VM executor images: internal packages, patched builds, and complex build-time dependencies."
 ---
 
 # Custom Libraries

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -138,7 +138,7 @@ In development mode, images are auto-built on first use. To pre-build:
 curl -X POST http://localhost:8000/job-types/data-processing/build
 ```
 
-!!! note "CLI support for building images is planned — see [GitHub #30](https://github.com/Tako-Research/TakoVM/issues/30)."
+!!! note "CLI support for building images is planned. See [GitHub #30](https://github.com/Tako-Research/TakoVM/issues/30)."
 
 Images are named `tako-vm-{name}:latest`.
 

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -1,5 +1,5 @@
 ---
-description: "Handle errors in Tako VM — error response format, timeouts, out-of-memory, and the built-in retry and resilience features."
+description: "Handle errors in Tako VM: error response format, timeouts, out-of-memory, and the built-in retry and resilience features."
 ---
 
 # Error Handling

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -4,7 +4,7 @@ description: "Step-by-step Tako VM tutorial: build a CSV data-processing pipelin
 
 # Tutorial: Build a Data Processing Pipeline
 
-This tutorial walks through building a complete application with Tako VM — from setup to processing results.
+This tutorial walks through building a complete application with Tako VM, from setup to processing results.
 
 ## What We'll Build
 
@@ -216,7 +216,7 @@ print("Results:", results)
 
 ## Next Steps
 
-- [REST API Reference](../api/rest.md) — all endpoints and options
-- [Environments](environments.md) — pre-configured job types
-- [Error Handling](error-handling.md) — robust error handling patterns
-- [Async Jobs](async-jobs.md) — advanced async patterns
+- [REST API Reference](../api/rest.md): all endpoints and options
+- [Environments](environments.md): pre-configured job types
+- [Error Handling](error-handling.md): robust error handling patterns
+- [Async Jobs](async-jobs.md): advanced async patterns

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM is a secure file system and Python execution layer for AI agents — gVisor-isolated Docker containers with job queues, workers, retries, and replay."
+description: "Tako VM is a secure file system and Python execution layer for AI agents: gVisor-isolated Docker containers with job queues, workers, retries, and replay."
 hide:
   - navigation
   - toc
@@ -10,7 +10,7 @@ hide:
 # Tako VM
 
 <p class="tako-tagline"><strong>A secure file system for your agents to execute code.</strong><br>
-File system and Python execution for your agents — run untrusted code in gVisor-isolated containers, with the queue, workers, execution history, retries, and replay you'd otherwise build yourself.</p>
+File system and Python execution for your agents: run untrusted code in gVisor-isolated containers, with the queue, workers, execution history, retries, and replay you'd otherwise build yourself.</p>
 
 <div class="tako-badges" markdown>
 [![PyPI](https://img.shields.io/pypi/v/tako-vm)](https://pypi.org/project/tako-vm/)
@@ -110,15 +110,15 @@ Sandbox-only tools (e2b, microsandbox) give you isolated execution. You still ne
 | Replay/debugging | Build custom tooling | Rerun/fork API |
 | Idempotency | Implement deduplication | `idempotency_key` |
 
-- **Job queue + workers** — no Redis/Celery setup needed
-- **Execution history** — every job persisted with timing and artifacts
-- **Replay to debug** — rerun past jobs with exact same inputs
-- **gVisor isolation** — userspace-kernel syscall interception (`runsc`), seccomp filtering, no network by default
-- **Self-hosted** — zero per-execution cost, works offline
+- **Job queue + workers**: no Redis/Celery setup needed
+- **Execution history**: every job persisted with timing and artifacts
+- **Replay to debug**: rerun past jobs with exact same inputs
+- **gVisor isolation**: userspace-kernel syscall interception (`runsc`), seccomp filtering, no network by default
+- **Self-hosted**: zero per-execution cost, works offline
 
 ## Security model
 
-Tako VM exists to run untrusted, often AI-generated, code — so isolation is layered: each job runs in its own ephemeral Docker container behind [gVisor](https://gvisor.dev)'s userspace kernel, with a default-deny seccomp profile, no network, dropped capabilities, and a non-root user. Even a kernel exploit stays inside the sandbox.
+Tako VM exists to run untrusted, often AI-generated, code, so isolation is layered: each job runs in its own ephemeral Docker container behind [gVisor](https://gvisor.dev)'s userspace kernel, with a default-deny seccomp profile, no network, dropped capabilities, and a non-root user. Even a kernel exploit stays inside the sandbox.
 
 For production with untrusted code, set `security_mode: strict` so execution **fails rather than silently falling back** to standard `runc` when gVisor is unavailable.
 
@@ -135,17 +135,17 @@ flowchart LR
 
 Three core concepts:
 
-- **Sandbox** — a gVisor-backed, single-use container that executes one job and is destroyed.
-- **Job** — an asynchronous unit of work with a persisted `ExecutionRecord` lifecycle (`queued → running → succeeded/failed/timeout/oom/cancelled`).
-- **Executor image** — the container image jobs run in; runtime `requirements` can be installed per-job via `uv` (opt-in: `allow_runtime_requirements`), with an optional shared cache (`enable_runtime_dependency_cache`) to speed up repeat installs.
+- **Sandbox**: a gVisor-backed, single-use container that executes one job and is destroyed.
+- **Job**: an asynchronous unit of work with a persisted `ExecutionRecord` lifecycle (`queued → running → succeeded/failed/timeout/oom/cancelled`).
+- **Executor image**: the container image jobs run in; runtime `requirements` can be installed per-job via `uv` (opt-in: `allow_runtime_requirements`), with an optional shared cache (`enable_runtime_dependency_cache`) to speed up repeat installs.
 
 !!! note "Where Tako VM is headed"
     The direction is a **serverless filesystem for agents**: durable, per-agent workspaces that persist and rehydrate across runs, spinning up on demand and scaling to zero with state preserved. Today each container is single-use; persistent workspaces are on the roadmap. gVisor remains the sole isolation boundary.
 
 ## Next steps
 
-- [Installation](getting-started/installation.md) — set up Tako VM
-- [Quick Start](getting-started/quickstart.md) — run your first code
-- [Agent Integration](guide/agent-tools.md) — use Tako VM as an agent tool
-- [Architecture](architecture.md) — how Tako VM works
-- [Changelog](changelog.md) — what's new in each release
+- [Installation](getting-started/installation.md): set up Tako VM
+- [Quick Start](getting-started/quickstart.md): run your first code
+- [Agent Integration](guide/agent-tools.md): use Tako VM as an agent tool
+- [Architecture](architecture.md): how Tako VM works
+- [Changelog](changelog.md): what's new in each release

--- a/docs/security/SOLUTIONS.md
+++ b/docs/security/SOLUTIONS.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM security solutions and limitations — what is already fixed (seccomp, path-traversal protection) and what cannot be fully mitigated."
+description: "Tako VM security solutions and limitations: what is already fixed (seccomp, path-traversal protection) and what cannot be fully mitigated."
 ---
 
 # Security Solutions & Limitations

--- a/docs/security/env-var-mitigation.md
+++ b/docs/security/env-var-mitigation.md
@@ -1,5 +1,5 @@
 ---
-description: "Mitigating environment-variable exposure in Tako VM — why /proc/self/environ leaks secrets and how to reduce the risk."
+description: "Mitigating environment-variable exposure in Tako VM: why /proc/self/environ leaks secrets and how to reduce the risk."
 ---
 
 # Environment Variable Mitigation

--- a/docs/security/honest-assessment.md
+++ b/docs/security/honest-assessment.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM threat model — strong isolation for trusted code, and the real-world limits for untrusted AI-generated code."
+description: "Tako VM threat model: strong isolation for trusted code, and the real-world limits for untrusted AI-generated code."
 ---
 
 # Threat Model
@@ -34,7 +34,7 @@ description: "Tako VM threat model — strong isolation for trusted code, and th
 
 **Limitations:**
 - Kernel vulnerabilities could allow escape (rare, quickly patched)
-- Shared kernel with host under `runc` — enable the built-in gVisor support (`container_runtime: runsc` + `security_mode: strict`) for a userspace-kernel boundary, or Kata for full VM isolation
+- Shared kernel with host under `runc`: enable the built-in gVisor support (`container_runtime: runsc` + `security_mode: strict`) for a userspace-kernel boundary, or Kata for full VM isolation
 
 ### ✅ Resource Exhaustion (GOOD)
 ```yaml

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM security documentation — vulnerability reporting, threat model, hardening guidance, and advisories."
+description: "Tako VM security documentation: vulnerability reporting, threat model, hardening guidance, and advisories."
 ---
 
 # Security
@@ -7,15 +7,15 @@ description: "Tako VM security documentation — vulnerability reporting, threat
 Tako VM runs untrusted, often AI-generated, code. This section documents the isolation model, what it does and does not protect against, and how to harden a deployment.
 
 !!! tip "Found a vulnerability?"
-    Report it privately via [GitHub security advisories](https://github.com/Tako-Research/TakoVM/security/advisories/new) — never in a public issue. See the [security policy](policy.md) for response timelines.
+    Report it privately via [GitHub security advisories](https://github.com/Tako-Research/TakoVM/security/advisories/new), never in a public issue. See the [security policy](policy.md) for response timelines.
 
 ## In this section
 
-- **[Security Policy](policy.md)** — how to report vulnerabilities, response timelines, supported versions
-- **[Threat Model](honest-assessment.md)** — practical security analysis: what's protected, what isn't, and for which workloads
-- **[Hardening Guide](../deployment/security.md)** — production configuration: `security_mode: strict`, gVisor, seccomp, network policy
-- **[Analysis: /proc exposure](proc-exposure-vulnerability.md)** — technical analysis of `/proc` filesystem access from sandboxed code
-- **[Mitigations](mitigations.md)** — implementation options (AppArmor, gVisor, env var migration)
+- **[Security Policy](policy.md)**: how to report vulnerabilities, response timelines, supported versions
+- **[Threat Model](honest-assessment.md)**: practical security analysis: what's protected, what isn't, and for which workloads
+- **[Hardening Guide](../deployment/security.md)**: production configuration: `security_mode: strict`, gVisor, seccomp, network policy
+- **[Analysis: /proc exposure](proc-exposure-vulnerability.md)**: technical analysis of `/proc` filesystem access from sandboxed code
+- **[Mitigations](mitigations.md)**: implementation options (AppArmor, gVisor, env var migration)
 
 ## Security Status
 
@@ -60,7 +60,7 @@ Code needs access to its configuration to function. If code requires an API key 
 ### 🔵 Optional Enhancements (For Specific Threat Models)
 
 **For untrusted/AI-generated code:**
-- The built-in gVisor runtime (`container_runtime: runsc` + `security_mode: strict`) — see the [hardening guide](../deployment/security.md)
+- The built-in gVisor runtime (`container_runtime: runsc` + `security_mode: strict`); see the [hardening guide](../deployment/security.md)
 - External secret management (AWS Secrets Manager, HashiCorp Vault)
 - AppArmor/SELinux to restrict `/proc` access (Linux only)
 - Artifact scanning for leaked credentials
@@ -159,7 +159,7 @@ For paranoid deployments, use gVisor (user-space kernel) or Kata (VM isolation).
 - Seccomp filtering, enabled by default
 - Container hardening: non-root execution, read-only filesystem, dropped capabilities
 - Network isolation (`--network=none` by default), resource and input limits
-- API-key authentication and rate limiting (auth off by default — [enable it in production](../deployment/security.md#api-security))
+- API-key authentication and rate limiting (auth off by default, [enable it in production](../deployment/security.md#api-security))
 
 **Roadmap** (tracked in [GitHub issues](https://github.com/Tako-Research/TakoVM/issues?q=is%3Aissue+is%3Aopen+label%3Asecurity)):
 

--- a/docs/security/mitigations.md
+++ b/docs/security/mitigations.md
@@ -1,5 +1,5 @@
 ---
-description: "Security mitigations for the Tako VM /proc filesystem exposure — current protections and options like AppArmor, gVisor, and env-var migration."
+description: "Security mitigations for the Tako VM /proc filesystem exposure: current protections and options like AppArmor, gVisor, and env-var migration."
 ---
 
 # Security Mitigations
@@ -29,9 +29,9 @@ enable_seccomp: true
 
 Every container runs with:
 
-- `--cap-drop=ALL` — all Linux capabilities removed
-- `--read-only` — read-only root filesystem
-- `--network=none` — no network access (by default)
+- `--cap-drop=ALL`: all Linux capabilities removed
+- `--read-only`: read-only root filesystem
+- `--network=none`: no network access (by default)
 - Non-root execution (uid 1000 via gosu)
 - Resource limits (memory, CPU, PIDs, file size)
 
@@ -55,7 +55,7 @@ job_types:
 
 **Use:**
 - For **trusted code**: pass secrets through `input_data` / `/input/data.json` (mounted read-only, scoped to one job)
-- For **untrusted or AI-generated code**: don't give the job secrets at all — code can read `/input/` exactly as easily as `/proc/self/environ`. Keep credentials in trusted infrastructure (your platform's secret manager: Vault, AWS Secrets Manager) and have it perform the privileged calls
+- For **untrusted or AI-generated code**: don't give the job secrets at all. Code can read `/input/` exactly as easily as `/proc/self/environ`. Keep credentials in trusted infrastructure (your platform's secret manager: Vault, AWS Secrets Manager) and have it perform the privileged calls
 - Use pre-built images with secrets baked in at build time (not at runtime)
 
 ### Enable gVisor for Production

--- a/docs/security/policy.md
+++ b/docs/security/policy.md
@@ -1,5 +1,5 @@
 ---
-description: "Tako VM security policy — how to report vulnerabilities privately, response timelines, and supported versions."
+description: "Tako VM security policy: how to report vulnerabilities privately, response timelines, and supported versions."
 ---
 
 --8<-- "SECURITY.md"

--- a/docs/security/proc-exposure-vulnerability.md
+++ b/docs/security/proc-exposure-vulnerability.md
@@ -1,5 +1,5 @@
 ---
-description: "Security analysis of /proc filesystem exposure in Tako VM containers — information-leak risk, severity, and exfiltration paths."
+description: "Security analysis of /proc filesystem exposure in Tako VM containers: information-leak risk, severity, and exfiltration paths."
 ---
 
 # Security Analysis: /proc Filesystem Exposure
@@ -128,7 +128,7 @@ with open('/output/processes.json', 'w') as f:
    - Read-only filesystem (except /output, /tmp)
    - Capability dropping (`--cap-drop=ALL`)
    - Network isolation by default
-   - Privilege drop to non-root (uid 1000) via `gosu` after dependency install (`no-new-privileges` is intentionally not set — see the [hardening guide](../deployment/security.md))
+   - Privilege drop to non-root (uid 1000) via `gosu` after dependency install (`no-new-privileges` is intentionally not set; see the [hardening guide](../deployment/security.md))
 
 3. **Filename Validation** ([security.py:335-360](https://github.com/Tako-Research/TakoVM/blob/main/tako_vm/security.py#L335-L360))
    - Blocks path separators in artifact names
@@ -145,7 +145,7 @@ with open('/output/processes.json', 'w') as f:
 
 ### Priority 1: Run under gVisor (available today)
 
-The gVisor runtime serves `/proc` from its userspace kernel rather than exposing the host kernel's procfs — this is the strongest available mitigation and is built in:
+The gVisor runtime serves `/proc` from its userspace kernel rather than exposing the host kernel's procfs. This is the strongest available mitigation and is built in:
 
 ```yaml
 # tako_vm.yaml
@@ -154,7 +154,7 @@ security_mode: strict   # fail rather than silently fall back to runc
 ```
 
 !!! note "What seccomp can and cannot do here"
-    Seccomp (enabled by default) blocks dangerous *syscalls* — `ptrace`, `process_vm_readv`, module loading — but cannot distinguish `open("/proc/self/environ")` from `open("/input/data.json")`: both are the same syscall. Path-based `/proc` restrictions under runc require an LSM (AppArmor/SELinux), which is on the roadmap.
+    Seccomp (enabled by default) blocks dangerous *syscalls* (`ptrace`, `process_vm_readv`, module loading) but cannot distinguish `open("/proc/self/environ")` from `open("/input/data.json")`: both are the same syscall. Path-based `/proc` restrictions under runc require an LSM (AppArmor/SELinux), which is on the roadmap.
 
 ### Priority 2: Avoid passing secrets via environment variables
 
@@ -178,7 +178,7 @@ cmd.append(f"--mount=type=bind,source={config_file},target=/config/secrets.json,
 
 ### Priority 3: Know what user code can see
 
-> **Security Notice:** Under `runc`, user code runs with read access to `/proc`, which exposes container metadata, environment variables, and process information. Do not pass sensitive secrets via environment variables. Use input files or external secret management instead — and for untrusted code, run under gVisor.
+> **Security Notice:** Under `runc`, user code runs with read access to `/proc`, which exposes container metadata, environment variables, and process information. Do not pass sensitive secrets via environment variables. Use input files or external secret management instead, and for untrusted code, run under gVisor.
 
 ## Impact Assessment
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Tako VM brand palette — deep ink primary, takoyaki accent */
+/* Tako VM brand palette: deep ink primary, takoyaki accent */
 :root {
   --md-primary-fg-color: #1c1e26;
   --md-primary-fg-color--light: #2e3140;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Tako VM
-site_description: Secure Python code execution and job queue infrastructure for AI agents — run untrusted code in gVisor-isolated Docker containers with workers, retries, and replay.
+site_description: Secure Python code execution and job queue infrastructure for AI agents: run untrusted code in gVisor-isolated Docker containers with workers, retries, and replay.
 site_url: https://tako-research.github.io/TakoVM/
 site_author: Tako VM
 
@@ -7,7 +7,7 @@ repo_url: https://github.com/Tako-Research/TakoVM
 repo_name: Tako-Research/TakoVM
 edit_uri: edit/main/docs/
 
-# Internal triage / design notes — not part of the public docs site.
+# Internal triage / design notes, not part of the public docs site.
 exclude_docs: |
   security/SOLUTIONS.md
   security/env-var-mitigation.md
@@ -154,4 +154,4 @@ extra:
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/tako-vm/
 
-copyright: Copyright &copy; 2026 Tako VM contributors — Apache-2.0
+copyright: Copyright &copy; 2026 Tako VM contributors, Apache-2.0

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  Tako VM 0.1.4 is out — typed Python SDK, reliability layer, and end-to-end hardening.
+  Tako VM 0.1.4 is out: typed Python SDK, reliability layer, and end-to-end hardening.
   <a href="{{ 'changelog/' | url }}">See what's new</a>
 {% endblock %}

--- a/tako_vm/cli.py
+++ b/tako_vm/cli.py
@@ -293,7 +293,7 @@ def run_setup(args):
     if result.returncode == 0 and "ok" in result.stdout:
         print("  Executor image works")
     else:
-        # The image is unusable — exit non-zero so `tako-vm setup && ...`
+        # The image is unusable, so exit non-zero so `tako-vm setup && ...`
         # doesn't proceed on a broken image and report success.
         print("Error: Image pulled but verification failed.", file=sys.stderr)
         if result.stderr:
@@ -564,7 +564,7 @@ def check_status(args):
 
     try:
         response = requests.get(f"{args.url}/health", timeout=5)
-        # A non-2xx /health means the server is up but unhealthy — surface the
+        # A non-2xx /health means the server is up but unhealthy: surface the
         # status code and body instead of blindly parsing JSON (which could
         # raise, or worse, print a healthy-looking "unknown").
         if response.status_code >= 400:
@@ -581,7 +581,7 @@ def check_status(args):
         print(f"Error: Cannot connect to {args.url}", file=sys.stderr)
         sys.exit(1)
     except ValueError as e:
-        # Reachable but the body wasn't valid JSON — show what we got.
+        # Reachable but the body wasn't valid JSON. Show what we got.
         print(f"Error: invalid JSON from {args.url}/health: {e}", file=sys.stderr)
         sys.exit(1)
     except Exception as e:
@@ -634,7 +634,7 @@ def validate_config(args):
                     print(f"    - {jt.name}")
         except (ImportError, ValueError, AttributeError) as e:
             # validate_config_file passed but the full loader (which also
-            # applies env overrides + resolve_paths) failed — that divergence
+            # applies env overrides + resolve_paths) failed; that divergence
             # matters, so don't hide it behind "Configuration is valid!".
             print(f"(could not render config summary: {e})", file=sys.stderr)
 

--- a/tako_vm/execution/builder.py
+++ b/tako_vm/execution/builder.py
@@ -73,8 +73,8 @@ class ContainerBuilder:
         this contract, because docker would otherwise execute the image's
         default CMD instead of the user's code.
 
-        Note: ``python_version`` no longer selects the default base image —
-        the executor base image pins the Python version. To use a different
+        Note: ``python_version`` no longer selects the default base image.
+        The executor base image pins the Python version. To use a different
         Python, point ``base_image`` at a custom executor-derived image.
 
         Args:
@@ -268,7 +268,7 @@ WORKDIR /app
                 if image_has_executor_entrypoint(job_type.image_name) is not True:
                     logger.warning(
                         "Built image %s does NOT carry the executor entrypoint contract "
-                        "(ENTRYPOINT %s) — the worker will refuse to run it. base_image "
+                        "(ENTRYPOINT %s); the worker will refuse to run it. base_image "
                         "'%s' for job type '%s' must derive from the executor image "
                         "(docker/Dockerfile.executor).",
                         job_type.image_name,

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -37,7 +37,7 @@ DEFAULT_EXECUTOR_IMAGE = "code-executor:latest"
 # entrypoint is what enforces the in-container startup/execution timeouts,
 # installs runtime requirements, writes the phase/timing file, and runs
 # /code/main.py itself (as the sandbox user via gosu). An image without it
-# would run its default CMD instead of the user's code — for python:slim the
+# would run its default CMD instead of the user's code. For python:slim the
 # REPL exits 0 on EOF, recording a bogus "succeeded" for code that never ran.
 EXECUTOR_ENTRYPOINT = "/entrypoint.sh"
 
@@ -79,7 +79,7 @@ def image_exists(image_name: str) -> bool:
 
     Positive results are cached for a short TTL so per-run lookups (e.g. "does
     this job type have a pre-built image?") don't cost a daemon round-trip on
-    every execution. Negative results are never cached — see
+    every execution. Negative results are never cached: see
     ``_IMAGE_CACHE_TTL_SECONDS``.
 
     Args:
@@ -113,7 +113,7 @@ def image_has_executor_entrypoint(image_name: str) -> Optional[bool]:
     """Check whether an image's ENTRYPOINT is exactly ``["/entrypoint.sh"]``.
 
     This is the cheap, reliable test for "was this image derived from the
-    executor base image" — i.e. does it honor the contract the worker depends
+    executor base image", i.e. does it honor the contract the worker depends
     on (in-container timeouts, dependency install, phase file, and running
     /code/main.py itself). Positive results are cached with a short TTL,
     mirroring ``image_exists``.
@@ -158,7 +158,7 @@ def image_has_executor_entrypoint(image_name: str) -> Optional[bool]:
 
 # Label applied to every executor container at `docker run` time. Cleanup
 # (DockerCleanup.cleanup_orphaned_containers) matches on this label, so it must
-# be applied by every launch path — base_isolation_args() does this centrally.
+# be applied by every launch path; base_isolation_args() does this centrally.
 CONTAINER_LABEL = "tako-vm-executor"
 
 # Label key carrying the execution/job ID, so an orphaned container can be
@@ -189,7 +189,7 @@ def generate_container_name(prefix: str, job_id: Optional[str] = None, attempt: 
 
     Retry attempts (attempt > 0) get a ``-r{attempt}`` suffix so a retry can
     never collide with a previous attempt's container that ``--rm`` has not
-    removed yet (exactly the daemon-hiccup scenario that triggers a retry —
+    removed yet (exactly the daemon-hiccup scenario that triggers a retry;
     a name collision would fail the retry with docker exit 125 "name already
     in use"). Attempt 0 keeps the plain deterministic ``{prefix}-{job_id}``
     name because external kill paths (queue.py cancel()/watchdog) compute
@@ -274,7 +274,7 @@ def remove_container(container_name: str) -> bool:
     one step. Used by the worker after every run (its containers are started
     without ``--rm`` so a 137 exit can be inspected for ``State.OOMKilled``)
     and before a retry attempt to clean up the previous attempt's container
-    so it cannot linger (removal can lag behind a daemon hiccup — the very
+    so it cannot linger (removal can lag behind a daemon hiccup, the very
     condition that triggers retries).
 
     Silently ignores errors (the container may already be gone).
@@ -365,7 +365,7 @@ def ulimit_args(limits) -> list[str]:
     gVisor does not impose on its own; they only take effect when passed via
     ``--ulimit`` at container creation. Both builders (``CodeExecutor`` and the
     library ``Sandbox``) assemble their own ``docker run`` command, so this is
-    factored out to keep them from drifting — the drift this guards against is
+    factored out to keep them from drifting; the drift this guards against is
     exactly issue #97, where the ``Sandbox`` path shipped with no ``--ulimit``
     at all and left ``RLIMIT_FSIZE`` unbounded against the writable ``/output``
     bind-mount (a host-disk-exhaustion DoS the gVisor boundary does not cover).
@@ -394,9 +394,9 @@ def base_isolation_args(
 ) -> list[str]:
     """Leading ``docker run`` args shared by every isolated-execution path.
 
-    Centralizes the always-on isolation posture — ``--rm``, ``--init``,
+    Centralizes the always-on isolation posture (``--rm``, ``--init``,
     ``--read-only``, the capability drop/add set, and the gVisor ``--runtime``
-    flag — so it is assembled in exactly one place. The execution paths that
+    flag) so it is assembled in exactly one place. The execution paths that
     each build their own command (``CodeExecutor`` and the library ``Sandbox``)
     start from this, which keeps the isolation flags from drifting between them
     (e.g. a hardening flag added to one builder and silently missed on

--- a/tako_vm/execution/health.py
+++ b/tako_vm/execution/health.py
@@ -209,10 +209,10 @@ class DockerCleanup:
         sandbox alike). Matching is label-only by design: name-pattern filters
         do substring matching and could sweep up unrelated user containers.
         (Containers launched by versions that predate the label are not
-        matched — a one-time concern, accepted to keep matching unambiguous.)
+        matched, a one-time concern, accepted to keep matching unambiguous.)
 
         This runs at server startup, so any labeled container still *running*
-        was launched by a previous (now dead) server process — its supervising
+        was launched by a previous (now dead) server process; its supervising
         subprocess is gone and nothing will ever reap it. Exited/dead labeled
         containers are removed unconditionally; running ones are only removed
         once older than ``max_age_seconds``, as a safety guard against killing

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -96,7 +96,7 @@ def prune_stale_workspaces(max_age_seconds: int) -> int:
 
     Each execution creates a temp dir (``job-*`` / ``sandbox-*``) that is
     normally removed in a finally block, but a hard crash or an rmtree failure
-    leaks it — and there is no other reaper, so host disk grows unbounded. This
+    leaks it, and there is no other reaper, so host disk grows unbounded. This
     removes such dirs whose mtime is older than ``max_age_seconds`` (chosen to
     sit well past any run's max timeout). Fail-soft: per-dir errors are logged
     and skipped. Returns the number of dirs removed.
@@ -127,7 +127,7 @@ def prune_old_run_dirs(data_dir: Path, ttl_days: int) -> int:
     """Remove on-disk run artifact dirs (``data_dir/runs/<id>``) past the TTL.
 
     The DB record cleanup deletes rows but not the on-disk code/input/output
-    artifacts, so they survive the configured retention indefinitely — disk
+    artifacts, so they survive the configured retention indefinitely: disk
     growth plus a retention/compliance gap (the stored source code and inputs
     outlive their record). This removes ``runs/<id>`` dirs whose mtime is older
     than ``ttl_days``. Fail-soft per dir. Returns the number of dirs removed.
@@ -157,7 +157,7 @@ def _clear_output_dir(output_dir: Path) -> None:
     file, or artifacts behind; without clearing, those leftovers would be
     reported as the next attempt's results. The directory itself is preserved
     (it is bind-mounted by path and carries the 0o777 mode the container user
-    needs) — only its entries are removed. Symlinks are unlinked, never
+    needs); only its entries are removed. Symlinks are unlinked, never
     followed: untrusted code may have planted a symlink at any name here.
 
     Fail-soft: per-entry errors are logged and skipped.
@@ -199,11 +199,11 @@ def _make_meta_dir(meta_dir: Path) -> Optional[Path]:
       entrypoint) can write, the sandbox user (uid 1000) cannot. Secure.
     - Server running as a non-root host user: container root cannot write
       either; the entrypoint detects this and falls back to the legacy
-      ``/output`` location (and ``parse_phase_file`` falls back with it) —
+      ``/output`` location (and ``parse_phase_file`` falls back with it),
       no worse than the previous behavior.
     - Server running as host uid 1000 exactly: the dir would be owned by the
       sandbox user inside the container, which as owner could chmod and write
-      it — the "trusted" location would be forgeable. Returns None so the
+      it: the "trusted" location would be forgeable. Returns None so the
       mount is skipped entirely and the legacy behavior applies.
 
     Returns:
@@ -243,7 +243,7 @@ def check_gvisor_available() -> bool:
         )
         if result.returncode != 0:
             # `docker info` failed (daemon not up yet, transient hiccup). Don't
-            # cache this as "gVisor unavailable" — a one-time probe failure
+            # cache this as "gVisor unavailable": a one-time probe failure
             # would otherwise sticky-degrade every later job to runc in
             # permissive mode. Leave the cache unset so we re-probe next call.
             logger.warning(
@@ -302,8 +302,8 @@ def parse_phase_file(
     sandboxed user code (uid 1000) cannot write to. When the meta copy exists
     it is authoritative and a (possibly forged) ``/output/.tako_phase`` is
     ignored. The ``output_dir`` fallback only applies when no meta copy was
-    written — a stale executor image that predates ``/tako-meta``, or a host
-    setup where container root could not write the mount — and that fallback
+    written (a stale executor image that predates ``/tako-meta``, or a host
+    setup where container root could not write the mount), and that fallback
     copy lives in the 0777 output dir, so it remains untrusted legacy data.
 
     Args:
@@ -398,8 +398,8 @@ def determine_timeout_phase(timing: Optional[ExecutionTiming], timed_out: bool) 
 def resolve_runtime(config: TakoVMConfig) -> str:
     """Resolve the container runtime ('runsc' or 'runc') from config.
 
-    Single source of truth shared by every execution path — the server
-    ``CodeExecutor`` and the library ``Sandbox`` — so they apply gVisor
+    Single source of truth shared by every execution path (the server
+    ``CodeExecutor`` and the library ``Sandbox``) so they apply gVisor
     identically and can't drift. In strict mode gVisor must be available or this
     fails closed; in permissive mode (the current default, see
     ``TakoVMConfig.security_mode``) a missing gVisor falls back to runc with a
@@ -554,7 +554,7 @@ class CodeExecutor:
             output_dir.mkdir()
             output_dir.chmod(0o777)  # Writable by container user (uid 1000)
             # Control metadata (.tako_phase) mount: writable by container
-            # root only, NOT by the sandbox user — see _make_meta_dir.
+            # root only, NOT by the sandbox user. See _make_meta_dir.
             # None when a trusted dir cannot be provided (mount is skipped).
             meta_dir = _make_meta_dir(workspace / "meta")
 
@@ -692,7 +692,7 @@ class CodeExecutor:
             output_dir.mkdir()
             output_dir.chmod(0o777)  # Writable by container user (uid 1000)
             # Control metadata (.tako_phase) mount: writable by container
-            # root only, NOT by the sandbox user — see _make_meta_dir.
+            # root only, NOT by the sandbox user. See _make_meta_dir.
             # None when a trusted dir cannot be provided (mount is skipped).
             meta_dir = _make_meta_dir(workspace / "meta")
 
@@ -740,7 +740,7 @@ class CodeExecutor:
                     # and can fail during the very daemon hiccup that
                     # triggered the retry), and its partial output
                     # (result.json, .tako_phase, artifacts) may still be in
-                    # output_dir/meta_dir — remove all of these so the retry
+                    # output_dir/meta_dir, so remove all of these so the retry
                     # cannot collide on a container name or report stale
                     # results from the failed attempt.
                     remove_container(generate_container_name("tako", job_id, attempt=attempt - 1))
@@ -914,7 +914,7 @@ class CodeExecutor:
                     if result.get("oom_killed") is None:
                         # inspect was inconclusive (daemon unreachable, container
                         # already gone). We default to OOM so a flaky inspect
-                        # never loses a true OOM — but the classification is a
+                        # never loses a true OOM, but the classification is a
                         # guess, so say so loudly rather than reporting a
                         # confident "oom".
                         logger.warning(
@@ -935,7 +935,7 @@ class CodeExecutor:
                 phase = timing.phase_at_exit if timing else None
                 if result.get("infra_failure"):
                     # Docker-level failure (daemon down, circuit breaker open):
-                    # don't run classify_error on daemon stderr — it would
+                    # don't run classify_error on daemon stderr: it would
                     # misattribute the failure to the user's code.
                     record.error = ExecutionError(
                         type="service_unavailable",
@@ -948,7 +948,7 @@ class CodeExecutor:
                     # The job was refused before any container ran (e.g. a raw
                     # base_image without the executor entrypoint contract, or
                     # an invalid image reference). Don't run classify_error on
-                    # the explanation text — this is a configuration problem,
+                    # the explanation text: this is a configuration problem,
                     # not the user's code failing.
                     record.error = ExecutionError(
                         type="config_error",
@@ -966,7 +966,7 @@ class CodeExecutor:
             return record
 
         except Exception as e:
-            # Unexpected error — keep the full traceback server-side; the
+            # Unexpected error: keep the full traceback server-side; the
             # sanitized message is all the API consumer sees.
             logger.exception("Unexpected error executing job %s: %s", job_id, e)
             record.status = "failed"
@@ -1131,25 +1131,25 @@ class CodeExecutor:
         Resolution order (each selection is logged for auditability):
 
         1. **Pre-built job-type image** (``tako-vm-<name>:latest``, produced by
-           ``tako-vm build``) — preferred when it exists locally AND carries
+           ``tako-vm build``): preferred when it exists locally AND carries
            the executor entrypoint contract (``ENTRYPOINT ["/entrypoint.sh"]``,
            the cheap reliable marker of an executor-derived image). Its
            ``job_type.requirements`` are baked in at build time, so the caller
            skips runtime installation of those.
-        2. **``job_type.base_image``** — allowed ONLY when the image itself
+        2. **``job_type.base_image``**: allowed ONLY when the image itself
            carries the executor entrypoint contract (and is therefore present
            locally, since the contract is verified via ``docker image
            inspect``). A raw image (e.g. ``python:3.11-slim``) is refused with
            a config error: without ``/entrypoint.sh`` the
            TAKO_STARTUP_TIMEOUT/TAKO_EXECUTION_TIMEOUT env vars are ignored
            (no in-container timeout at all), no phase/timing file is written,
-           and — worst — ``docker run`` appends only the image, so the image's
+           and, worst, ``docker run`` appends only the image, so the image's
            default CMD runs instead of ``/code/main.py``. For ``python:slim``
            the REPL exits 0 on EOF, so the job would be recorded as
            "succeeded" with empty output for code that NEVER ran.
            ``ContainerBuilder`` exists precisely to wrap a base image with the
            executor contract, so the error directs users to ``tako-vm build``.
-        3. **Default executor image** (``self.docker_image``) — the unchanged
+        3. **Default executor image** (``self.docker_image``): the unchanged
            legacy path; requirements are installed at container startup by the
            entrypoint.
 
@@ -1195,7 +1195,7 @@ class CodeExecutor:
                 )
             if image_has_executor_entrypoint(job_type.base_image) is not True:
                 logger.error(
-                    "Job type '%s': refusing to run base_image %s — it does not carry "
+                    "Job type '%s': refusing to run base_image %s, it does not carry "
                     "the executor entrypoint contract (ENTRYPOINT %s) or is not present "
                     "locally. Build an executor-derived image with 'tako-vm build %s'.",
                     job_type.name,
@@ -1271,7 +1271,7 @@ class CodeExecutor:
 
         The container is started WITHOUT ``--rm`` so that on exit code 137 the
         exited container can be inspected for ``State.OOMKilled`` (the only
-        authoritative OOM signal — ``--rm`` would race the inspect). Every
+        authoritative OOM signal; ``--rm`` would race the inspect). Every
         exit path from this method removes the container via a best-effort
         ``docker rm -f`` in a ``finally`` block; the labeled orphan cleanup at
         startup remains as a backstop only.
@@ -1317,7 +1317,7 @@ class CodeExecutor:
         # Resolve which image to run: a pre-built job-type image, an
         # executor-derived base image, or the default executor image. Raw
         # base images without the executor entrypoint contract are refused
-        # here — running them would execute the image's default CMD instead
+        # here; running them would execute the image's default CMD instead
         # of /code/main.py (see _resolve_image).
         image_name, image_source, image_error = self._resolve_image(job_type)
         if image_error is not None:
@@ -1326,7 +1326,7 @@ class CodeExecutor:
         # Validate runtime requirements before deciding network and tmpfs policy.
         # A pre-built image already has job_type.requirements baked in at build
         # time, so only per-job extra requirements still need runtime
-        # installation — otherwise the entrypoint would reinstall the full set
+        # installation; otherwise the entrypoint would reinstall the full set
         # on every run, defeating the point of `tako-vm build`.
         if image_source == "built":
             all_requirements = []
@@ -1505,7 +1505,7 @@ class CodeExecutor:
             # non-zero exit from user code) means Docker itself is healthy.
             circuit_breaker.record_success()
 
-            # Exit 137 is SIGKILL — could be the OOM killer, but also `docker
+            # Exit 137 is SIGKILL: could be the OOM killer, but also `docker
             # kill` (cancel path), a pids-limit kill, or user sys.exit(137).
             # classify_sigkill inspects the exited container's State.OOMKilled
             # before the finally block removes it. Note: in-container timeout
@@ -1528,7 +1528,7 @@ class CodeExecutor:
             # Kill the orphaned container (subprocess died but container keeps running)
             if not kill_container(container_name):
                 # An untrusted container that outlived its host timeout and
-                # could not be killed is a real containment concern — surface it.
+                # could not be killed is a real containment concern: surface it.
                 logger.warning(
                     "Failed to kill container %s after host timeout for job %s; "
                     "it may still be running",
@@ -1569,7 +1569,7 @@ class CodeExecutor:
             )
             # Best-effort kill; the container may never have started (error
             # before `docker run`), so a False return here is often benign and
-            # not worth a warning — the finally block removes it regardless.
+            # not worth a warning; the finally block removes it regardless.
             kill_container(container_name)
             error_msg = str(e).lower()
             if "docker" in error_msg or "daemon" in error_msg or "connection" in error_msg:

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -413,7 +413,7 @@ class Sandbox:
 
             start_time = time.time()
             # The container runs without --rm (see _build_docker_command), so
-            # this try/finally — entered only once `docker run` is attempted —
+            # this try/finally (entered only once `docker run` is attempted)
             # owns removal on every exit path: success, failure, OOM, host
             # timeout, and unexpected exceptions. remove_container does
             # `docker rm -f`, which also kills a still-running container (the
@@ -468,7 +468,7 @@ class Sandbox:
                     if proc.returncode == 124:
                         error = f"Execution timed out after {timeout}s"
                     elif proc.returncode == 137:
-                        # Exit 137 is SIGKILL — could be the OOM killer, but
+                        # Exit 137 is SIGKILL: could be the OOM killer, but
                         # also `docker kill` or user code calling
                         # sys.exit(137). classify_sigkill inspects the exited
                         # container's State.OOMKilled before the finally block
@@ -499,7 +499,7 @@ class Sandbox:
                 except subprocess.TimeoutExpired as exc:
                     duration_ms = int((time.time() - start_time) * 1000)
                     # Reaching the host backstop means the in-container timeout
-                    # (TAKO_EXECUTION_TIMEOUT) did NOT fire — daemon hung, heavy
+                    # (TAKO_EXECUTION_TIMEOUT) did NOT fire: daemon hung, heavy
                     # container overhead, or a stuck startup phase. Report the
                     # real budget consumed (subprocess_timeout), not the inner
                     # code timeout, and say which limit tripped.

--- a/tako_vm/server/limits.py
+++ b/tako_vm/server/limits.py
@@ -111,7 +111,7 @@ class ApiProtectionMiddleware:
         # This middleware wraps the app *outside* FastAPI's exception handlers,
         # so an unexpected error in the protection logic would otherwise escape
         # as an opaque 500 with no correlated log line. Catch it, log loudly,
-        # and emit a sanitized 500 — unless the response has already started
+        # and emit a sanitized 500, unless the response has already started
         # streaming, in which case we can only re-raise.
         response_started = False
 

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -193,7 +193,7 @@ MIGRATIONS: list[tuple[str, str]] = [
 # ON CONFLICT ... DO UPDATE SET clause are ALL generated from _EXECUTION_COLUMNS
 # below, so adding a column is one row here instead of four hand-synced edits in
 # one statement (the exact drift hazard the `runtime`/`correlation_id`
-# migrations hit) — and a placeholder miscount can no longer silently shift
+# migrations hit), and a placeholder miscount can no longer silently shift
 # every column. `_row_to_record` stays hand-written: it carries per-field decode
 # and corruption-fallback logic that resists tabulation.
 #
@@ -649,7 +649,7 @@ class ExecutionStorage:
     def _row_to_record(self, row: RowMapping) -> ExecutionRecord:
         """Convert database row to ExecutionRecord."""
         # All ResourceUsage fields are independently nullable, so rebuild the
-        # model if ANY metric column was stored — gating on wall_time_ms alone
+        # model if ANY metric column was stored; gating on wall_time_ms alone
         # would silently drop records saved with only max_rss_mb/cpu_time_ms.
         resource_usage = None
         if any(

--- a/tests/test_artifact_symlink.py
+++ b/tests/test_artifact_symlink.py
@@ -5,7 +5,7 @@ Untrusted code in the sandbox can drop a symlink in /output pointing at a
 host-readable file (the config with api_keys, /proc/self/environ, another run's
 data). The host-side worker collects artifacts and reads result.json/.tako_phase
 *outside* any sandbox, so following such a symlink would exfiltrate host files.
-These are pure host-side file tests — no Docker required.
+These are pure host-side file tests: no Docker required.
 """
 
 from pathlib import Path

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -4,7 +4,7 @@ Tests for ContainerBuilder.
 Covers the opt-in ``skip_existing`` behavior of ``build_all`` (skip job types
 whose image is already present) and the generated Dockerfile's executor
 entrypoint contract: built images must derive from the executor base image
-(inheriting ``ENTRYPOINT /entrypoint.sh``) and must not override USER/CMD —
+(inheriting ``ENTRYPOINT /entrypoint.sh``) and must not override USER/CMD;
 otherwise the worker refuses to run them (see CodeExecutor._resolve_image).
 """
 

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -196,7 +196,7 @@ class TestRemoveContainer:
 
 
 class TestInspectOomKilled:
-    """Tests for inspect_oom_killed() — the authoritative OOM signal."""
+    """Tests for inspect_oom_killed(): the authoritative OOM signal."""
 
     @patch("subprocess.run")
     def test_inspect_calls_docker_with_oomkilled_format(self, mock_run):
@@ -252,7 +252,7 @@ class TestInspectOomKilled:
 
 
 class TestImageExists:
-    """Tests for image_exists() — cached local-image presence check."""
+    """Tests for image_exists(): cached local-image presence check."""
 
     @patch("subprocess.run")
     def test_calls_docker_image_inspect_with_timeout(self, mock_run):
@@ -328,7 +328,7 @@ class TestImageExists:
 
 
 class TestImageHasExecutorEntrypoint:
-    """Tests for image_has_executor_entrypoint() — the executor contract check."""
+    """Tests for image_has_executor_entrypoint(): the executor contract check."""
 
     @staticmethod
     def _inspect_result(stdout):

--- a/tests/test_failure_mode_handling.py
+++ b/tests/test_failure_mode_handling.py
@@ -54,7 +54,7 @@ def test_middleware_unexpected_error_returns_sanitized_500(monkeypatch, caplog):
 
 
 def test_gvisor_probe_does_not_cache_transient_failure(monkeypatch):
-    """A transient probe failure must NOT sticky-cache gVisor as unavailable —
+    """A transient probe failure must NOT sticky-cache gVisor as unavailable:
     otherwise one flaky `docker info` degrades every later job to runc."""
     import subprocess
 

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -11,7 +11,7 @@ contract:
    ``max_age_seconds`` guard for running containers, and removes exactly the
    matched container IDs.
 
-All tests mock subprocess.run — no Docker required.
+All tests mock subprocess.run: no Docker required.
 """
 
 from datetime import datetime, timedelta, timezone

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -4,7 +4,7 @@ Runtime (gVisor) enforcement tests for the library Sandbox path.
 The ``Sandbox`` / ``sandbox.run`` convenience entry point must apply the same
 container runtime policy as the server execution path: pass ``--runtime=runsc``
 when gVisor is selected, and fail closed in strict mode when gVisor is absent.
-These are pure command-construction tests — no Docker required.
+These are pure command-construction tests: no Docker required.
 """
 
 from pathlib import Path

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -311,8 +311,8 @@ class TestExecution:
 
 class TestServerContractViolations:
     """A 2xx response with a schema-mismatched body must surface a structured,
-    correlated MalformedResponseError — never a naked KeyError or a vague
-    "Execution failed" — and must be logged loudly (verbose-on-failure)."""
+    correlated MalformedResponseError (never a naked KeyError or a vague
+    "Execution failed") and must be logged loudly (verbose-on-failure)."""
 
     def test_submit_code_missing_job_id_raises_malformed(self, caplog):
         session = _mock_session({"status": "queued", "oops": 1})  # no job_id

--- a/tests/test_storage_columns.py
+++ b/tests/test_storage_columns.py
@@ -23,7 +23,7 @@ from tako_vm.storage import (
 )
 
 # Frozen expectation: (column_name, conflict_policy) in physical order. If you
-# add a column, add it here too — that is the point (one place, reviewed).
+# add a column, add it here too: that is the point (one place, reviewed).
 EXPECTED = [
     ("execution_id", _SET_KEY),
     ("status", _SET_EXCLUDED),

--- a/tests/test_worker_errors.py
+++ b/tests/test_worker_errors.py
@@ -21,7 +21,7 @@ Covers:
    record.stdout_truncated / stderr_truncated were never set.
 
 5. OOM detection: exit code 137 was unconditionally reported as "oom", but
-   137 is just SIGKILL — `docker kill` (cancel), pids-limit kills, and user
+   137 is just SIGKILL: `docker kill` (cancel), pids-limit kills, and user
    sys.exit(137) looked identical, and the authoritative State.OOMKilled flag
    was unreadable because `--rm` removed the container before inspection.
 
@@ -30,7 +30,7 @@ Covers:
    that feeds status determination. It now lives in the root-only /tako-meta
    mount when available.
 
-All tests mock subprocess.run — no Docker required.
+All tests mock subprocess.run: no Docker required.
 """
 
 import subprocess
@@ -835,7 +835,7 @@ class TestPhaseFileTrust:
 
 class TestImageResolution:
     """F7: images built by `tako-vm build` must actually be executed, and raw
-    base images without the executor entrypoint contract must be refused —
+    base images without the executor entrypoint contract must be refused:
     running them would execute the image's default CMD instead of
     /code/main.py and record a bogus success for code that never ran."""
 
@@ -886,7 +886,7 @@ class TestImageResolution:
         self, tmp_path, breaker, monkeypatch
     ):
         """Per-job extra requirements are not baked in and still install at
-        runtime — but the job type's own requirements must not be re-listed."""
+        runtime, but the job type's own requirements must not be re-listed."""
         jt = JobType(name="custom", requirements=["pandas"])
         monkeypatch.setattr(worker_module, "image_exists", lambda name: name == jt.image_name)
         monkeypatch.setattr(
@@ -996,7 +996,7 @@ class TestImageResolution:
 
     def test_raw_base_image_is_refused_not_bogus_success(self, tmp_path, breaker, monkeypatch):
         """A raw base image (no /entrypoint.sh) must fail fast with a config
-        error — previously python:slim's default CMD (the REPL) ran instead of
+        error. Previously python:slim's default CMD (the REPL) ran instead of
         the user's code, exited 0 on EOF, and the job was recorded
         'succeeded' with empty output for code that NEVER ran."""
         jt = JobType(name="custom", base_image="python:3.11-slim")


### PR DESCRIPTION
Removes every em-dash (U+2014) from the repo and replaces it with natural ASCII punctuation (comma, colon, parentheses, period), enforcing the no-em-dash rule everywhere.

- **Punctuation-only:** 57 files, +188 / -188, no rewording or restructuring.
- Covers Python comments/docstrings, all docs, README/CONTRIBUTING/SECURITY/CHANGELOG/CLAUDE, .github templates, mkdocs.yml, CSS/HTML overrides, and the demo tape.
- Verified: `git grep '—'` returns nothing; ruff + import smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)