### PR TITLE
fix(executor): redirect lib cache dirs to writable /tmp + document filesystem/cache model

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ tako-vm --config my.yaml server   # Use specific config file
 | REST API | [docs/api/rest.md](docs/api/rest.md) |
 | Python SDK | [docs/api/sdk.md](docs/api/sdk.md) |
 | Job Types & Environments | [docs/guide/environments.md](docs/guide/environments.md) |
+| Filesystem, Caches & ML Models | [docs/guide/filesystem-and-caches.md](docs/guide/filesystem-and-caches.md) |
 | Security | [docs/deployment/security.md](docs/deployment/security.md) |
 | Deployment | [docs/deployment/how-to-deploy.md](docs/deployment/how-to-deploy.md) |
 | Config Reference | [tako_vm.yaml.example](tako_vm.yaml.example) |

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -138,6 +138,18 @@ echo "phase=execution" >> "$PHASE_FILE"
 START_EXEC=$(get_time_ms)
 echo "execution_start_ms=$START_EXEC" >> "$PHASE_FILE"
 
+# Redirect library cache/config dirs onto the writable /tmp tmpfs. The root
+# filesystem is mounted --read-only and the sandbox user's HOME (/home/sandbox)
+# lives there, so any library that wants $HOME/.cache (ezdxf, matplotlib,
+# fontconfig, ...) would otherwise fail to create it and warn on every run.
+# gosu preserves the environment, so both vars reach the Python process below.
+# Created as container root, so hand ownership to the sandbox user (uid 1000)
+# the same way the uv cache dir is above, since code runs unprivileged.
+export XDG_CACHE_HOME=/tmp/.cache
+export MPLCONFIGDIR=/tmp/.cache/matplotlib
+mkdir -p "$XDG_CACHE_HOME" "$MPLCONFIGDIR"
+chown -R sandbox:sandbox "$XDG_CACHE_HOME"
+
 # Drop privileges and run user code as sandbox user
 # Using exec replaces this process, so we need a wrapper to capture timing.
 # --kill-after sends SIGKILL after a grace period so untrusted code that

--- a/docs/guide/custom-libraries.md
+++ b/docs/guide/custom-libraries.md
@@ -79,3 +79,5 @@ result = MyClass().process(data)
 - Dependencies of your library must either be included as wheels or available via PyPI
 - To update a library, replace the wheel and rebuild the image
 - Libraries are available to all code executions using that image
+- To pre-stage **ML model weights** (not just code) into an image so they load under the
+  read-only root filesystem, see [Filesystem & Caches](filesystem-and-caches.md)

--- a/docs/guide/filesystem-and-caches.md
+++ b/docs/guide/filesystem-and-caches.md
@@ -1,0 +1,121 @@
+---
+description: "How the Tako VM container filesystem is laid out, why library caches are redirected to writable scratch space, and how to load ML models under the read-only root filesystem."
+---
+
+# Filesystem & Caches
+
+Every job runs in a container whose **root filesystem is mounted read-only**
+(`--read-only`). This is a core security property: untrusted code cannot modify
+any binary, library, or config baked into the image. Understanding which paths
+*are* writable explains how caching libraries behave and how to load large
+models without hitting "read-only filesystem" errors.
+
+## What is writable
+
+| Path | Type | Writable? | Persists between runs? |
+|------|------|-----------|------------------------|
+| `/` (root, incl. `/home/sandbox`) | image layers | **No** (read-only) | n/a |
+| `/tmp` | tmpfs (RAM-backed) | Yes | **No** wiped on exit |
+| `/output` | bind mount | Yes | Collected as artifacts |
+| `/input`, `/code` | bind mount | No (read-only) | n/a |
+
+Two consequences matter for library behavior:
+
+- The sandbox user's home, `/home/sandbox`, lives on the **read-only** root. Anything
+  that tries to write under `$HOME` fails.
+- `/tmp` is **RAM-backed and size-capped** (100 MB default, 300 MB while installing
+  dependencies) and is **wiped when the container exits**. It is scratch space, not
+  storage.
+
+> Today each container is single-use, so nothing written at runtime survives. Durable,
+> per-agent workspaces are on the roadmap, see the project direction in the README.
+
+## Library caches (`$HOME/.cache`)
+
+Many libraries cache reusable data under `$HOME/.cache` by the
+[XDG convention](https://specifications.freedesktop.org/basedir-spec/latest/),
+matplotlib caches a font list, fontconfig caches font metadata, ezdxf caches parsed
+resources. On a read-only `$HOME` those writes fail, and you would see warnings like:
+
+```
+Cannot create cache home directory: '/home/sandbox/.cache/ezdxf', cache files will not be saved.
+```
+
+Tako VM avoids this by pointing the cache/config directories at the writable `/tmp`
+tmpfs before running your code (in `docker/entrypoint.sh`):
+
+```sh
+export XDG_CACHE_HOME=/tmp/.cache       # ezdxf, fontconfig, most XDG-aware libs
+export MPLCONFIGDIR=/tmp/.cache/matplotlib   # matplotlib uses its own variable
+```
+
+This is handled automatically, no action needed for these libraries. The cache lives
+in `/tmp`, so it is recomputed on the next run (it is an optimization, not stored data).
+
+## Loading ML models (Hugging Face, PyTorch, NLTK, ...)
+
+Caching libraries *tolerate* an unwritable cache, they warn and continue. **Download
+and cache** libraries do not: when you call `AutoModel.from_pretrained(...)`, the
+library downloads weights and writes them under `$HOME/.cache` (or `HF_HOME`), then
+loads them from that path. There is no in-memory fallback, so an unwritable cache is a
+hard failure, not a warning.
+
+Redirecting the cache to `/tmp` does **not** reliably fix this, `/tmp` is too small for
+a multi-hundred-MB model, is RAM-backed (so it competes with your job's memory limit),
+and is wiped every run (so the model re-downloads each time). Network is also disabled
+by default (`--network=none`), so a runtime download often cannot happen at all.
+
+The correct approach is to **pre-stage the model so it is present and read-only at
+runtime.** Hugging Face and friends are happy to *load* from a read-only cache, they
+only fail when they must *write* one. Set offline mode so the library reads the staged
+files instead of checking the network:
+
+```sh
+export HF_HOME=/opt/hf-cache
+export HF_HUB_OFFLINE=1        # also: TRANSFORMERS_OFFLINE=1
+```
+
+### Option A, bake the model into the executor image (build time)
+
+Download the model while building the image, where the filesystem is writable, and ship
+it inside the image. This is the same build-time pattern as
+[Custom Libraries](custom-libraries.md).
+
+```dockerfile
+ENV HF_HOME=/opt/hf-cache
+# Pin a revision so every run loads byte-identical weights.
+RUN python -c "from huggingface_hub import snapshot_download; \
+    snapshot_download('org/model', revision='<commit-sha>')"
+```
+
+At runtime `/opt/hf-cache` is read-only, which is fine, the weights are already there
+and the library only reads them.
+
+- **Pros:** fully self-contained, reproducible, no runtime network.
+- **Cons:** large images (weights can be GBs); one image per model set.
+
+### Option B, mount a read-only model volume (runtime)
+
+Populate a volume once and mount it read-only, the same shape Tako VM already uses for
+its read-only `/code`/`/input` mounts and the `UV_CACHE_VOLUME` dependency cache.
+
+```
+--mount=type=volume,source=hf-models,target=/opt/hf-cache,readonly
+```
+
+- **Pros:** images stay small; swap models by pointing `HF_HOME` elsewhere; share across jobs.
+- **Cons:** the volume must be populated and managed out of band.
+
+### Determinism
+
+Pin the model `revision` to a commit SHA. A baked, revision-pinned model loads identical
+weights on every run, which is stronger than a runtime download that could silently pull
+an updated or moved model.
+
+## Summary
+
+| If you use... | Do this |
+|---------------|---------|
+| matplotlib, ezdxf, fontconfig (cache-for-speed libs) | Nothing, caches are redirected to `/tmp` automatically |
+| Hugging Face / torch / NLTK (download-and-cache libs) | Pre-stage the model (bake into image or read-only volume) and set `HF_HOME` + offline mode |
+| Anything that must write at runtime | Write under `/tmp` (scratch, ephemeral) or `/output` (collected); never expect `$HOME` to be writable |


### PR DESCRIPTION
## Problem

The sandbox container runs with a `--read-only` root filesystem, and the
`sandbox` user's `HOME` (`/home/sandbox`) lives on that read-only root. Any
library that wants `$HOME/.cache` fails to create it:

- **Cache-for-speed libs** (matplotlib, ezdxf, fontconfig) tolerate it but warn
  on every run: `Cannot create cache home directory: '/home/sandbox/.cache/ezdxf', cache files will not be saved.`
- **Download-and-cache libs** (Hugging Face, torch, NLTK) *hard-fail*, the cache
  dir is where they stage downloaded weights, so an unwritable `$HOME` blocks the
  job entirely.

This is core behavior (read-only root + `$HOME` on root + only `/tmp`/`/output`
writable), so any deployment inherits it.

## Fix

In `docker/entrypoint.sh`, before dropping privileges, point the cache/config
dirs at the writable `/tmp` tmpfs:

- `XDG_CACHE_HOME=/tmp/.cache` covers ezdxf and fontconfig
- `MPLCONFIGDIR=/tmp/.cache/matplotlib` covers matplotlib

`gosu` preserves the environment, so both reach the Python process. Keeps the
`--read-only` root filesystem property intact. Dirs are created as container root
and `chown`ed to the sandbox user, matching how the uv cache dir is handled.

## Docs

Adds `docs/guide/filesystem-and-caches.md` documenting:

- which paths are writable (`/tmp` tmpfs, `/output`) vs read-only, and the tmpfs
  caveats (RAM-backed, size-capped, wiped each run)
- the automatic cache redirect (no action needed for the forgiving libs)
- why the `/tmp` redirect does **not** fix large ML models, and how to pre-stage
  them instead (bake into the image or mount a read-only model volume, with
  `HF_HOME` + offline mode)

Linked from the README docs table and the Custom Libraries guide.

## Notes

- **Deploy:** requires rebuilding the executor images (the entrypoint is baked in).
- **Scope:** this is intentionally just the cache fix + docs. It is separate from
  outerport's PR #3, which bundles the same cache change with an unrelated, still
  unmerged roaming-agent/session feature. That feature is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)