### PR TITLE
feat(sessions): additive session-persistence schema (Phase 0)

### DIFF
--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -427,6 +427,35 @@ class TakoVMConfig(BaseModel):
         description="Mount a shared uv cache volume for runtime dependency installs",
     )
 
+    # Session runtime controls.
+    #
+    # Persistence scaffolding for long-running sessions (durable, per-agent
+    # workspaces). Disabled by default: when sessions_enabled is False none of
+    # this is reachable from any execution path. The bounds mirror
+    # SessionRecord.idle_timeout_seconds / ttl_seconds so config-level defaults
+    # and per-session values stay consistent.
+    sessions_enabled: bool = Field(
+        default=False,
+        description="Enable long-running sessions (persistence scaffolding; off by default)",
+    )
+    session_idle_timeout_seconds: int = Field(
+        default=1800,
+        ge=30,
+        le=86400,
+        description="Default idle window before a session is reaped, in seconds",
+    )
+    session_max_ttl_seconds: int = Field(
+        default=86400,
+        ge=60,
+        le=604800,
+        description="Default absolute maximum session lifetime, in seconds",
+    )
+    session_max_concurrent: int = Field(
+        default=50,
+        ge=1,
+        description="Maximum number of concurrent live sessions",
+    )
+
     # Retention
     execution_record_ttl_days: int = Field(default=30, ge=1, le=3650)
     dlq_ttl_days: int = Field(
@@ -528,6 +557,8 @@ class TakoVMConfig(BaseModel):
             raise ValueError("default_timeout must be <= max_timeout")
         if self.default_startup_timeout > self.max_startup_timeout:
             raise ValueError("default_startup_timeout must be <= max_startup_timeout")
+        if self.session_idle_timeout_seconds > self.session_max_ttl_seconds:
+            raise ValueError("session_idle_timeout_seconds must be <= session_max_ttl_seconds")
         return self
 
     def resolve_paths(self) -> "TakoVMConfig":
@@ -761,6 +792,20 @@ def load_config(config_path: Optional[Path] = None) -> TakoVMConfig:
             "1",
             "yes",
         )
+    if "TAKO_VM_SESSIONS_ENABLED" in os.environ:
+        config_dict["sessions_enabled"] = os.environ["TAKO_VM_SESSIONS_ENABLED"].lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+    if "TAKO_VM_SESSION_IDLE_TIMEOUT_SECONDS" in os.environ:
+        config_dict["session_idle_timeout_seconds"] = parse_env_int(
+            "TAKO_VM_SESSION_IDLE_TIMEOUT_SECONDS"
+        )
+    if "TAKO_VM_SESSION_MAX_TTL_SECONDS" in os.environ:
+        config_dict["session_max_ttl_seconds"] = parse_env_int("TAKO_VM_SESSION_MAX_TTL_SECONDS")
+    if "TAKO_VM_SESSION_MAX_CONCURRENT" in os.environ:
+        config_dict["session_max_concurrent"] = parse_env_int("TAKO_VM_SESSION_MAX_CONCURRENT")
     # Validate and create config
     try:
         config = TakoVMConfig(**config_dict)

--- a/tako_vm/models.py
+++ b/tako_vm/models.py
@@ -415,6 +415,14 @@ class ExecutionRecord(BaseModel):
     relationship: Optional[Literal["rerun", "fork"]] = None
     """Relationship to parent execution."""
 
+    # Session linkage. Nullable FK to sessions.session_id: when an execution runs
+    # inside a long-running session, this links the exec to its session for
+    # audit. None for standalone executions and for legacy rows written before
+    # sessions existed. Persistence scaffolding only (sessions are feature-flagged
+    # off via config.sessions_enabled); nothing in the execution path sets it yet.
+    session_id: Optional[str] = Field(default=None, max_length=64)
+    """ID of the session this execution ran in, if any."""
+
     @field_validator("stdout", "stderr", mode="before")
     @classmethod
     def ensure_string(cls, v: str) -> str:
@@ -573,3 +581,128 @@ class DeadLetterEntry(BaseModel):
             if value is not None:
                 summary[key] = value
         return summary
+
+
+# Canonical session status values.
+#
+# A session is a long-running, single-tenant container whose workspace persists
+# across multiple executions (the "serverless filesystem for agents" direction).
+# These states cover the full lifecycle so the sessions.status CHECK constraint
+# never needs widening:
+# - 'suspended' is reserved for a later phase (a session whose container has been
+#   stopped but whose workspace is retained for rehydration); it exists in the
+#   vocabulary now purely so the persisted CHECK constraint already accepts it.
+# - 'idle' marks a live session with no in-flight execution.
+# This scaffolding is feature-flagged off (config.sessions_enabled defaults to
+# False) and is not yet wired into any execution path.
+SessionStatus = Literal[
+    "creating",  # Container being provisioned
+    "running",  # Live container with an in-flight execution
+    "idle",  # Live container, no in-flight execution
+    "suspended",  # Reserved: container stopped, workspace retained (later phase)
+    "terminated",  # Cleanly torn down
+    "failed",  # Provisioning or runtime failure
+    "expired",  # Reaped after exceeding idle timeout or TTL
+]
+
+# Direction of a persisted session event relative to the sandboxed process.
+SessionEventDirection = Literal[
+    "in",  # Input delivered to the session (e.g. a message/file from the caller)
+    "out",  # Output produced by the session
+    "system",  # System/lifecycle event (created, terminated, etc.)
+]
+
+
+class SessionRecord(BaseModel):
+    """
+    Persistent metadata for a long-running session container.
+
+    A session owns a single container plus a workspace that survives across
+    executions. This record is the audit-grade source of truth for a session's
+    lifecycle (creation, activity, expiry, teardown). Persistence scaffolding
+    only: nothing in the execution path reads or writes it yet, and it is gated
+    behind ``config.sessions_enabled`` (default False).
+    """
+
+    model_config = {"extra": "forbid"}
+
+    # Identity
+    session_id: str = Field(default_factory=lambda: str(uuid.uuid4()), max_length=64)
+    """Unique identifier for this session."""
+
+    # Status
+    status: SessionStatus = "creating"
+    """Current session lifecycle status."""
+
+    # Container binding
+    container_name: str = Field(..., min_length=1, max_length=128)
+    """Name of the container backing this session."""
+
+    container_id: Optional[str] = Field(default=None, max_length=128)
+    """Docker container ID once the container has been created."""
+
+    image_name: Optional[str] = Field(default=None, max_length=255)
+    """Image the session container was launched from."""
+
+    runtime: Optional[str] = Field(default=None, max_length=16)
+    """Effective container runtime: 'runsc' (gVisor) or 'runc' (weaker fallback)."""
+
+    workspace_dir: str = Field(..., min_length=1, max_length=1024)
+    """Path to the session's persistent workspace directory."""
+
+    # Timing
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    """When the session was created/requested."""
+
+    started_at: Optional[datetime] = None
+    """When the session container started."""
+
+    last_activity_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    """When the session last saw activity (drives idle-timeout reaping)."""
+
+    expires_at: Optional[datetime] = None
+    """Absolute deadline after which the session must be reaped (TTL)."""
+
+    ended_at: Optional[datetime] = None
+    """When the session was terminated/expired."""
+
+    # Lifecycle bounds
+    idle_timeout_seconds: int = Field(default=1800, ge=30, le=86400)
+    """Idle window before the session is reaped, in seconds."""
+
+    ttl_seconds: int = Field(default=86400, ge=60, le=604800)
+    """Absolute maximum session lifetime, in seconds."""
+
+    # Free-form metadata
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    """Caller-supplied, non-secret session metadata."""
+
+
+class SessionEvent(BaseModel):
+    """
+    Input/output event persisted for a session.
+
+    Sessions accumulate an ordered event log (messages in, results out, system
+    lifecycle markers) so callers can poll a session's history. Persistence
+    scaffolding only, gated behind ``config.sessions_enabled``.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    id: Optional[int] = Field(default=None, ge=0)
+    """Database ID (set by storage on insert)."""
+
+    session_id: str = Field(..., min_length=1, max_length=64)
+    """Session this event belongs to (FK to sessions.session_id)."""
+
+    direction: SessionEventDirection
+    """Whether the event is input to, output from, or a system event of the session."""
+
+    event_type: str = Field(default="message", min_length=1, max_length=64)
+    """Event classifier, e.g. 'message'."""
+
+    payload: Any = None
+    """Event payload (JSON-serializable)."""
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    """When the event was recorded."""

--- a/tako_vm/storage.py
+++ b/tako_vm/storage.py
@@ -24,6 +24,8 @@ from .models import (
     InputArtifact,
     JobVersion,
     ResourceUsage,
+    SessionEvent,
+    SessionRecord,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,13 @@ RowMapping = Mapping[str, Any]
 # record is terminal, later writes (e.g. a stale executor result racing a
 # cancellation, or vice versa) are refused by the save_record upsert guard.
 TERMINAL_STATUSES = ("succeeded", "failed", "timeout", "oom", "cancelled")
+
+# Terminal session statuses. A session in one of these states has been reaped or
+# torn down and will never run again. Defined alongside the execution
+# TERMINAL_STATUSES so the sessions feature mirrors the same lifecycle guarantee
+# when later phases add transition guards; the schema (0005_sessions) already
+# pins the full status vocabulary via a CHECK constraint.
+SESSION_TERMINAL_STATUSES = ("terminated", "failed", "expired")
 
 # Backoff schedule (seconds) for retrying save_record on transient connection
 # errors. Tests may monkeypatch this to avoid real sleeps.
@@ -184,6 +193,71 @@ MIGRATIONS: list[tuple[str, str]] = [
         ALTER TABLE execution_records ADD COLUMN IF NOT EXISTS runtime TEXT
         """,
     ),
+    (
+        # Persistence scaffolding for long-running sessions (feature-flagged off
+        # via config.sessions_enabled; no execution path reads or writes these
+        # tables yet). The status CHECK pins the full SessionStatus vocabulary,
+        # INCLUDING the not-yet-used 'suspended'/'idle' states, so the constraint
+        # never has to be widened (and re-validated) in a later phase.
+        "0005_sessions",
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL DEFAULT 'creating'
+                CHECK (status IN (
+                    'creating', 'running', 'idle', 'suspended',
+                    'terminated', 'failed', 'expired'
+                )),
+
+            container_name TEXT NOT NULL,
+            container_id TEXT,
+            image_name TEXT,
+            runtime TEXT,
+            workspace_dir TEXT NOT NULL,
+
+            created_at TIMESTAMPTZ NOT NULL,
+            started_at TIMESTAMPTZ,
+            last_activity_at TIMESTAMPTZ NOT NULL,
+            expires_at TIMESTAMPTZ,
+            ended_at TIMESTAMPTZ,
+
+            idle_timeout_seconds INTEGER NOT NULL,
+            ttl_seconds INTEGER NOT NULL,
+
+            metadata_json JSONB
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+        CREATE INDEX IF NOT EXISTS idx_sessions_last_activity
+            ON sessions(last_activity_at);
+        CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
+
+        CREATE TABLE IF NOT EXISTS session_events (
+            id BIGSERIAL PRIMARY KEY,
+            session_id TEXT NOT NULL
+                REFERENCES sessions(session_id) ON DELETE CASCADE,
+            direction TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            payload_json JSONB,
+            created_at TIMESTAMPTZ NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_session_events_session_id
+            ON session_events(session_id, id);
+        """,
+    ),
+    (
+        # Nullable FK linking an execution to the session it ran in, for audit.
+        # Legacy rows (and all standalone, non-session executions) predate it and
+        # leave it NULL. Mirrors the 0004_runtime additive-column pattern.
+        "0006_execution_session_fk",
+        """
+        ALTER TABLE execution_records ADD COLUMN IF NOT EXISTS session_id TEXT;
+
+        CREATE INDEX IF NOT EXISTS idx_execution_session_id
+            ON execution_records(session_id);
+        """,
+    ),
 ]
 
 
@@ -282,6 +356,9 @@ _EXECUTION_COLUMNS: list = [
     ("parent_execution_id", _SET_COALESCE_EXISTING, lambda r, b: r.parent_execution_id),
     ("relationship", _SET_COALESCE_EXISTING, lambda r, b: r.relationship),
     ("runtime", _SET_COALESCE_EXCLUDED, lambda r, b: r.runtime),
+    # Session linkage is fixed at submission and never reassigned, so keep the
+    # first non-null value (like the other submission-identity fields).
+    ("session_id", _SET_COALESCE_EXISTING, lambda r, b: r.session_id),
 ]
 
 _INSERT_COLUMN_SQL = ", ".join(name for name, _, _ in _EXECUTION_COLUMNS)
@@ -757,6 +834,200 @@ class ExecutionStorage:
             parent_execution_id=row.get("parent_execution_id"),
             relationship=row.get("relationship"),
             runtime=row.get("runtime"),
+            session_id=row.get("session_id"),
+        )
+
+    # --- Sessions ----------------------------------------------------------
+    #
+    # Persistence scaffolding for long-running sessions. These methods mirror
+    # the save/get/list patterns used for execution records and job versions.
+    # They are not wired into any execution path yet (sessions are gated behind
+    # config.sessions_enabled, default False).
+
+    async def save_session(self, session: SessionRecord) -> None:
+        """Insert or update a session record (full-row upsert keyed on session_id)."""
+        metadata_json = Jsonb(session.metadata) if session.metadata is not None else None
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO sessions (
+                    session_id, status,
+                    container_name, container_id, image_name, runtime, workspace_dir,
+                    created_at, started_at, last_activity_at, expires_at, ended_at,
+                    idle_timeout_seconds, ttl_seconds,
+                    metadata_json
+                ) VALUES (
+                    %s, %s,
+                    %s, %s, %s, %s, %s,
+                    %s, %s, %s, %s, %s,
+                    %s, %s,
+                    %s
+                )
+                ON CONFLICT (session_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    container_name = EXCLUDED.container_name,
+                    container_id = EXCLUDED.container_id,
+                    image_name = EXCLUDED.image_name,
+                    runtime = EXCLUDED.runtime,
+                    workspace_dir = EXCLUDED.workspace_dir,
+                    created_at = sessions.created_at,
+                    started_at = EXCLUDED.started_at,
+                    last_activity_at = EXCLUDED.last_activity_at,
+                    expires_at = EXCLUDED.expires_at,
+                    ended_at = EXCLUDED.ended_at,
+                    idle_timeout_seconds = EXCLUDED.idle_timeout_seconds,
+                    ttl_seconds = EXCLUDED.ttl_seconds,
+                    metadata_json = EXCLUDED.metadata_json
+                """,
+                (
+                    session.session_id,
+                    session.status,
+                    session.container_name,
+                    session.container_id,
+                    session.image_name,
+                    session.runtime,
+                    session.workspace_dir,
+                    session.created_at,
+                    session.started_at,
+                    session.last_activity_at,
+                    session.expires_at,
+                    session.ended_at,
+                    session.idle_timeout_seconds,
+                    session.ttl_seconds,
+                    metadata_json,
+                ),
+            )
+
+    async def get_session(self, session_id: str) -> Optional[SessionRecord]:
+        """Retrieve a session by ID."""
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                "SELECT * FROM sessions WHERE session_id = %s", (session_id,)
+            )
+            row = await cursor.fetchone()
+
+        if not row:
+            return None
+        return self._row_to_session(cast(RowMapping, row))
+
+    async def list_sessions(
+        self,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[SessionRecord]:
+        """List sessions with an optional status filter, newest first."""
+        query = "SELECT * FROM sessions WHERE 1=1"
+        params: List[Any] = []
+
+        if status:
+            query += " AND status = %s"
+            params.append(status)
+
+        query += " ORDER BY created_at DESC LIMIT %s OFFSET %s"
+        params.extend([limit, offset])
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(query, params)
+            rows = await cursor.fetchall()
+
+        return [self._row_to_session(cast(RowMapping, row)) for row in rows]
+
+    async def touch_session(self, session_id: str, touched_at: Optional[datetime] = None) -> bool:
+        """Update a session's last_activity_at timestamp.
+
+        Returns True if a session row was updated.
+        """
+        now = touched_at or datetime.now(timezone.utc)
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                "UPDATE sessions SET last_activity_at = %s WHERE session_id = %s",
+                (now, session_id),
+            )
+            return cursor.rowcount > 0
+
+    async def save_session_event(self, event: SessionEvent) -> SessionEvent:
+        """Insert a session event and return it with its assigned database ID."""
+        payload_json = Jsonb(event.payload) if event.payload is not None else None
+
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                INSERT INTO session_events (
+                    session_id, direction, event_type, payload_json, created_at
+                ) VALUES (%s, %s, %s, %s, %s)
+                RETURNING *
+                """,
+                (
+                    event.session_id,
+                    event.direction,
+                    event.event_type,
+                    payload_json,
+                    event.created_at,
+                ),
+            )
+            row = await cursor.fetchone()
+
+        return self._row_to_session_event(cast(RowMapping, row))
+
+    async def list_session_events(
+        self,
+        session_id: str,
+        after_id: int = 0,
+        limit: int = 100,
+    ) -> List[SessionEvent]:
+        """List a session's events after a cursor ID, in insertion order."""
+        pool = self._get_pool()
+        async with pool.connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT * FROM session_events
+                WHERE session_id = %s AND id > %s
+                ORDER BY id ASC
+                LIMIT %s
+                """,
+                (session_id, after_id, limit),
+            )
+            rows = await cursor.fetchall()
+
+        return [self._row_to_session_event(cast(RowMapping, row)) for row in rows]
+
+    def _row_to_session(self, row: RowMapping) -> SessionRecord:
+        """Convert a database row to a SessionRecord."""
+        metadata = row.get("metadata_json") or {}
+        return SessionRecord(
+            session_id=row["session_id"],
+            status=row["status"],
+            container_name=row["container_name"],
+            container_id=row.get("container_id"),
+            image_name=row.get("image_name"),
+            runtime=row.get("runtime"),
+            workspace_dir=row["workspace_dir"],
+            created_at=row["created_at"],
+            started_at=row.get("started_at"),
+            last_activity_at=row["last_activity_at"],
+            expires_at=row.get("expires_at"),
+            ended_at=row.get("ended_at"),
+            idle_timeout_seconds=row["idle_timeout_seconds"],
+            ttl_seconds=row["ttl_seconds"],
+            metadata=metadata,
+        )
+
+    def _row_to_session_event(self, row: RowMapping) -> SessionEvent:
+        """Convert a database row to a SessionEvent."""
+        return SessionEvent(
+            id=row["id"],
+            session_id=row["session_id"],
+            direction=row["direction"],
+            event_type=row["event_type"],
+            payload=row.get("payload_json"),
+            created_at=row["created_at"],
         )
 
     async def save_version(self, version: JobVersion) -> None:

--- a/tests/test_sessions_schema.py
+++ b/tests/test_sessions_schema.py
@@ -1,0 +1,471 @@
+"""
+Tests for the session persistence scaffolding (phase 0, feature-flagged off).
+
+Covers the additive, zero-runtime-change schema work:
+- SessionStatus / SessionEventDirection / SessionRecord / SessionEvent models
+- ExecutionRecord.session_id nullable FK
+- the 0005_sessions / 0006_execution_session_fk migrations (shape only)
+- the session config fields, bounds, cross-field validator, and env wiring
+- storage round-trips (Postgres-backed; skip cleanly when DB unavailable)
+
+The model, migration-shape, and config tests are pure (no DB). The storage
+round-trip tests reuse the shared ``test_storage`` fixture from conftest, which
+skips when no Postgres test database is reachable (and fails loudly in CI).
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import get_args
+
+import pytest
+from pydantic import ValidationError
+
+from tako_vm.config import ConfigurationError, TakoVMConfig, load_config
+from tako_vm.models import (
+    ExecutionRecord,
+    SessionEvent,
+    SessionEventDirection,
+    SessionRecord,
+    SessionStatus,
+)
+from tako_vm.storage import MIGRATIONS, SESSION_TERMINAL_STATUSES
+
+# ---------------------------------------------------------------------------
+# Model unit tests (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRecordModel:
+    """SessionRecord defaults, bounds, and serialization."""
+
+    def test_minimal_session_defaults(self):
+        """Required fields only; everything else takes documented defaults."""
+        session = SessionRecord(
+            container_name="tako-session-abc",
+            workspace_dir="/workspaces/abc",
+        )
+        assert session.status == "creating"
+        assert session.container_id is None
+        assert session.image_name is None
+        assert session.runtime is None
+        assert session.idle_timeout_seconds == 1800
+        assert session.ttl_seconds == 86400
+        assert session.metadata == {}
+        assert session.started_at is None
+        assert session.expires_at is None
+        assert session.ended_at is None
+        # session_id is a uuid4 by default.
+        assert isinstance(session.session_id, str)
+        assert len(session.session_id) <= 64
+        # Activity/creation timestamps default to "now".
+        assert isinstance(session.created_at, datetime)
+        assert isinstance(session.last_activity_at, datetime)
+
+    def test_container_name_required(self):
+        with pytest.raises(ValidationError):
+            SessionRecord(workspace_dir="/workspaces/abc")
+
+    def test_workspace_dir_required(self):
+        with pytest.raises(ValidationError):
+            SessionRecord(container_name="tako-session-abc")
+
+    @pytest.mark.parametrize("status", list(get_args(SessionStatus)))
+    def test_all_seven_statuses_accepted(self, status):
+        """All 7 SessionStatus values must be accepted by the model."""
+        session = SessionRecord(
+            container_name="c",
+            workspace_dir="/w",
+            status=status,
+        )
+        assert session.status == status
+
+    def test_session_status_has_all_seven_states(self):
+        assert set(get_args(SessionStatus)) == {
+            "creating",
+            "running",
+            "idle",
+            "suspended",
+            "terminated",
+            "failed",
+            "expired",
+        }
+
+    def test_idle_timeout_lower_bound(self):
+        SessionRecord(container_name="c", workspace_dir="/w", idle_timeout_seconds=30)
+        with pytest.raises(ValidationError):
+            SessionRecord(container_name="c", workspace_dir="/w", idle_timeout_seconds=29)
+
+    def test_idle_timeout_upper_bound(self):
+        SessionRecord(container_name="c", workspace_dir="/w", idle_timeout_seconds=86400)
+        with pytest.raises(ValidationError):
+            SessionRecord(container_name="c", workspace_dir="/w", idle_timeout_seconds=86401)
+
+    def test_ttl_lower_bound(self):
+        SessionRecord(container_name="c", workspace_dir="/w", ttl_seconds=60)
+        with pytest.raises(ValidationError):
+            SessionRecord(container_name="c", workspace_dir="/w", ttl_seconds=59)
+
+    def test_ttl_upper_bound(self):
+        SessionRecord(container_name="c", workspace_dir="/w", ttl_seconds=604800)
+        with pytest.raises(ValidationError):
+            SessionRecord(container_name="c", workspace_dir="/w", ttl_seconds=604801)
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            SessionRecord(container_name="c", workspace_dir="/w", bogus="x")
+
+    def test_serialization_round_trip(self):
+        """model_dump -> model_validate preserves every field."""
+        session = SessionRecord(
+            session_id="sess-1",
+            status="running",
+            container_name="tako-session-1",
+            container_id="deadbeef",
+            image_name="code-executor:latest",
+            runtime="runsc",
+            workspace_dir="/workspaces/1",
+            idle_timeout_seconds=600,
+            ttl_seconds=7200,
+            metadata={"source": "test"},
+        )
+        dumped = session.model_dump()
+        restored = SessionRecord.model_validate(dumped)
+        assert restored == session
+        assert restored.metadata["source"] == "test"
+
+
+class TestSessionEventModel:
+    """SessionEvent defaults, direction enum, and serialization."""
+
+    def test_defaults(self):
+        event = SessionEvent(session_id="sess-1", direction="in")
+        assert event.id is None
+        assert event.event_type == "message"
+        assert event.payload is None
+        assert isinstance(event.created_at, datetime)
+
+    def test_session_id_required(self):
+        with pytest.raises(ValidationError):
+            SessionEvent(direction="in")
+
+    def test_direction_required(self):
+        with pytest.raises(ValidationError):
+            SessionEvent(session_id="sess-1")
+
+    @pytest.mark.parametrize("direction", list(get_args(SessionEventDirection)))
+    def test_all_directions_accepted(self, direction):
+        event = SessionEvent(session_id="sess-1", direction=direction)
+        assert event.direction == direction
+
+    def test_invalid_direction_rejected(self):
+        with pytest.raises(ValidationError):
+            SessionEvent(session_id="sess-1", direction="sideways")
+
+    def test_serialization_round_trip(self):
+        event = SessionEvent(
+            id=5,
+            session_id="sess-1",
+            direction="out",
+            event_type="message",
+            payload={"value": 1},
+        )
+        restored = SessionEvent.model_validate(event.model_dump())
+        assert restored == event
+
+
+class TestExecutionRecordSessionId:
+    """ExecutionRecord gains a nullable session_id FK."""
+
+    def test_defaults_none(self):
+        record = ExecutionRecord()
+        assert record.session_id is None
+
+    def test_session_id_serializes(self):
+        record = ExecutionRecord(session_id="sess-42")
+        dumped = record.model_dump()
+        assert dumped["session_id"] == "sess-42"
+        restored = ExecutionRecord.model_validate(dumped)
+        assert restored.session_id == "sess-42"
+
+    def test_none_serializes(self):
+        record = ExecutionRecord()
+        assert record.model_dump()["session_id"] is None
+
+    def test_max_length_enforced(self):
+        with pytest.raises(ValidationError):
+            ExecutionRecord(session_id="x" * 65)
+
+
+# ---------------------------------------------------------------------------
+# Migration shape tests (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionMigrationsShape:
+    """The new migrations are present, ordered, unique, and non-empty."""
+
+    def test_new_migrations_present(self):
+        versions = [v for v, _ in MIGRATIONS]
+        assert "0005_sessions" in versions
+        assert "0006_execution_session_fk" in versions
+
+    def test_versions_unique(self):
+        versions = [v for v, _ in MIGRATIONS]
+        assert len(versions) == len(set(versions))
+
+    def test_versions_sorted_and_ordered(self):
+        versions = [v for v, _ in MIGRATIONS]
+        assert versions == sorted(versions)
+        # The two new migrations come last, in order.
+        assert versions[-2:] == ["0005_sessions", "0006_execution_session_fk"]
+
+    def test_all_sql_non_empty_strings(self):
+        for version, sql in MIGRATIONS:
+            assert isinstance(sql, str)
+            assert sql.strip(), f"migration {version} has empty SQL"
+
+    def test_sessions_migration_pins_full_status_vocabulary(self):
+        sql = dict(MIGRATIONS)["0005_sessions"]
+        assert "CREATE TABLE IF NOT EXISTS sessions" in sql
+        assert "CREATE TABLE IF NOT EXISTS session_events" in sql
+        # CHECK constraint covers all 7 states (so it never needs widening).
+        for status in get_args(SessionStatus):
+            assert f"'{status}'" in sql
+
+    def test_session_fk_migration_is_additive(self):
+        sql = dict(MIGRATIONS)["0006_execution_session_fk"]
+        assert "ADD COLUMN IF NOT EXISTS session_id" in sql
+        assert "idx_execution_session_id" in sql
+
+    def test_session_terminal_statuses_constant(self):
+        assert set(SESSION_TERMINAL_STATUSES) == {"terminated", "failed", "expired"}
+        # Every terminal status is a real SessionStatus.
+        assert set(SESSION_TERMINAL_STATUSES).issubset(set(get_args(SessionStatus)))
+
+
+# ---------------------------------------------------------------------------
+# Config tests (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionConfig:
+    """Session config fields, defaults, bounds, validator, and env wiring."""
+
+    def test_defaults(self):
+        config = TakoVMConfig()
+        assert config.sessions_enabled is False
+        assert config.session_idle_timeout_seconds == 1800
+        assert config.session_max_ttl_seconds == 86400
+        assert config.session_max_concurrent == 50
+
+    def test_idle_le_ttl_validator_accepts_equal(self):
+        config = TakoVMConfig(
+            session_idle_timeout_seconds=3600,
+            session_max_ttl_seconds=3600,
+        )
+        assert config.session_idle_timeout_seconds == 3600
+
+    def test_idle_le_ttl_validator_rejects_idle_greater_than_ttl(self):
+        with pytest.raises(ValidationError):
+            TakoVMConfig(
+                session_idle_timeout_seconds=10000,
+                session_max_ttl_seconds=5000,
+            )
+
+    def test_idle_timeout_bounds(self):
+        TakoVMConfig(session_idle_timeout_seconds=30)
+        with pytest.raises(ValidationError):
+            TakoVMConfig(session_idle_timeout_seconds=29)
+        with pytest.raises(ValidationError):
+            TakoVMConfig(session_idle_timeout_seconds=86401)
+
+    def test_max_ttl_bounds(self):
+        # Lower idle alongside ttl so the idle<=ttl cross-field validator isn't
+        # what trips; we're exercising the ttl field bounds here.
+        TakoVMConfig(session_idle_timeout_seconds=60, session_max_ttl_seconds=60)
+        with pytest.raises(ValidationError):
+            TakoVMConfig(session_max_ttl_seconds=59)
+        with pytest.raises(ValidationError):
+            TakoVMConfig(session_max_ttl_seconds=604801)
+
+    def test_max_concurrent_lower_bound(self):
+        TakoVMConfig(session_max_concurrent=1)
+        with pytest.raises(ValidationError):
+            TakoVMConfig(session_max_concurrent=0)
+
+    def test_env_var_parsing(self, monkeypatch):
+        monkeypatch.setenv("TAKO_VM_SECURITY_MODE", "permissive")
+        monkeypatch.setenv("TAKO_VM_SESSIONS_ENABLED", "true")
+        monkeypatch.setenv("TAKO_VM_SESSION_IDLE_TIMEOUT_SECONDS", "900")
+        monkeypatch.setenv("TAKO_VM_SESSION_MAX_TTL_SECONDS", "43200")
+        monkeypatch.setenv("TAKO_VM_SESSION_MAX_CONCURRENT", "7")
+
+        config = load_config()
+        assert config.sessions_enabled is True
+        assert config.session_idle_timeout_seconds == 900
+        assert config.session_max_ttl_seconds == 43200
+        assert config.session_max_concurrent == 7
+
+    def test_env_sessions_enabled_falsey(self, monkeypatch):
+        monkeypatch.setenv("TAKO_VM_SECURITY_MODE", "permissive")
+        monkeypatch.setenv("TAKO_VM_SESSIONS_ENABLED", "no")
+        config = load_config()
+        assert config.sessions_enabled is False
+
+    def test_env_non_integer_raises(self, monkeypatch):
+        monkeypatch.setenv("TAKO_VM_SECURITY_MODE", "permissive")
+        monkeypatch.setenv("TAKO_VM_SESSION_MAX_CONCURRENT", "not-an-int")
+        with pytest.raises(ConfigurationError):
+            load_config()
+
+
+# ---------------------------------------------------------------------------
+# Storage round-trip tests (Postgres-backed; skip cleanly without a DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(test_storage):
+    """Reuse the shared Postgres-backed storage fixture from conftest."""
+    return test_storage
+
+
+class TestSessionStorage:
+    """save/get/list/touch + session events round-trip through Postgres."""
+
+    @staticmethod
+    def _make_session(session_id: str, status: SessionStatus = "running") -> SessionRecord:
+        now = datetime.now(timezone.utc)
+        return SessionRecord(
+            session_id=session_id,
+            status=status,
+            container_name=f"tako-session-{session_id}",
+            image_name="code-executor:latest",
+            runtime="runc",
+            workspace_dir=f"/workspaces/{session_id}",
+            created_at=now,
+            last_activity_at=now,
+            idle_timeout_seconds=1800,
+            ttl_seconds=86400,
+            metadata={"source": "test"},
+        )
+
+    def test_save_and_get_session(self, storage):
+        session = self._make_session("session-1")
+        storage.save_session(session)
+
+        loaded = storage.get_session("session-1")
+        assert loaded is not None
+        assert loaded.session_id == "session-1"
+        assert loaded.status == "running"
+        assert loaded.container_name == "tako-session-session-1"
+        assert loaded.workspace_dir == "/workspaces/session-1"
+        assert loaded.metadata["source"] == "test"
+
+    def test_get_missing_session_returns_none(self, storage):
+        assert storage.get_session("does-not-exist") is None
+
+    def test_save_session_upsert_updates(self, storage):
+        session = self._make_session("session-upsert", status="creating")
+        storage.save_session(session)
+
+        session.status = "running"
+        session.container_id = "container-xyz"
+        storage.save_session(session)
+
+        loaded = storage.get_session("session-upsert")
+        assert loaded.status == "running"
+        assert loaded.container_id == "container-xyz"
+
+    def test_list_sessions_with_status_filter(self, storage):
+        storage.save_session(self._make_session("running-1", status="running"))
+        storage.save_session(self._make_session("terminated-1", status="terminated"))
+
+        running = storage.list_sessions(status="running")
+        assert len(running) == 1
+        assert running[0].session_id == "running-1"
+
+    def test_list_sessions_no_filter(self, storage):
+        storage.save_session(self._make_session("a", status="running"))
+        storage.save_session(self._make_session("b", status="idle"))
+        assert len(storage.list_sessions()) == 2
+
+    def test_touch_session_updates_last_activity(self, storage):
+        session = self._make_session("session-touch")
+        storage.save_session(session)
+
+        touched_at = datetime.now(timezone.utc) + timedelta(seconds=5)
+        updated = storage.touch_session("session-touch", touched_at=touched_at)
+        assert updated is True
+
+        loaded = storage.get_session("session-touch")
+        assert loaded is not None
+        assert loaded.last_activity_at == touched_at
+
+    def test_touch_missing_session_returns_false(self, storage):
+        assert storage.touch_session("nope") is False
+
+    def test_save_and_list_session_events(self, storage):
+        storage.save_session(self._make_session("session-events"))
+
+        first = storage.save_session_event(
+            SessionEvent(
+                session_id="session-events",
+                direction="out",
+                event_type="message",
+                payload={"value": 1},
+            )
+        )
+        second = storage.save_session_event(
+            SessionEvent(
+                session_id="session-events",
+                direction="in",
+                payload={"value": 2},
+            )
+        )
+
+        assert first.id is not None
+        assert second.id is not None
+        assert second.id != first.id
+
+        events = storage.list_session_events("session-events")
+        assert len(events) == 2
+        assert events[0].payload == {"value": 1}
+        assert events[1].direction == "in"
+
+    def test_list_session_events_after_cursor(self, storage):
+        storage.save_session(self._make_session("session-cursor"))
+
+        event1 = storage.save_session_event(
+            SessionEvent(session_id="session-cursor", direction="in", payload={"n": 1})
+        )
+        event2 = storage.save_session_event(
+            SessionEvent(session_id="session-cursor", direction="out", payload={"n": 2})
+        )
+
+        assert event1.id is not None
+        assert event2.id is not None
+
+        later = storage.list_session_events("session-cursor", after_id=event1.id)
+        assert len(later) == 1
+        assert later[0].id == event2.id
+
+    def test_execution_record_session_id_round_trips(self, storage):
+        """ExecutionRecord.session_id persists and reloads through the upsert."""
+        record = ExecutionRecord(
+            execution_id="exec-with-session",
+            status="succeeded",
+            session_id="sess-linked",
+        )
+        storage.save_record(record)
+
+        loaded = storage.get_record("exec-with-session")
+        assert loaded is not None
+        assert loaded.session_id == "sess-linked"
+
+    def test_execution_record_session_id_defaults_none_in_db(self, storage):
+        record = ExecutionRecord(execution_id="exec-no-session", status="succeeded")
+        storage.save_record(record)
+
+        loaded = storage.get_record("exec-no-session")
+        assert loaded is not None
+        assert loaded.session_id is None

--- a/tests/test_storage_columns.py
+++ b/tests/test_storage_columns.py
@@ -62,6 +62,7 @@ EXPECTED = [
     ("parent_execution_id", _SET_COALESCE_EXISTING),
     ("relationship", _SET_COALESCE_EXISTING),
     ("runtime", _SET_COALESCE_EXCLUDED),
+    ("session_id", _SET_COALESCE_EXISTING),
 ]
 
 


### PR DESCRIPTION
## What

Additive persistence scaffolding for durable sessions. **Feature-flagged off, zero runtime behavior change** — no execution path (`app.py`/`worker.py`/`queue.py`/`sandbox.py`/`job_types.py`) is touched.

- **models** (`models.py`): `SessionRecord`, `SessionEvent`, `SessionStatus` (all 7 states incl. the reserved `suspended`), `SessionEventDirection`; plus a nullable **`ExecutionRecord.session_id`** so an exec can be audited back to its session — the FK the abandoned `0010`–`0012` branches never added.
- **storage** (`storage.py`): migrations `0005_sessions` + `0006_execution_session_fk` (idempotent, additive `CREATE TABLE`/`ADD COLUMN IF NOT EXISTS`); `session_id` threaded through the single-source `execution_records` upsert column set; `save_session`/`get_session`/`list_sessions`/`touch_session`/`save_session_event`/`list_session_events`. All values parameterized; the `sessions.status` CHECK pins the full vocabulary so the model and DB can't drift.
- **config** (`config.py`): `sessions_enabled` (default `False`), `session_idle_timeout_seconds`/`session_max_ttl_seconds`/`session_max_concurrent` with bounds, an `idle <= ttl` validator, and `TAKO_VM_SESSION_*` env wiring.

## Why

Phase 0 of the durable-session roadmap: a place to persist session state with a fail-loud schema, landed before any container behavior changes so every later phase has somewhere to write. The `ExecutionRecord.session_id` FK closes a real auditability gap in the prior session attempt.

## Dynamic testing

- New `tests/test_sessions_schema.py`: model defaults/bounds/serialization, migration-shape (presence/uniqueness/ordering, CHECK vocabulary coupled to the `SessionStatus` model), config defaults + validator + env parsing, and **Postgres-backed round-trips** (save→get→compare).
- **Verified against a real Postgres** (provisioned + torn down): `tests/test_sessions_schema.py tests/test_storage.py tests/test_storage_columns.py tests/test_models.py tests/test_config.py` → **205 passed, 0 skipped**.
- Without a DB the 11 round-trip tests skip cleanly (fail loud in CI, skip locally) — `45 passed, 11 skipped`.
- `ruff check` + `format` clean (pinned 0.15.16).
- Independently code-reviewed: migrations idempotent/additive, FK wiring correct, all SQL parameterized, no execution-path changes.

## Scope

`+450` lines across `config.py`/`models.py`/`storage.py` + 2 test files. Independent of Phase 0 PR #136 (both branch off `main`; either can merge first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)